### PR TITLE
mp queue: fix close without any put

### DIFF
--- a/lib-python/3/multiprocessing/queues.py
+++ b/lib-python/3/multiprocessing/queues.py
@@ -29,6 +29,7 @@ _ForkingPickler = context.reduction.ForkingPickler
 from .util import debug, info, Finalize, register_after_fork, is_exiting
 
 
+# PyPy added to fix issue bpo 42752
 class CleanExchange:
     def __init__(self, obj, attr):
         self.obj = obj

--- a/lib-python/3/test/_test_multiprocessing.py
+++ b/lib-python/3/test/_test_multiprocessing.py
@@ -1118,6 +1118,7 @@ class _TestQueue(BaseTestCase):
         self.assertTrue(not_serializable_obj.reduce_was_called)
         self.assertTrue(not_serializable_obj.on_queue_feeder_error_was_called)
 
+    # PyPy added to fix issue bpo 42752
     def test_closed_queue_closes_both(self):
         q = multiprocessing.Queue()
         q.put(1)


### PR DESCRIPTION
In GitLab by @crazycasta on Jan 1, 2021, 05:14

This fixes #3372.

In short:
* Current CPython multiprocessing.queues.Queue doesn't close properly unless put has been called before you try to close.
* Not as simple as just changing the write pipe close as this has to be done in the context of the buffer thread.
* This makes sure that before the thread has been started (before put has been called for instance) that something will close the write pipe.