### PR TITLE
Add docstrings to tupleobject

### DIFF
--- a/pypy/objspace/std/objectobject.py
+++ b/pypy/objspace/std/objectobject.py
@@ -221,42 +221,6 @@ def descr___format__(space, w_obj, w_format_spec):
         space.warn(space.newtext(msg), space.w_PendingDeprecationWarning)
     return space.format(w_as_str, w_format_spec)
 
-
-W_ObjectObject.typedef = TypeDef("object",
-    __rpython_level_class__ = W_ObjectObject,
-    __doc__ = "The most base type",
-    __new__ = interp2app(descr__new__,
-                         doc=ObjectObjectDocstrings.__new__.__doc__),
-    __subclasshook__ = interp2app(descr___subclasshook__, as_classmethod=True,
-                                  doc=ObjectObjectDocstrings.__subclasshook__.__doc__),
-
-    # these are actually implemented in pypy.objspace.descroperation
-    __getattribute__ = interp2app(Object.descr__getattribute__.im_func,
-                                  doc=ObjectObjectDocstrings.__getattribute__.__doc__),
-    __setattr__ = interp2app(Object.descr__setattr__.im_func,
-                             doc=ObjectObjectDocstrings.__setattr__.__doc__),
-    __delattr__ = interp2app(Object.descr__delattr__.im_func,
-                             doc=ObjectObjectDocstrings.__delattr__.__doc__),
-
-    __init__ = interp2app(descr__init__,
-                          doc=ObjectObjectDocstrings.__init__.__doc__),
-    __class__ = GetSetProperty(descr_get___class__, descr_set___class__,
-                               doc=ObjectObjectDocstrings.__class__.__doc__),
-    __repr__ = interp2app(descr__repr__,
-                          doc=ObjectObjectDocstrings.__repr__.__doc__),
-    __str__ = interp2app(descr__str__,
-                         doc=ObjectObjectDocstrings.__str__.__doc__),
-    __hash__ = interp2app(default_identity_hash,
-                          doc=ObjectObjectDocstrings.__hash__.__doc__),
-    __reduce__ = interp2app(descr__reduce__,
-                            doc=ObjectObjectDocstrings.__reduce__.__doc__),
-    __reduce_ex__ = interp2app(descr__reduce_ex__,
-                               doc=ObjectObjectDocstrings.__reduce_ex__.__doc__),
-    __format__ = interp2app(descr___format__,
-                            doc=ObjectObjectDocstrings.__format__.__doc__),
-)
-
-
 class ObjectObjectDocstrings:
 
     def __new__():
@@ -304,3 +268,37 @@ class ObjectObjectDocstrings:
 
     def __format__():
         """default object formatter"""
+
+W_ObjectObject.typedef = TypeDef("object",
+    __rpython_level_class__ = W_ObjectObject,
+    __doc__ = "The most base type",
+    __new__ = interp2app(descr__new__,
+                         doc=ObjectObjectDocstrings.__new__.__doc__),
+    __subclasshook__ = interp2app(descr___subclasshook__, as_classmethod=True,
+                                  doc=ObjectObjectDocstrings.__subclasshook__.__doc__),
+
+    # these are actually implemented in pypy.objspace.descroperation
+    __getattribute__ = interp2app(Object.descr__getattribute__.im_func,
+                                  doc=ObjectObjectDocstrings.__getattribute__.__doc__),
+    __setattr__ = interp2app(Object.descr__setattr__.im_func,
+                             doc=ObjectObjectDocstrings.__setattr__.__doc__),
+    __delattr__ = interp2app(Object.descr__delattr__.im_func,
+                             doc=ObjectObjectDocstrings.__delattr__.__doc__),
+
+    __init__ = interp2app(descr__init__,
+                          doc=ObjectObjectDocstrings.__init__.__doc__),
+    __class__ = GetSetProperty(descr_get___class__, descr_set___class__,
+                               doc=ObjectObjectDocstrings.__class__.__doc__),
+    __repr__ = interp2app(descr__repr__,
+                          doc=ObjectObjectDocstrings.__repr__.__doc__),
+    __str__ = interp2app(descr__str__,
+                         doc=ObjectObjectDocstrings.__str__.__doc__),
+    __hash__ = interp2app(default_identity_hash,
+                          doc=ObjectObjectDocstrings.__hash__.__doc__),
+    __reduce__ = interp2app(descr__reduce__,
+                            doc=ObjectObjectDocstrings.__reduce__.__doc__),
+    __reduce_ex__ = interp2app(descr__reduce_ex__,
+                               doc=ObjectObjectDocstrings.__reduce_ex__.__doc__),
+    __format__ = interp2app(descr___format__,
+                            doc=ObjectObjectDocstrings.__format__.__doc__),
+)

