### PR TITLE
change PyBUF_MAX_NDIM back to 36 for ABI consistancy (issue #4816)

### DIFF
--- a/pypy/module/cpyext/parse/cpyext_object.h
+++ b/pypy/module/cpyext/parse/cpyext_object.h
@@ -73,8 +73,8 @@ typedef Py_ssize_t (*segcountproc)(PyObject *, Py_ssize_t *);
 typedef Py_ssize_t (*charbufferproc)(PyObject *, Py_ssize_t, char **);
 
 /* Py3k buffer interface, adapted for PyPy */
-/* XXX remove this constant, us a PyObject_VAR_HEAD instead */
-#define PyBUF_MAX_NDIM 64
+/* Changing this constant changes the ABI */
+#define PyBUF_MAX_NDIM 36
 typedef struct bufferinfo {
     void *buf;
     PyObject *obj;        /* owned reference */


### PR DESCRIPTION
@mgorny, this is enough to fix #4186, right?