### PR TITLE
implement Py_Is in terms of space.is_w (issue #4044)

### DIFF
--- a/pypy/module/cpyext/include/object.h
+++ b/pypy/module/cpyext/include/object.h
@@ -608,9 +608,7 @@ Don't forget to apply Py_INCREF() when returning this value!!!
 PyAPI_DATA(PyObject) _Py_NoneStruct; /* Don't use this directly */
 #define Py_None (&_Py_NoneStruct)
 
-// Test if an object is the None singleton, the same as "x is None" in Python.
-PyAPI_FUNC(int) Py_IsNone(PyObject *x);
-#define Py_IsNone(x) Py_Is((x), Py_None)
+#define Py_IsNone(x) ((x) == Py_None)
 
 /* Macro for returning Py_None from a function */
 #define Py_RETURN_NONE return Py_NewRef(Py_None)

--- a/pypy/module/cpyext/object.py
+++ b/pypy/module/cpyext/object.py
@@ -500,4 +500,7 @@ def PyObject_GC_IsFinalized(space, w_obj):
     """
     return 0
 
-
+@cpython_api([PyObject, PyObject], rffi.INT_real, error=-1)
+def Py_Is(space, w_obj1, w_obj2):
+    res = space.is_w(w_obj1, w_obj2)
+    return int(res)

--- a/pypy/module/cpyext/test/test_object.py
+++ b/pypy/module/cpyext/test/test_object.py
@@ -545,6 +545,23 @@ class AppTestObject(AppTestCpythonExtensionBase):
         assert a.y == 43
         assert a.__dict__ is nd
 
+    def test_Py_Is(self):
+        module = self.import_extension('foo', [
+            ('test_is', 'METH_VARARGS',
+             """
+                 PyObject *obj1 = PyTuple_GET_ITEM(args, 0);
+                 PyObject *obj2 = PyTuple_GET_ITEM(args, 1);
+                 int res = Py_Is(obj1, obj2);
+                 return PyLong_FromLong(res);
+             """)])
+        nan1 = float('nan')
+        nan2 = float('nan')
+        assert module.test_is(nan1, nan2)
+        a = 1
+        b = 1
+        assert module.test_is(a, b)
+        assert not module.test_is(a, nan1)
+
 
 class AppTestPyBuffer_FillInfo(AppTestCpythonExtensionBase):
     """


### PR DESCRIPTION
Fixes #4044 by calling `space.is_w` for `Py_Is`