--- a/pypy/objspace/std/objectobject.py
+++ b/pypy/objspace/std/objectobject.py
@@ -225,20 +225,82 @@ def descr___format__(space, w_obj, w_format_spec):
 W_ObjectObject.typedef = TypeDef("object",
     __rpython_level_class__ = W_ObjectObject,
     __doc__ = "The most base type",
-    __new__ = interp2app(descr__new__),
-    __subclasshook__ = interp2app(descr___subclasshook__, as_classmethod=True),
+    __new__ = interp2app(descr__new__,
+                         doc=ObjectObjectDocstrings.__new__.__doc__),
+    __subclasshook__ = interp2app(descr___subclasshook__, as_classmethod=True,
+                                  doc=ObjectObjectDocstrings.__subclasshook__.__doc__),
 
     # these are actually implemented in pypy.objspace.descroperation
-    __getattribute__ = interp2app(Object.descr__getattribute__.im_func),
-    __setattr__ = interp2app(Object.descr__setattr__.im_func),
-    __delattr__ = interp2app(Object.descr__delattr__.im_func),
+    __getattribute__ = interp2app(Object.descr__getattribute__.im_func,
+                                  doc=ObjectObjectDocstrings.__getattribute__.__doc__),
+    __setattr__ = interp2app(Object.descr__setattr__.im_func,
+                             doc=ObjectObjectDocstrings.__setattr__.__doc__),
+    __delattr__ = interp2app(Object.descr__delattr__.im_func,
+                             doc=ObjectObjectDocstrings.__delattr__.__doc__),
 
-    __init__ = interp2app(descr__init__),
-    __class__ = GetSetProperty(descr_get___class__, descr_set___class__),
-    __repr__ = interp2app(descr__repr__),
-    __str__ = interp2app(descr__str__),
-    __hash__ = interp2app(default_identity_hash),
-    __reduce__ = interp2app(descr__reduce__),
-    __reduce_ex__ = interp2app(descr__reduce_ex__),
-    __format__ = interp2app(descr___format__),
+    __init__ = interp2app(descr__init__,
+                          doc=ObjectObjectDocstrings.__init__.__doc__),
+    __class__ = GetSetProperty(descr_get___class__, descr_set___class__,
+                               doc=ObjectObjectDocstrings.__class__.__doc__),
+    __repr__ = interp2app(descr__repr__,
+                          doc=ObjectObjectDocstrings.__repr__.__doc__),
+    __str__ = interp2app(descr__str__,
+                         doc=ObjectObjectDocstrings.__str__.__doc__),
+    __hash__ = interp2app(default_identity_hash,
+                          doc=ObjectObjectDocstrings.__hash__.__doc__),
+    __reduce__ = interp2app(descr__reduce__,
+                            doc=ObjectObjectDocstrings.__reduce__.__doc__),
+    __reduce_ex__ = interp2app(descr__reduce_ex__,
+                               doc=ObjectObjectDocstrings.__reduce_ex__.__doc__),
+    __format__ = interp2app(descr___format__,
+                            doc=ObjectObjectDocstrings.__format__.__doc__),
 )
