### PR TITLE
Replace Heptapod and Mercurial mentions with GitHub and git

### DIFF
--- a/pypy/doc/build.rst
+++ b/pypy/doc/build.rst
@@ -31,7 +31,7 @@ Clone the repository
 If you prefer to compile your own PyPy, or if you want to modify it, you
 will need to obtain a copy of the sources.  This can be done either by
 `downloading them from the download page`_ or by checking them out from the
-repository using mercurial.  We suggest using mercurial if you want to access
+repository using git.  We suggest using git if you want to access
 the current development.
 
 .. _downloading them from the download page: https://www.pypy.org/download.html

--- a/pypy/doc/build.rst
+++ b/pypy/doc/build.rst
@@ -39,7 +39,7 @@ the current development.
 You must issue the following command on your
 command line, DOS box, or terminal::
 
-    hg clone https://foss.heptapod.net/pypy/pypy pypy
+    git clone https://github.com/pypy/pypy.git
 
 This will clone the repository and place it into a directory
 named ``pypy``, and will get you the PyPy source in ``pypy/pypy`` and
@@ -97,7 +97,7 @@ after building PyPy, otherwise the corresponding CFFI modules are not
 built (you can run or re-run `lib_pypy/pypy_tools/build_cffi_imports.py`_ to
 build them; you don't need to re-translate the whole PyPy):
 
-.. _`lib_pypy/pypy_tools/build_cffi_imports.py`: https://foss.heptapod.net/pypy/pypy/-/blob/branch/default/lib_pypy/pypy_tools/build_cffi_imports.py
+.. _`lib_pypy/pypy_tools/build_cffi_imports.py`: https://github.com/pypy/pypy/blob/main/lib_pypy/pypy_tools/build_cffi_imports.py
 
 sqlite3
     libsqlite3

--- a/pypy/doc/coding-guide.rst
+++ b/pypy/doc/coding-guide.rst
@@ -544,7 +544,7 @@ Committing & Branching to the repository
 Using the development bug/feature tracker
 -----------------------------------------
 
-We use https://foss.heptapod.net/pypy/pypy for :source:`issues` tracking and
+We use https://github.com/pypy/pypy/ for :source:`issues` tracking and
 :source:`pull-requests`.
 
 .. _testing:
@@ -735,7 +735,7 @@ files.  Here is a `ReST quickstart`_ but you can also just look
 at the existing documentation and see how things work.
 
 Note that the web site of https://pypy.org/ is maintained separately.
-It is in the repository https://foss.heptapod.net/pypy/pypy.org
+It is in the repository https://github.com/pypy/pypy.org
 
 .. _ReST quickstart: https://docutils.sourceforge.net/docs/user/rst/quickref.html
 

--- a/pypy/doc/coding-guide.rst
+++ b/pypy/doc/coding-guide.rst
@@ -544,7 +544,7 @@ Committing & Branching to the repository
 Using the development bug/feature tracker
 -----------------------------------------
 
-We use https://github.com/pypy/pypy/ for :source:`issues` tracking and
+We use https://github.com/pypy/pypy for :source:`issues` tracking and
 :source:`pull-requests`.
 
 .. _testing:

--- a/pypy/doc/contributing.rst
+++ b/pypy/doc/contributing.rst
@@ -46,14 +46,14 @@ coding sprints which are separately announced and are usually announced on `the
 blog`_.
 
 Like any Open Source project, issues should be filed on the `issue tracker`_,
-and `merge requests`_ to fix issues are welcome.
+and `pull requests`_ to fix issues are welcome.
 
 Further Reading: :ref:`Contact <contact>`
 
 .. _the blog: https://pypy.org/blog
 .. _pypy-dev mailing list: https://mail.python.org/mailman/listinfo/pypy-dev
-.. _`PyPy group page`: https://foss.heptapod.net/pypy
-.. _`merge requests`: https://foss.heptapod.net/heptapod/foss.heptapod.net/-/merge_requests
+.. _`PyPy group page`: https://github.com/pypy
+.. _`pull requests`: https://github.com/pypy/pypy/pulls/
 
 
 Your first contribution
@@ -77,14 +77,15 @@ Some ideas for first contributions are:
 * Missing language features - these are listed in our `issue tracker`_
 
 .. _nightly builds: https://buildbot.pypy.org/nightly/
-.. _issue tracker: https://foss.heptapod.net/pypy/pypy/issues
+.. _issue tracker: https://github.com/pypy/pypy/issues/
 
 Source Control
 --------------
 
-PyPy's main repositories are hosted here: https://foss.heptapod.net/pypy.
+PyPy's main repositories are hosted here: https://github.com/pypy.
 
-`Heptapod <https://heptapod.net/>`_ is a friendly fork of GitLab Community
+Pypy's repositories used to be hosted on `Heptapod <https://heptapod.net/>`_.
+Heptapod is a friendly fork of GitLab Community
 Edition supporting Mercurial. https://foss.heptapod.net is a public instance
 for Free and Open-Source Software (more information `here
 <https://foss.heptapod.net/heptapod/foss.heptapod.net>`_).
@@ -102,65 +103,39 @@ Thanks to `Octobus <https://octobus.net/>`_ and `Clever Cloud
      </a>
    </h1>
 
-Get Access
-----------
-
-As stated above, you need to request access to the repo.
-Since the free hosting on foss.heptapod.net does not allow personal forks, you
-need permissions to push your changes directly to our repo. Once you sign in to
-https://foss.heptapod.net using either a new login or your GitHub or Atlassian
-logins, you can get developer status for pushing directly to
-the project (just ask by clicking the link at foss.heptapod.net/pypy just under
-the logo, and you'll get it, basically).  Once you have it you can rewrite your
-file ``.hg/hgrc`` to contain ``default = ssh://hg@foss.heptapod.net/pypy/pypy``.
-Your changes will then be pushed directly to a branch on the official repo, and
-we will review the branches you want to merge.
 
 Clone
 -----
 
 * Clone the PyPy repo to your local machine with the command
-  ``hg clone https://foss.heptapod.net/pypy/pypy``.  It takes a minute or two
+  ``git clone https://github.com/pypy/pypy.git``.  It takes a minute or two
   operation but only ever needs to be done once.  See also
   https://pypy.org/download.html#building-from-source .
-  If you already cloned the repo before, even if some time ago,
-  then you can reuse the same clone by editing the file ``.hg/hgrc`` in
-  your clone to contain the line ``default =
-  https://foss.heptapod.net/pypy/pypy``, and then do ``hg pull && hg
-  up``.  If you already have such a clone but don't want to change it,
-  you can clone that copy with ``hg clone /path/to/other/copy``, and
-  then edit ``.hg/hgrc`` as above and do ``hg pull && hg up``.
 
-* Now you have a complete copy of the PyPy repo.  Make a long-lived branch
-  with a command like ``hg branch name_of_your_branch``.
+
+* Now you have a complete copy of the PyPy repo.
 
 Edit
 ----
 
-* Edit things.  Use ``hg diff`` to see what you changed.  Use ``hg add``
-  to make Mercurial aware of new files you added, e.g. new test files.
-  Use ``hg status`` to see if there are such files.  Write and run tests!
+* Edit things.  Use ``git diff`` to see what you changed.  Use ``git add``
+  to make git aware of new files you added, e.g. new test files.
+  Use ``git status`` to see if there are such files.  Write and run tests!
   (See the rest of this page.)
 
-* Commit regularly with ``hg commit``.  A one-line commit message is
+* Commit regularly with ``git commit``.  A one-line commit message is
   fine.  We love to have tons of commits; make one as soon as you have
   some progress, even if it is only some new test that doesn't pass yet,
   or fixing things even if not all tests pass.  Step by step, you are
   building the history of your changes, which is the point of a version
-  control system.  (There are commands like ``hg log`` and ``hg up``
+  control system.  (There are commands like ``git log``
   that you should read about later, to learn how to navigate this
   history.)
 
-* The commits stay on your machine until you do ``hg push`` to "push"
-  them back to the repo named in the file ``.hg/hgrc``.  Repos are
-  basically just collections of commits (a commit is also called a
-  changeset): there is one repo per url, plus one for each local copy on
-  each local machine.  The commands ``hg push`` and ``hg pull`` copy
+* The commits stay on your machine until you do ``git push`` to "push"
+  them back to your fork.  The commands ``git push`` and ``git pull`` copy
   commits around, with the goal that all repos in question end up with
-  the exact same set of commits.  By opposition, ``hg up`` only updates
-  the "working copy" by reading the local repository, i.e. it makes the
-  files that you see correspond to the latest (or any other) commit
-  locally present.
+  the exact same set of commits.
 
 * You should push often; there is no real reason not to.  Remember that
   even if they are pushed, with the setup above, the commits are only in the
@@ -172,10 +147,10 @@ Edit
   accept it as is for PyPy, asking you instead to improve some things,
   but we are not going to judge you unless you don't write tests.
 
-Merge Request
+Pull Request
 -------------
 
-* The final step is to open a merge request, so that we know that you'd
+* The final step is to open a pull request, so that we know that you'd
   like to merge that branch back to the original ``pypy/pypy`` repo.
   This can also be done several times if you have interesting
   intermediate states, but if you get there, then we're likely to
@@ -185,7 +160,7 @@ Merge Request
   that we generally push small changes as one or a few commits directly
   to the branch ``default`` or ``py3.9``.  Also, we often collaborate even if
   we are on other branches, which do not really "belong" to anyone.  At this
-  point you'll need ``hg merge`` and learn how to resolve conflicts that
+  point you'll need ``git merge`` and learn how to resolve conflicts that
   sometimes occur when two people try to push different commits in
   parallel on the same branch.  But it is likely an issue for later ``:-)``
 

--- a/pypy/doc/contributing.rst
+++ b/pypy/doc/contributing.rst
@@ -82,9 +82,10 @@ Some ideas for first contributions are:
 Source Control
 --------------
 
-PyPy's main repositories are hosted here: https://github.com/pypy.
+PyPy's main git repositories are hosted here: https://github.com/pypy,
+and legacy repositories are hosted here: https://foss.heptapod.net/pypy.
 
-Pypy's repositories used to be hosted on `Heptapod <https://heptapod.net/>`_.
+Pypy's legacy repositories are hosted on `Heptapod <https://heptapod.net/>`_.
 Heptapod is a friendly fork of GitLab Community
 Edition supporting Mercurial. https://foss.heptapod.net is a public instance
 for Free and Open-Source Software (more information `here

--- a/pypy/doc/cpython_differences.rst
+++ b/pypy/doc/cpython_differences.rst
@@ -84,7 +84,7 @@ object and the weakref will be considered as dead at the same time,
 and the callback will not be invoked.  (Issue `#2030`__)
 
 .. __: https://docs.python.org/2/library/weakref.html
-.. __: https://foss.heptapod.net/pypy/pypy/-/issues/2030/
+.. __: https://github.com/pypy/pypy/issues/2030/
 
 A new difference: before CPython 3.4, a weakref to ``x`` was always
 cleared before the ``x.__del__()`` method was called.  Since CPython 3.4
@@ -117,7 +117,7 @@ difference if the ``yield`` keyword it is suspended at is itself
 enclosed in a ``try:`` or a ``with:`` block.  This shows up for example
 as `issue 736`__.
 
-.. __: https://foss.heptapod.net/pypy/pypy/-/issues/736
+.. __: https://github.com/pypy/pypy/issues/736
 
 Using the default GC (called ``minimark``), the built-in function ``id()``
 works like it does in CPython.  With other GCs it returns numbers that
@@ -301,7 +301,7 @@ Another consequence is that ``cmp(float('nan'), float('nan')) == 0``, because
 no good value to return from this call to ``cmp``, because ``cmp`` pretends
 that there is a total order on floats, but that is wrong for NaNs).
 
-.. __: https://foss.heptapod.net/pypy/pypy/-/issues/1974
+.. __: https://github.com/pypy/pypy/issues/1974
 
 Permitted ABI tags in extensions
 --------------------------------
@@ -690,6 +690,6 @@ that are neither mentioned above nor in :source:`lib_pypy/` are not available in
 
 .. _`is ignored in PyPy`: https://bugs.python.org/issue14621
 .. _`little point`: https://events.ccc.de/congress/2012/Fahrplan/events/5152.en.html
-.. _`#2072`: https://foss.heptapod.net/pypy/pypy/-/issues/2072/
-.. _`issue #2653`: https://foss.heptapod.net/pypy/pypy/-/issues/2653/
+.. _`#2072`: https://github.com/pypy/pypy/issues/2072/
+.. _`issue #2653`: https://github.com/pypy/pypy/issues/2653/
 .. _SyntaxError: https://www.pypy.org/posts/2018/04/improving-syntaxerror-in-pypy-5733639208090522433.html

--- a/pypy/doc/dev_method.rst
+++ b/pypy/doc/dev_method.rst
@@ -4,12 +4,12 @@ Distributed and agile development in PyPy
 .. note::
   This page describes the mode of development that preceeds the current models
   of Open Source development. While people are welcome to join our (now yearly)
-  sprints, we encourage engagement via the gitlab repo at
-  https://foss.heptapod.net/pypy/pypy. Issues can be filed and discussed in the
-  `issue tracker`_ and we welcome `merge requests`_.
+  sprints, we encourage engagement via the GitHub repo at
+  https://github.com/pypy/pypy/. Issues can be filed and discussed in the
+  `issue tracker`_ and we welcome `pull requests`_.
 
-.. _`issue tracker`: https://foss.heptapod.net/heptapod/foss.heptapod.net/-/issues
-.. _`merge requests`: https://foss.heptapod.net/heptapod/foss.heptapod.net/-/merge_requests
+.. _`issue tracker`: https://github.com/pypy/pypy/issues/
+.. _`pull requests`: https://github.com/pypy/pypy/pulls/
 
 PyPy isn't just about producing code - it's also about how we produce code.
 The challenges of coordinating work within a community and making sure it is
@@ -30,7 +30,7 @@ Main methods for achieving this is:
 Main tools for achieving this is:
 
   * py.test - automated testing
-  * Mercurial - version control
+  * Git - version control
   * Transparent communication and documentation (mailinglists, IRC, tutorials
     etc etc)
 

--- a/pypy/doc/faq.rst
+++ b/pypy/doc/faq.rst
@@ -392,12 +392,12 @@ the most immediate way to get feedback (at least during some parts of the day;
 most PyPy developers are in Europe) and the `mailing list`_ is better for long
 discussions.
 
-We also encourage engagement via the gitlab repo at
-https://foss.heptapod.net/pypy/pypy. Issues can be filed and discussed in the
-`issue tracker`_ and we welcome `merge requests`.
+We also encourage engagement via the GitHub repo at
+https://github.com/pypy/pypy. Issues can be filed and discussed in the
+`issue tracker`_ and we welcome `pull requests`.
 
-.. _`issue tracker`: https://foss.heptapod.net/heptapod/foss.heptapod.net/-/issues
-.. _`merge requests`: https://foss.heptapod.net/heptapod/foss.heptapod.net/-/merge_requests
+.. _`issue tracker`: https://github.com/pypy/pypy/issues/
+.. _`pull requests`: https://github.com/pypy/pypy/pulls/
 
 .. _mailing list: https://mail.python.org/mailman/listinfo/pypy-dev
 
@@ -422,7 +422,7 @@ Be sure to enable it again if you need it!
 How should I report a bug?
 --------------------------
 
-Our bug tracker is here: https://foss.heptapod.net/pypy/pypy/issues/
+Our bug tracker is here: https://github.com/pypy/pypy/issues/
 
 Missing features or incompatibilities with CPython are considered
 bugs, and they are welcome.  (See also our list of `known
@@ -441,7 +441,7 @@ Debugging PyPy can be annoying.
 `This is a clear and useful bug report.`__  (Admittedly, sometimes
 the problem is really hard to reproduce, but please try to.)
 
-.. __: https://foss.heptapod.net/pypy/pypy/issues/2363/segfault-in-gc-pinned-object-in
+.. __: https://github.com/pypy/pypy/issues/2363
 
 In more details:
 

--- a/pypy/doc/index.rst
+++ b/pypy/doc/index.rst
@@ -9,7 +9,7 @@ implementation of the Python_ language.
 
 * If you're interested in trying PyPy out, check out the :doc:`installation instructions <install>`.
 
-* If you want to help develop PyPy, please have a look at :doc:`contributing <contributing>` and at the repo on https://foss.heptapod.net/pypy/pypy
+* If you want to help develop PyPy, please have a look at :doc:`contributing <contributing>` and at the repo on https://github.com/pypy/pypy
   and get in touch (:ref:`contact`)!
 
 All of the documentation and source code is available under the MIT license,
@@ -110,7 +110,7 @@ Watch us on twitch_
 .. _here: https://quodlibet.duckdns.org/irc/pypy/latest.log.html#irc-end
 .. _Development mailing list: https://mail.python.org/mailman/listinfo/pypy-dev
 .. _Commit mailing list: https://mail.python.org/mailman/listinfo/pypy-commit
-.. _Development bug/feature tracker: https://foss.heptapod.net/pypy/pypy/issues
+.. _Development bug/feature tracker: https://github.com/pypy/pypy/issues/
 .. _`#pypyproject`: https://twitter.com/pypyproject
 .. _twitch: https://www.twitch.tv/pypyproject
 

--- a/pypy/doc/install.rst
+++ b/pypy/doc/install.rst
@@ -30,7 +30,7 @@ On macOS you can also use homebrew, which provides signed packages. As of April
 2023, you can find pypy2.7 and pypy3.7 there. Help moving issue 3697_ to
 provide other versions is welcome.
 
-.. _3697: https://foss.heptapod.net/pypy/pypy/-/issues/3697 
+.. _3697: https://github.com/pypy/pypy/issues/3697 
 .. _`blog post`: https://www.pypy.org/posts/2022/11/pypy-and-conda-forge.html
 
 Linux distributions
@@ -103,13 +103,13 @@ Installing using virtualenv
 
 It is often convenient to run pypy inside a virtualenv.  To do this
 you need a version of virtualenv -- 1.6.1 or greater.  You can
-then install PyPy both from a precompiled tarball or from a mercurial
+then install PyPy both from a precompiled tarball or from a git
 checkout after translation::
 
 	# from a tarball
 	$ virtualenv -p /opt/pypy-xxx/bin/pypy my-pypy-env
 
-	# from the mercurial checkout
+	# from the git checkout
 	$ virtualenv -p /path/to/pypy/pypy/translator/goal/pypy-c my-pypy-env
 
 	# in any case activate it

--- a/pypy/doc/project-ideas.rst
+++ b/pypy/doc/project-ideas.rst
@@ -41,10 +41,10 @@ Simple tasks for newcomers
 --------------------------
 
 * Optimize random:
-  https://foss.heptapod.net/pypy/pypy/-/issues/1901
+  https://github.com/pypy/pypy/issues/1901
 
 * Implement AF_XXX packet types of sockets:
-  https://foss.heptapod.net/pypy/pypy/-/issues/1942
+  https://github.com/pypy/pypy/issues/1942
 
 * Help with documentation. One task would be to document rpython configuration
   options currently listed only on :doc:`this site <configuration>` also on the
@@ -70,7 +70,7 @@ own improvement ideas. In any case, if you feel like working on some of those
 projects, or anything else in PyPy, pop up on IRC or write to us on the
 `mailing list`_.
 
-.. _issue tracker: https://foss.heptapod.net/pypy/pypy/-/issues
+.. _issue tracker: https://github.com/pypy/pypy/issues/
 .. _mailing list: https://mail.python.org/mailman/listinfo/pypy-dev
 
 

--- a/pypy/doc/sandbox.rst
+++ b/pypy/doc/sandbox.rst
@@ -121,7 +121,7 @@ If you don't have a regular PyPy installed, you should, because it's
 faster to translate; but you can also run the same line with ``python``
 in front.
 
-.. _repository: https://foss.heptapod.net/pypy/pypy
+.. _repository: https://github.com/pypy/pypy
 
 
 To run it, use the tools in the pypy/sandbox directory::


### PR DESCRIPTION
This PR aims to help the migration effort to GitHub by replacing mentions of Heptapod and Mercurial with GitHub and git.

So far, it's missing some hg command translations.