### PR TITLE
remove the other _testmultiphase_build import from test.support

### DIFF
--- a/lib-python/3/test/support/__init__.py
+++ b/lib-python/3/test/support/__init__.py
@@ -23,9 +23,6 @@ try:
 except ImportError:
     unicode_legacy_string = None
 
-# This will create the _testmultiphaseimport c-extension module if it does not exist
-import _testmultiphase_build
-
 __all__ = [
     # globals
     "PIPE_MAX_SIZE", "verbose", "max_memuse", "use_resources", "failfast",


### PR DESCRIPTION
It seems that the import was supposed to be removed as part of:

commit aeb68b0468010b31c3d8bb2e529b20f8c0e2a10a
Author:     Matti Picus <matti.picus@gmail.com>
AuthorDate: 2023-08-16 22:17:12 +0200
Commit:     Matti Picus <matti.picus@gmail.com>
CommitDate: 2023-08-16 22:17:12 +0200

    create test c-extension modules as part of the build, not as part of testing

However, it seems that a second copy persisted after the merge to py3.10 branch.  Remove it as well.