+
+
+class ObjectObjectDocstrings:
+
+    def __new__():
+        """T.__new__(S, ...) -> a new object with type S, a subtype of T"""
+
+    def __subclasshook__():
+        """Abstract classes can override this to customize issubclass().
+
+        This is invoked early on by abc.ABCMeta.__subclasscheck__().
+        It should return True, False or NotImplemented.  If it returns
+        NotImplemented, the normal algorithm is used.  Otherwise, it
+        overrides the normal algorithm (and the outcome is cached).
+        """
+
+    def __hash__():
+        """x.__hash__() <==> hash(x)"""
+
+    def __setattr__():
+        """x.__setattr__('name', value) <==> x.name = value"""
+
+    def __getattribute__():
+        """"x.__getattribute__('name') <==> x.name"""
+
+    def __delattr__():
+        """x.__delattr__('name') <==> del x.name"""
+
+    def __init__():
+        """x.__init__(...) initializes x; see help(type(x)) for signature."""
+
+    def __class__():
+        """type(object) -> the object's type
+        type(name, bases, dict) -> a new type"""
+
+    def __repr__():
+        """x.__repr__() <==> repr(x)"""
+
+    def __str__():
+        """x.__str__() <==> str(x)"""
+
+    def __reduce__():
+        """helper for pickle"""
+
+    def __reduce_ex__():
+        """helper for pickle"""
+
+    def __format__():
+        """default object formatter"""

--- a/pypy/objspace/std/tupleobject.py
+++ b/pypy/objspace/std/tupleobject.py
@@ -244,6 +244,61 @@ class W_AbstractTupleObject(W_Root):
     def _unroll_condition(self):
         raise NotImplementedError("abstract base class")
 
