### PR TITLE
port cffi PR 46

### DIFF
--- a/extra_tests/cffi_tests/cffi0/test_parsing.py
+++ b/extra_tests/cffi_tests/cffi0/test_parsing.py
@@ -614,3 +614,8 @@ def test_unsigned_int_suffix_for_constant():
     for base, expected_result in (('bin', 2), ('oct', 8), ('dec', 10), ('hex', 16)):
         for index in range(7):
             assert getattr(C, '{base}_{index}'.format(base=base, index=index)) == expected_result
+
+def test_missing_newline_bug():
+    ffi = FFI(backend=FakeBackend())
+    ffi.cdef("#pragma foobar")
+    ffi.cdef("#pragma foobar")    # used to crash the second time

--- a/lib_pypy/cffi/cparser.py
+++ b/lib_pypy/cffi/cparser.py
@@ -329,6 +329,7 @@ class Parser(object):
         # called <cdef source string> from line 1
         csourcelines.append('# 1 "%s"' % (CDEF_SOURCE_STRING,))
         csourcelines.append(csource)
+        csourcelines.append('')   # see test_missing_newline_bug
         fullcsource = '\n'.join(csourcelines)
         if lock is not None:
             lock.acquire()     # pycparser is not thread-safe...
@@ -430,7 +431,14 @@ class Parser(object):
                             typedef_example="*(%s *)0" % (decl.name,))
                     self._declare('typedef ' + decl.name, realtype, quals=quals)
                 elif decl.__class__.__name__ == 'Pragma':
-                    pass    # skip pragma, only in pycparser 2.15
+                    import warnings
+                    warnings.warn(
+                        "#pragma in cdef() are entirely ignored. "
+                        "They should be removed for now, otherwise your "
+                        "code might behave differently in a future version "
+                        "of CFFI if #pragma support gets added. Note that "
+                        "'#pragma pack' needs to be replaced with the "
+                        "'packed' keyword argument to cdef().")
                 else:
                     raise CDefError("unexpected <%s>: this construct is valid "
                                     "C but not valid in cdef()" %

--- a/rpython/tool/cparser/cparser.py
+++ b/rpython/tool/cparser/cparser.py
@@ -419,9 +419,16 @@ class Parser(object):
                     self._parse_decl(decl)
                 elif isinstance(decl, pycparser.c_ast.Typedef):
                     self._parse_typedef(decl)
-                elif decl.__class__.__name__ == 'Pragma' and not self._options["packed"]:
+                elif (decl.__class__.__name__ == 'Pragma' and
+                      'string' in decl.attr_names and
+                      'pack' in decl.string and
+                      not self._options["packed"]
+                    ):
+                    # TODO: check that the pragma matches the kwarg
                     raise CDefError("'#pragma pack' needs to be paired with "
                         "the 'packed' keyword argument.")
+                elif decl.__class__.__name__ == 'Pragma':
+                    pass
                 else:
                     raise CDefError("unexpected <%s>: this construct is valid "
                                     "C but not valid in cdef()" %

--- a/rpython/tool/cparser/cparser.py
+++ b/rpython/tool/cparser/cparser.py
@@ -340,6 +340,7 @@ class Parser(object):
         # called <cdef source string> from line 1
         csourcelines.append('# 1 "%s"' % (CDEF_SOURCE_STRING,))
         csourcelines.append(csource)
+        csourcelines.append('')
         fullcsource = '\n'.join(csourcelines)
         try:
             ast = _get_parser().parse(fullcsource)
@@ -418,8 +419,9 @@ class Parser(object):
                     self._parse_decl(decl)
                 elif isinstance(decl, pycparser.c_ast.Typedef):
                     self._parse_typedef(decl)
-                elif decl.__class__.__name__ == 'Pragma':
-                    pass    # skip pragma, only in pycparser 2.15
+                elif decl.__class__.__name__ == 'Pragma' and not self._options["packed"]:
+                    raise CDefError("'#pragma pack' needs to be paired with "
+                        "the 'packed' keyword argument.")
                 else:
                     raise CDefError("unexpected <%s>: this construct is valid "
                                     "C but not valid in cdef()" %


### PR DESCRIPTION
Port python-cffi/cffi#46:

- add a warning when passing `#pragmas` to the `cdef()`
- test and fix for a case where `pycparser` is left in a bogus state

Motivated by https://github.com/python-cffi/cffi/issues/45 .