### PR TITLE
Init sys.executable from GetModuleFileName on win32

### DIFF
--- a/extra_tests/test_startup.py
+++ b/extra_tests/test_startup.py
@@ -7,3 +7,23 @@ def test_platform_not_imported():
     modules = [x.strip(' "\'') for x in out.strip().strip('[]').split(',')]
     assert 'platform' not in modules
     assert 'threading' not in modules
+
+
+def test_executable_win32():
+    # issue #4003
+    import os
+    import subprocess
+    import sys
+
+    out = subprocess.check_output([r'*', '-c',
+         'import sys; print (repr(sys.executable))'], universal_newlines=True, executable=sys.executable)
+    if sys.platform == 'win32':
+        assert out.strip() == repr(sys.executable)
+
+        fake_executable = r'C:\Windows\System32\cmd.exe'
+        assert os.path.isfile(fake_executable)  # should exist always
+        out = subprocess.check_output([fake_executable, '-c',
+            'import sys; print (repr(sys.executable))'], universal_newlines=True, executable=sys.executable)
+        assert out.strip() == repr(sys.executable)
+    else:
+        assert out.strip() == repr('')

--- a/pypy/module/sys/initpath.py
+++ b/pypy/module/sys/initpath.py
@@ -149,6 +149,14 @@ def compute_stdlib_path_maybe(state, prefix):
 
 @unwrap_spec(executable='fsencode')
 def pypy_find_executable(space, executable):
+    if _WIN32:
+        module_filename = pypy_init_executable()
+        if module_filename:
+            module_path = rffi.charp2str(module_filename)
+            pypy_init_free(module_filename)
+            module_path = rpath.rabspath(module_path)
+            if _exists_and_is_executable(module_path):
+                return space.newtext(module_path)
     return space.newtext(find_executable(executable))
 
 
@@ -215,6 +223,23 @@ char *_pypy_init_home(void)
     }
     return p;
 }
+
+char *_pypy_init_executable(void)
+{
+    DWORD res;
+    char *p;
+
+    p = malloc(_MAX_PATH);
+    if (p == NULL)
+        return NULL;
+    res = GetModuleFileName(NULL, p, _MAX_PATH);
+    if (res >= _MAX_PATH || res <= 0) {
+        free(p);
+        fprintf(stderr, "PyPy initialization: GetModuleFileName() failed\n");
+        return NULL;
+    }
+    return p;
+}
 """
 
 else:
@@ -257,6 +282,8 @@ else:
     post_include_bits=['RPY_EXPORTED char *_pypy_init_home(void);',
                        'RPY_EXPORTED void _pypy_init_free(char*);',
                       ]
+    if _WIN32:
+        post_include_bits.append('RPY_EXPORTED char *_pypy_init_executable(void);')
 
 _eci = ExternalCompilationInfo(separate_module_sources=[_source_code],
                                post_include_bits=post_include_bits)
@@ -266,3 +293,6 @@ pypy_init_home = rffi.llexternal("_pypy_init_home", [], rffi.CCHARP,
                                  _nowrapper=True, compilation_info=_eci)
 pypy_init_free = rffi.llexternal("_pypy_init_free", [rffi.CCHARP], lltype.Void,
                                  _nowrapper=True, compilation_info=_eci)
+if _WIN32:
+    pypy_init_executable = rffi.llexternal("_pypy_init_executable", [], rffi.CCHARP,
+                                           _nowrapper=True, compilation_info=_eci)

--- a/pypy/module/sys/test/apptest_initpath.py
+++ b/pypy/module/sys/test/apptest_initpath.py
@@ -1,0 +1,14 @@
+# spaceconfig = {"usemodules":["sys"]}
+
+def test_pypy_find_executable():
+    # issue #4003
+    import sys
+
+    executable = sys.pypy_find_executable('*')
+    if sys.platform == 'win32':
+        assert executable.endswith('.exe')
+
+        fake_executable = r'C:\Windows\System32\cmd.exe'  # should exist always
+        assert executable == sys.pypy_find_executable(fake_executable)
+    else:
+        assert executable == ''


### PR DESCRIPTION
Fixes #4003.

Based on https://github.com/python/cpython/blob/v2.7.18/PC/getpathp.c#L414-L415, `sys.executable` should always be initialized from `GetModuleFileName` on win32 if possible.