### PR TITLE
RPython: add support for from __future__ import print_function

### DIFF
--- a/rpython/flowspace/flowcontext.py
+++ b/rpython/flowspace/flowcontext.py
@@ -1,6 +1,6 @@
 """Implements the core parts of flow graph creation.
 """
-
+from __future__ import print_function
 import sys
 import collections
 import types
@@ -13,7 +13,7 @@ from rpython.flowspace.model import (Constant, Variable, Block, Link,
     c_last_exception, const, FSException)
 from rpython.flowspace.framestate import FrameState
 from rpython.flowspace.specialcase import (rpython_print_item,
-    rpython_print_newline)
+    rpython_print_newline, rpython_print_end)
 from rpython.flowspace.operation import op
 from rpython.flowspace.bytecode import BytecodeCorruption
 
@@ -956,14 +956,44 @@ class FlowContext(object):
             key = w_key.value
             keywords[key] = w_value
         arguments = self.popvalues(n_arguments)
-        args = CallSpec(arguments, keywords, w_star)
         w_function = self.popvalue()
+        try:
+            # py3-style print function
+            if w_function.value == print:
+                return self.handle_print_function(arguments, keywords, w_star)
+        except (AttributeError, TypeError):
+            pass
+
+        args = CallSpec(arguments, keywords, w_star)
         if args.keywords or isinstance(args.w_stararg, Variable):
             shape, args_w = args.flatten()
             hlop = op.call_args(w_function, Constant(shape), *args_w)
         else:
             hlop = op.simple_call(w_function, *args.as_list())
         self.pushvalue(hlop.eval(self))
+
+    def handle_print_function(self, arguments, keywords, w_star):
+        if w_star:
+            raise FlowingError(
+                "print function with *args is not RPython"
+            )
+
+        bad_kwargs = [k for k in keywords if k != "end"]
+        if bad_kwargs:
+            raise FlowingError(
+                "print function with {}= is not RPython"
+                .format(bad_kwargs[0])
+            )
+
+        for w_arg in arguments:
+            w_s = op.str(w_arg).eval(self)
+            self.appcall(rpython_print_item, w_s)
+
+        if "end" in keywords:
+            self.appcall(rpython_print_end, keywords["end"])
+        else:
+            self.appcall(rpython_print_newline)
+        self.pushvalue(Constant(None))
 
     def CALL_FUNCTION(self, oparg):
         self.call_function(oparg)

--- a/rpython/flowspace/specialcase.py
+++ b/rpython/flowspace/specialcase.py
@@ -79,6 +79,24 @@ def rpython_print_item(s):
     buf.append(' ')
 rpython_print_item._annenforceargs_ = (str,)
 
+def rpython_print_end(s):
+    buf = stdoutbuffer.linebuf
+    if not s:
+        return
+
+    if s[0] == '\n':
+        rpython_print_newline()
+    elif buf:
+        buf[-1] = s[0]
+    else:
+        buf.append(s[0])
+
+    for c in s[1:]:
+        if c == '\n':
+            rpython_print_newline()
+        else:
+            buf.append(c)
+
 def rpython_print_newline():
     buf = stdoutbuffer.linebuf
     if buf:

--- a/rpython/flowspace/test/test_objspace.py
+++ b/rpython/flowspace/test/test_objspace.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+from __future__ import print_function, with_statement
 import types
 import py
 from contextlib import contextmanager
@@ -114,16 +114,25 @@ class TestFlowObjSpace(Base):
 
     #__________________________________________________________
     def print_(i):
-        print i
+        print(i, end=" ")
+        print(i)
 
     def test_print(self):
         x = self.codetest(self.print_)
 
     def test_bad_print(self):
         def f(x):
-            print >> x, "Hello"
+            print("Hello", file=x)
         with py.test.raises(FlowingError):
             self.codetest(f)
+
+    def test_bad_print2(self):
+        def f(x):
+            args = ["Hello", x]
+            print(*args)
+        with py.test.raises(FlowingError):
+            self.codetest(f)
+
     #__________________________________________________________
     def while_(i):
         while i > 0:
@@ -444,14 +453,6 @@ class TestFlowObjSpace(Base):
         assert ops[0].args == [const(g), const(error)]
 
     #__________________________________________________________
-    def raise2(msg):
-        raise IndexError, msg
-
-    def test_raise2(self):
-        x = self.codetest(self.raise2)
-        # XXX can't check the shape of the graph, too complicated...
-
-    #__________________________________________________________
     def raise3(msg):
         raise IndexError(msg)
 
@@ -465,13 +466,6 @@ class TestFlowObjSpace(Base):
 
     def test_raise4(self):
         x = self.codetest(self.raise4)
-
-    #__________________________________________________________
-    def raisez(z, tb):
-        raise z.__class__,z, tb
-
-    def test_raisez(self):
-        x = self.codetest(self.raisez)
 
     #__________________________________________________________
     def raise_and_catch_1(exception_instance):

--- a/rpython/flowspace/test/test_objspace_py2.py
+++ b/rpython/flowspace/test/test_objspace_py2.py
@@ -1,0 +1,37 @@
+"""In which we test that various pieces of py2-only syntax are still supported."""
+from __future__ import with_statement
+import py
+
+from rpython.flowspace.flowcontext import FlowingError
+from .test_objspace import Base
+
+
+class TestFlowObjSpacePy2(Base):
+
+    #__________________________________________________________
+    def raise2(msg):
+        raise IndexError, msg
+
+    def test_raise2(self):
+        x = self.codetest(self.raise2)
+        # XXX can't check the shape of the graph, too complicated...
+
+   #__________________________________________________________
+    def raisez(z, tb):
+        raise z.__class__,z, tb
+
+    def test_raisez(self):
+        x = self.codetest(self.raisez)
+
+    #__________________________________________________________
+    def print_(i):
+        print i
+
+    def test_print(self):
+        x = self.codetest(self.print_)
+
+    def test_bad_print(self):
+        def f(x):
+            print >> x, "Hello"
+        with py.test.raises(FlowingError):
+            self.codetest(f)

--- a/rpython/translator/goal/targetprintfunction.py
+++ b/rpython/translator/goal/targetprintfunction.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+
+# __________  Entry point  __________
+
+def entry_point(argv):
+    if len(argv) > 1:
+        name = argv[1]
+    else:
+        name = "print-function"
+
+    print("Hello,", name + "!")
+
+    return 0
+
+# _____ Define and setup target ___
+
+def target(*args):
+    return entry_point


### PR DESCRIPTION
This is mostly selfish because my code editor no longer supports the python2 print syntax. It makes both of the following valid rpython snippets (so long as they live in separate files):

```python
from __future__ import print_function

print("oh no!", end="")
```

```python
print "foo",
```

Have to admit I also have my eye on making "six-compatible" python valid rpython - for future editor, linter support etc.