### PR TITLE
Give the named branches token write access to push.

### DIFF
--- a/.github/workflows/named-branches.yml
+++ b/.github/workflows/named-branches.yml
@@ -1,12 +1,17 @@
 name: 'Named Branches'
 on: push
+permissions:
+  contents: write
 jobs:
   named-branches:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        # Fetch 100 commits maximum when setting named branches.
+        # We can play with this number, but setting this to 0 takes 2 full
+        # minutes to checkout the repo.
+        fetch-depth: 100
     - uses: Julian/named-branch-action@v1
       with:
         github_token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
And limit how much we fetch so we don't wait ages.