### PR TITLE
expose long double in _ffi (which is _rawffi.alt) and ctypes

### DIFF
--- a/lib-python/2.7/ctypes/test/test_arrays.py
+++ b/lib-python/2.7/ctypes/test/test_arrays.py
@@ -6,19 +6,10 @@ from ctypes.test import need_symbol
 
 formats = "bBhHiIlLqQfd"
 
-# c_longdouble commented out for PyPy, look at the commend in test_longdouble
 formats = c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint, \
-          c_long, c_ulonglong, c_float, c_double #, c_longdouble
+          c_long, c_ulonglong, c_float, c_double, c_longdouble
 
 class ArrayTestCase(unittest.TestCase):
-
-    @impl_detail('long double not supported by PyPy', pypy=False)
-    def test_longdouble(self):
-        """
-        This test is empty. It's just here to remind that we commented out
-        c_longdouble in "formats". If pypy will ever supports c_longdouble, we
-        should kill this test and uncomment c_longdouble inside formats.
-        """
 
     def test_simple(self):
         # create classes holding simple numeric types, and check

--- a/lib-python/2.7/ctypes/test/test_cfuncs.py
+++ b/lib-python/2.7/ctypes/test/test_cfuncs.py
@@ -160,14 +160,12 @@ class CFunctions(unittest.TestCase):
         self.assertEqual(self._dll.tf_bd(0, 42.), 14.)
         self.assertEqual(self.S(), 42)
 
-    @impl_detail('long double not supported by PyPy', pypy=False)
     def test_longdouble(self):
         self._dll.tf_D.restype = c_longdouble
         self._dll.tf_D.argtypes = (c_longdouble,)
         self.assertEqual(self._dll.tf_D(42.), 14.)
         self.assertEqual(self.S(), 42)
 
-    @impl_detail('long double not supported by PyPy', pypy=False)
     def test_longdouble_plus(self):
         self._dll.tf_bD.restype = c_longdouble
         self._dll.tf_bD.argtypes = (c_byte, c_longdouble)

--- a/lib-python/2.7/ctypes/test/test_functions.py
+++ b/lib-python/2.7/ctypes/test/test_functions.py
@@ -140,7 +140,6 @@ class FunctionTestCase(unittest.TestCase):
         self.assertEqual(result, -21)
         self.assertEqual(type(result), float)
 
-    @impl_detail('long double not supported by PyPy', pypy=False)
     def test_longdoubleresult(self):
         f = dll._testfunc_D_bhilfD
         f.argtypes = [c_byte, c_short, c_int, c_long, c_float, c_longdouble]

