### PR TITLE
(cfbolz, narpfel) generate shorter bytecode for `namedtuple._replace`

### DIFF
--- a/lib-python/3/collections/__init__.py
+++ b/lib-python/3/collections/__init__.py
@@ -457,8 +457,8 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
     else:
         star = ""
     arguments = "\n".join(
-        f"            {field}=_self.{field} if {field} is _not_given else {field},"
-        for field in field_names
+        f"            {field}=_self[{i}] if {field} is _not_given else {field},"
+        for i, field in enumerate(field_names)
     )
     code = f"""\
 _not_given = object()


### PR DESCRIPTION
Using attribute access for accessing the `namedtuple`’s fields in the generated code leads to method calls to `__getitem__`, which make traces longer and require more work from the JIT.

Most of the time, the overhead of the attribute access is optimised away by the JIT, but when the `namedtuple` is large and there are many `_replace` calls, it can prevent inlining and thus further optimisations.

This comment https://github.com/pypy/pypy/issues/3883#issuecomment-1872112434 shows the difference in traced bytecode, along with an example that shows a noticeable performance difference.

By the way, the issue numbers seem to have shifted during the move to GitHub. #3883 was issue 3884 on heptapod.

Resolves #3883.