### PR TITLE
Add test showing issue with PyExc_StopIteration

### DIFF
--- a/pypy/module/cpyext/test/test_async_iter.py
+++ b/pypy/module/cpyext/test/test_async_iter.py
@@ -187,13 +187,19 @@ class AppTestCoroReturn(AppTestCpythonExtensionBase):
                 if (PyType_Ready(&MyAwaitable_Type) < 0) INITERROR;
             ''')
 
-        import asyncio
         async def arun(coro):
             return await coro
 
+        def run_until_complete(coro):
+            while True:
+                try:
+                    fut = coro.send(None)
+                except StopIteration as ex:
+                    return ex.args[0]
+
         for _ in range(2):
             print("Trying with build_exception_object = %d" % module.build_exception_object())
-            x = asyncio.run(arun(module.my_awaitable()))
+            x = run_until_complete(arun(module.my_awaitable()))
             assert x == 30
             module.toggle_build_exception_object();
         """


### PR DESCRIPTION
In GitLab by @rtobar on Jul 19, 2023, 05:59

This test shows that, depending on how a StopIteration object is built in a C
extension, the final result of an awaitable is visible or not at the python
layer.

The exception is "raised" by calling PyExc_SetObject(PyExc_StopIteration,
value).  When "value" is an instance of PyExc_StopIteration that has already
been constructed with a value (i.e., "PyObject_CallOneArg(PyExc_StopIteration,
x)") then the exception is seen as expected, and the final value "x" is seen.
However, when "value" is "x" itself, the python layer gets a None object
instead. This difference in construction of exceptions in C extensions
(normalised v/s non-normalised exceptions) works seamlesly in CPython, but
doesn't in PyPy.

Note however that while developing this test and making it as minimal as
possible, I played with a simpler C extension that had a generator, and using
"yield from" from the python layer. That *did* work in both cases. This suggests
that the issue is specific to how coroutines are handled in PyPy.

--HG--
branch : stopiteration-issue