--- a/lib_pypy/_ctypes/basics.py
+++ b/lib_pypy/_ctypes/basics.py
@@ -297,6 +297,7 @@ _shape_to_ffi_type.typemap =  {
     'Q' : _ffi.types.ulonglong,
     'f' : _ffi.types.float,
     'd' : _ffi.types.double,
+    'g' : _ffi.types.longdouble,
     's' : _ffi.types.void_p,
     'P' : _ffi.types.void_p,
     'z' : _ffi.types.void_p,

--- a/lib_pypy/_ctypes/primitive.py
+++ b/lib_pypy/_ctypes/primitive.py
@@ -99,6 +99,8 @@ def swap_bytes(value, sizeof, typeof, get_or_set):
         return swap_double_float('f')
     elif typeof in ('c_double', 'c_double_le', 'c_double_be'):
         return swap_double_float('d')
+    elif typeof in ('c_longdouble', 'c_longdouble_le', 'c_longdouble_be'):
+        return swap_double_float('g')
     else:
         if sizeof == 2:
             return swap_2()

--- a/pypy/module/_rawffi/alt/interp_ffitype.py
+++ b/pypy/module/_rawffi/alt/interp_ffitype.py
@@ -90,6 +90,9 @@ class W_FFIType(W_Root):
     def is_singlefloat(self):
         return self is app_types.float
 
+    def is_longdouble(self):
+        return self is app_types.longdouble
+
     def is_void(self):
         return self is app_types.void
 
@@ -134,6 +137,7 @@ def build_ffi_types():
         W_FFIType('char',      libffi.types.uchar),
         W_FFIType('unichar',   libffi.types.wchar_t),
         #
+        W_FFIType('longdouble',libffi.types.longdouble),
         W_FFIType('double',    libffi.types.double),
         W_FFIType('float',     libffi.types.float),
         W_FFIType('void',      libffi.types.void),

--- a/pypy/module/_rawffi/alt/interp_funcptr.py
+++ b/pypy/module/_rawffi/alt/interp_funcptr.py
@@ -179,6 +179,9 @@ class PushArgumentConverter(FromAppLevelConverter):
     def handle_singlefloat(self, w_ffitype, w_obj, singlefloatval):
         self.argchain.arg(singlefloatval)
 
+    def handle_longdouble(self, w_ffitype, w_obj, longdoubleval):
+        self.argchain.arg(longdoubleval)
+
     def handle_struct(self, w_ffitype, w_structinstance):
         # arg_raw directly takes value to put inside ll_args
         ptrval = w_structinstance.rawmem
@@ -265,6 +268,9 @@ class CallFunctionConverter(ToAppLevelConverter):
 
     def get_singlefloat(self, w_ffitype):
         return self.func.call(self.argchain, rffi.FLOAT)
+
+    def get_longdouble(self, w_ffitype):
+        return self.func.call(self.argchain, rffi.LONGDOUBLE)
 
     def get_struct(self, w_ffitype, w_structdescr):
         addr = self.func.call(self.argchain, rffi.LONG, is_struct=True)

--- a/pypy/module/_rawffi/alt/test/test_ffitype.py
+++ b/pypy/module/_rawffi/alt/test/test_ffitype.py
@@ -7,6 +7,7 @@ class AppTestFFIType(object):
         assert str(types.uint) == "<ffi type uint>"
         assert types.sint.name == 'sint'
         assert types.uint.name == 'uint'
+        assert types.longdouble.name == 'longdouble'
 
     def test_sizeof(self):
         from _rawffi.alt import types

--- a/pypy/module/_rawffi/alt/test/test_funcptr.py
+++ b/pypy/module/_rawffi/alt/test/test_funcptr.py
@@ -415,6 +415,24 @@ class AppTestFFI(BaseAppTestFFI):
         assert res == self.f_12_34_plus_56_78
 
 
+    def test_long_double_args(self):
+        """
+            #include <stdio.h>
+            DLLEXPORT long double sum_xy_longdouble(long double x, long double y)
+            {
+                /* fprintf(stdout, "x,y %g, %g\\n", x, y); */
+                return x+y;
+            }
+        """
+        from _rawffi.alt import CDLL, types
+        libfoo = CDLL(self.libfoo_name)
+        sum_xy = libfoo.getfunc('sum_xy_longdouble',
+                                [types.longdouble, types.longdouble],
+                                types.longdouble)
+        res = sum_xy(12.34, 56.78)
+        assert res  - self.f_12_34_plus_56_78 < 0.01
+
+
     def test_slonglong_args(self):
         """
             DLLEXPORT long long sum_xy_longlong(long long x, long long y)

--- a/rpython/rlib/clibffi.py
+++ b/rpython/rlib/clibffi.py
@@ -388,7 +388,7 @@ def push_arg_as_ffiptr(ffitp, arg, ll_buf):
     if c_size == TP_size:
         buf = rffi.cast(TP_P, ll_buf)
         buf[0] = arg
-    elif TP in (rffi.FLOAT, rffi.DOUBLE) and c_size > TP_size:
+    elif (TP is rffi.FLOAT or TP is rffi.DOUBLE) and c_size > TP_size:
         # LongDouble. Convert the python float. The assert should not be needed
         assert isinstance(arg, float)
         result = StringBuilder(c_size)

--- a/rpython/rlib/clibffi.py
+++ b/rpython/rlib/clibffi.py
@@ -389,7 +389,8 @@ def push_arg_as_ffiptr(ffitp, arg, ll_buf):
         buf = rffi.cast(TP_P, ll_buf)
         buf[0] = arg
     elif TP in (rffi.FLOAT, rffi.DOUBLE) and c_size > TP_size:
-        # LongDouble. Convert the python float.
+        # LongDouble. Convert the python float. The assert should not be needed
+        assert isinstance(arg, float)
         result = StringBuilder(c_size)
         pack_float80(result, arg, c_size, False) 
         asbytes = result.build()


### PR DESCRIPTION
In GitLab by @mattip on Oct 4, 2020, 00:26

Support longdouble in _rawffi.alt, which will make it available to ctypes