+class TupleDocstrings:
+
+    def __eq__():
+        """x.__eq__(y) <==> x==y'"""
+
+    def __ne__():
+        """x.__ne__(y) <==> x!=y"""
+
+    def __lt__():
+        """x.__lt__(y) <==> x<y"""
+
+    def __le__():
+        """x.__le__(y) <==> x<=y"""
+
+    def __gt__():
+        """x.__gt__(y) <==> x>y"""
+
+    def __ge__():
+        """x.__ge__(y) <==> x>=y"""
+
+    def __len__():
+        """x.__len__() <==> len(x)"""
+
+    def __iter__():
+        """x.__iter__() <==> iter(x)"""
+
+    def __contains__():
+        """x.__contains__(y) <==> y in x"""
+
+    def __add__():
+        """x.__add__(y) <==> x+y"""
+
+    def __mul__():
+        """x.__mul__(n) <==> x*n"""
+
+    def __rmul__():
+        """x.__rmul__(n) <==> n*x"""
+
+    def __getitem__():
+        """x.__getitem__(y) <==> x[y]"""
+
+    def __getslice__():
+        """x.__getslice__(i, j) <==> x[i:j]
+
+        Use of negative indices is not supported."""
+
+    def __getnewargs__():
+        """""" # empty
+
+    def count():
+        """T.count(value) -> integer -- return number of occurrences of value"""
+
+    def index():
+        """"T.index(value, [start, [stop]]) -> integer -- return first index of value.
+        Raises ValueError if the value is not present."""
 
 W_AbstractTupleObject.typedef = TypeDef(
     "tuple",
@@ -255,13 +310,10 @@ If the argument is a tuple, the return value is the same object.""",
                          doc=ObjectObjectDocstrings.__new__.__doc__),
     __repr__ = interp2app(W_AbstractTupleObject.descr_repr,
                           doc=ObjectObjectDocstrings.__repr__.__doc__),
-    __hash__ = interpindirect2app(W_AbstractTupleObject.descr_hash,
-                                  doc=ObjectObjectDocstrings.__hash__.__doc__),
+    __hash__ = interpindirect2app(W_AbstractTupleObject.descr_hash),
 
-    __eq__ = interpindirect2app(W_AbstractTupleObject.descr_eq,
-                                doc=TupleDocstrings.__eq__.__doc__),
-    __ne__ = interpindirect2app(W_AbstractTupleObject.descr_ne,
-                                doc=TupleDocstrings.__ne__.__doc__),
+    __eq__ = interpindirect2app(W_AbstractTupleObject.descr_eq),
+    __ne__ = interpindirect2app(W_AbstractTupleObject.descr_ne),
     __lt__ = interp2app(W_AbstractTupleObject.descr_lt,
                         doc=TupleDocstrings.__lt__.__doc__),
     __le__ = interp2app(W_AbstractTupleObject.descr_le,
@@ -286,12 +338,12 @@ If the argument is a tuple, the return value is the same object.""",
                           doc=TupleDocstrings.__rmul__.__doc__),
 
     __getitem__ = interp2app(W_AbstractTupleObject.descr_getitem,
-                             doc=doc=TupleDocstrings.__getitem__.__doc__),
+                             doc=TupleDocstrings.__getitem__.__doc__),
     __getslice__ = interp2app(W_AbstractTupleObject.descr_getslice,
-                              doc=doc=TupleDocstrings.__getslice__.__doc__),
+                              doc=TupleDocstrings.__getslice__.__doc__),
 
     __getnewargs__ = interp2app(W_AbstractTupleObject.descr_getnewargs,
-                                doc=doc=TupleDocstrings.__getnewargs__.__doc__),
+                                doc=TupleDocstrings.__getnewargs__.__doc__),
     count = interp2app(W_AbstractTupleObject.descr_count,
                        doc=TupleDocstrings.count.__doc__),
     index = interp2app(W_AbstractTupleObject.descr_index,
@@ -406,58 +458,3 @@ def wraptuple2(space, w_a, w_b):
             pass
     return W_TupleObject([w_a, w_b])
 
-class TupleDocstrings:
-
-    def __eq__():
-        """x.__eq__(y) <==> x==y'"""
-
-    def __ne__():
-        """x.__ne__(y) <==> x!=y"""
-
-    def __lt__():
-        """x.__lt__(y) <==> x<y"""
-
-    def __le__():
-        """x.__le__(y) <==> x<=y"""
-
-    def __gt__():
-        """x.__gt__(y) <==> x>y"""
-
-    def __ge__():
-        """x.__ge__(y) <==> x>=y"""
-
-    def __len__():
-        """x.__len__() <==> len(x)"""
-
-    def __iter__():
-        """x.__iter__() <==> iter(x)"""
-
-    def __contains__():
-        """x.__contains__(y) <==> y in x"""
-
-    def __add__():
-        """x.__add__(y) <==> x+y"""
-
-    def __mul__():
-        """x.__mul__(n) <==> x*n"""
-
-    def __rmul__():
-        """x.__rmul__(n) <==> n*x"""
-
-    def __getitem__():
-        """x.__getitem__(y) <==> x[y]"""
-
-    def __getslice__():
-        """x.__getslice__(i, j) <==> x[i:j]
-
-        Use of negative indices is not supported."""
-
-    def __getnewargs__():
-        """""" # empty
-
-    def count():
-        """T.count(value) -> integer -- return number of occurrences of value"""
-
-    def index():
-        """"T.index(value, [start, [stop]]) -> integer -- return first index of value.
-        Raises ValueError if the value is not present."""

--- a/pypy/objspace/std/tupleobject.py
+++ b/pypy/objspace/std/tupleobject.py
@@ -250,31 +250,51 @@ W_AbstractTupleObject.typedef = TypeDef(
 tuple(sequence) -> tuple initialized from sequence's items
 
 If the argument is a tuple, the return value is the same object.""",
-    __new__ = interp2app(W_AbstractTupleObject.descr_new),
-    __repr__ = interp2app(W_AbstractTupleObject.descr_repr),
-    __hash__ = interpindirect2app(W_AbstractTupleObject.descr_hash),
+    __new__ = interp2app(W_AbstractTupleObject.descr_new,
+                         doc=TupleDocstrings.__new__.__doc__),
+    __repr__ = interp2app(W_AbstractTupleObject.descr_repr,
+                          doc=TupleDocstrings.__repr__.__doc__),
+    __hash__ = interpindirect2app(W_AbstractTupleObject.descr_hash,
+                                  doc=TupleDocstrings.__hash__.__doc__),
 
-    __eq__ = interpindirect2app(W_AbstractTupleObject.descr_eq),
-    __ne__ = interpindirect2app(W_AbstractTupleObject.descr_ne),
-    __lt__ = interp2app(W_AbstractTupleObject.descr_lt),
-    __le__ = interp2app(W_AbstractTupleObject.descr_le),
-    __gt__ = interp2app(W_AbstractTupleObject.descr_gt),
-    __ge__ = interp2app(W_AbstractTupleObject.descr_ge),
+    __eq__ = interpindirect2app(W_AbstractTupleObject.descr_eq,
+                                doc=TupleDocstrings.__eq__.__doc__),
+    __ne__ = interpindirect2app(W_AbstractTupleObject.descr_ne,
+                                doc=TupleDocstrings.__ne__.__doc__),
+    __lt__ = interp2app(W_AbstractTupleObject.descr_lt,
+                        doc=TupleDocstrings.__lt__.__doc__),
+    __le__ = interp2app(W_AbstractTupleObject.descr_le,
+                        doc=TupleDocstrings.__le__.__doc__),
+    __gt__ = interp2app(W_AbstractTupleObject.descr_gt,
+                        doc=TupleDocstrings.__gt__.__doc__),
+    __ge__ = interp2app(W_AbstractTupleObject.descr_ge,
+                        doc=TupleDocstrings.__ge__.__doc__),
 
-    __len__ = interp2app(W_AbstractTupleObject.descr_len),
-    __iter__ = interp2app(W_AbstractTupleObject.descr_iter),
-    __contains__ = interp2app(W_AbstractTupleObject.descr_contains),
+    __len__ = interp2app(W_AbstractTupleObject.descr_len,
+                         doc=TupleDocstrings.__len__.__doc__),
+    __iter__ = interp2app(W_AbstractTupleObject.descr_iter,
+                          doc=TupleDocstrings.__iter__.__doc__),
+    __contains__ = interp2app(W_AbstractTupleObject.descr_contains,
+                              doc=TupleDocstrings.__contains__.__doc__),
 
-    __add__ = interp2app(W_AbstractTupleObject.descr_add),
-    __mul__ = interp2app(W_AbstractTupleObject.descr_mul),
-    __rmul__ = interp2app(W_AbstractTupleObject.descr_mul),
+    __add__ = interp2app(W_AbstractTupleObject.descr_add,
+                         doc=TupleDocstrings.__add__.__doc__),
+    __mul__ = interp2app(W_AbstractTupleObject.descr_mul,
+                         doc=TupleDocstrings.__mul__.__doc__),
+    __rmul__ = interp2app(W_AbstractTupleObject.descr_mul,
+                          doc=TupleDocstrings.__rmul__.__doc__),
 
-    __getitem__ = interp2app(W_AbstractTupleObject.descr_getitem),
-    __getslice__ = interp2app(W_AbstractTupleObject.descr_getslice),
+    __getitem__ = interp2app(W_AbstractTupleObject.descr_getitem,
+                             doc=doc=TupleDocstrings.__getitem__.__doc__),
+    __getslice__ = interp2app(W_AbstractTupleObject.descr_getslice,
+                              doc=doc=TupleDocstrings.__getslice__.__doc__),
 
-    __getnewargs__ = interp2app(W_AbstractTupleObject.descr_getnewargs),
-    count = interp2app(W_AbstractTupleObject.descr_count),
-    index = interp2app(W_AbstractTupleObject.descr_index)
+    __getnewargs__ = interp2app(W_AbstractTupleObject.descr_getnewargs,
+                                doc=doc=TupleDocstrings.__getnewargs__.__doc__),
+    count = interp2app(W_AbstractTupleObject.descr_count,
+                       doc=TupleDocstrings.count.__doc__),
+    index = interp2app(W_AbstractTupleObject.descr_index,
+                       doc=TupleDocstrings.index.__doc__)
 )
 W_AbstractTupleObject.typedef.flag_sequence_bug_compat = True
 
@@ -384,3 +404,68 @@ def wraptuple2(space, w_a, w_b):
         except NotSpecialised:
             pass
     return W_TupleObject([w_a, w_b])
+
+class TupleDocstrings:
+
+    def __new__():
+        """T.__new__(S, ...) -> a new object with type S, a subtype of T"""
+
+    def __repr__():
+        """x.__repr__() <==> repr(x)"""
+
+    def __hash__():
+        """x.__hash__() <==> hash(x)"""
+
+    def __eq__():
+        """x.__eq__(y) <==> x==y'"""
+
+    def __ne__():
+        """x.__ne__(y) <==> x!=y"""
+
+    def __lt__():
+        """x.__lt__(y) <==> x<y"""
+
+    def __le__():
+        """x.__le__(y) <==> x<=y"""
+
+    def __gt__():
+        """x.__gt__(y) <==> x>y"""
+
+    def __ge__():
+        """x.__ge__(y) <==> x>=y"""
+
+    def __len__():
+        """x.__len__() <==> len(x)"""
+
+    def __iter__():
+        """x.__iter__() <==> iter(x)"""
+
+    def __contains__():
+        """x.__contains__(y) <==> y in x"""
+
+    def __add__():
+        """x.__add__(y) <==> x+y"""
+
+    def __mul__():
+        """x.__mul__(n) <==> x*n"""
+
+    def __rmul__():
+        """x.__rmul__(n) <==> n*x"""
+
+    def __getitem__():
+        """x.__getitem__(y) <==> x[y]"""
+
+    def __getslice__():
+        """x.__getslice__(i, j) <==> x[i:j]
+
+        Use of negative indices is not supported."""
+
+    def __getnewargs__():
+        """""" # empty
+
+    def count():
+        """T.count(value) -> integer -- return number of occurrences of value"""
+
+    def index():
+        """"T.index(value, [start, [stop]]) -> integer -- return first index of value.
+        Raises ValueError if the value is not present."""

--- a/pypy/objspace/std/tupleobject.py
+++ b/pypy/objspace/std/tupleobject.py
@@ -7,6 +7,7 @@ from pypy.interpreter.error import OperationError, oefmt
 from pypy.interpreter.gateway import (
     WrappedDefault, interp2app, interpindirect2app, unwrap_spec)
 from pypy.interpreter.typedef import TypeDef
+from pypy.objspace.std.objectobject import ObjectObjectDocstrings
 from pypy.objspace.std.sliceobject import (W_SliceObject, unwrap_start_stop,
     normalize_simple_slice)
 from pypy.objspace.std.util import negate, IDTAG_SPECIAL, IDTAG_SHIFT
@@ -251,11 +252,11 @@ tuple(sequence) -> tuple initialized from sequence's items
 
 If the argument is a tuple, the return value is the same object.""",
     __new__ = interp2app(W_AbstractTupleObject.descr_new,
-                         doc=TupleDocstrings.__new__.__doc__),
+                         doc=ObjectObjectDocstrings.__new__.__doc__),
     __repr__ = interp2app(W_AbstractTupleObject.descr_repr,
-                          doc=TupleDocstrings.__repr__.__doc__),
+                          doc=ObjectObjectDocstrings.__repr__.__doc__),
     __hash__ = interpindirect2app(W_AbstractTupleObject.descr_hash,
-                                  doc=TupleDocstrings.__hash__.__doc__),
+                                  doc=ObjectObjectDocstrings.__hash__.__doc__),
 
     __eq__ = interpindirect2app(W_AbstractTupleObject.descr_eq,
                                 doc=TupleDocstrings.__eq__.__doc__),
@@ -406,15 +407,6 @@ def wraptuple2(space, w_a, w_b):
     return W_TupleObject([w_a, w_b])
 
 class TupleDocstrings:
-
-    def __new__():
-        """T.__new__(S, ...) -> a new object with type S, a subtype of T"""
-
-    def __repr__():
-        """x.__repr__() <==> repr(x)"""
-
-    def __hash__():
-        """x.__hash__() <==> hash(x)"""
 
     def __eq__():
         """x.__eq__(y) <==> x==y'"""


### PR DESCRIPTION
This PR is related to #3678.

First I tried add doctrings to tuple. Those doctriings I added are copied from Python 2.7.  

Should I add those from Python 3 instead of Python 2?