### PR TITLE
fix limited API guard for METH_FASTCALL to match CPython

### DIFF
--- a/pypy/module/cpyext/include/methodobject.h
+++ b/pypy/module/cpyext/include/methodobject.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define METH_COEXIST   0x0040
 
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03100000
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030A0000
 #define METH_FASTCALL  0x0080
 #endif
 


### PR DESCRIPTION
This should fix `METH_FASTCALL` so it is included in the 3.10 limited API like in CPython.

Fixes #4050