### PR TITLE
RPython: add support for from __future__ import print_function

### DIFF
--- a/rpython/annotator/test/test_annrpython_py2.py
+++ b/rpython/annotator/test/test_annrpython_py2.py
@@ -1,0 +1,78 @@
+"""In which we test that various pieces of py2-only syntax are supported."""
+from __future__ import with_statement
+
+from rpython.conftest import option
+
+from rpython.annotator import model as annmodel
+from rpython.annotator.annrpython import RPythonAnnotator as _RPythonAnnotator
+from rpython.translator.test import snippet
+
+from .test_annrpython import (
+    TestAnnotateTestCase as _TestAnnotateTestCase, graphof
+)
+
+
+class TestAnnotateTestCase:
+    def teardown_method(self, meth):
+        assert annmodel.s_Bool == annmodel.SomeBool()
+
+    class RPythonAnnotator(_RPythonAnnotator):
+        def build_types(self, *args):
+            s = _RPythonAnnotator.build_types(self, *args)
+            self.validate()
+            if option.view:
+                self.translator.view()
+            return s
+
+    def test_harmonic(self):
+        a = self.RPythonAnnotator()
+        s = a.build_types(snippet.harmonic, [int])
+        assert s.knowntype == float
+        # check that the list produced by range() is not mutated or resized
+        graph = graphof(a, snippet.harmonic)
+        all_vars = set().union(*[block.getvariables() for block in graph.iterblocks()])
+        print all_vars
+        for var in all_vars:
+            s_value = var.annotation
+            if isinstance(s_value, annmodel.SomeList):
+                assert not s_value.listdef.listitem.resized
+                assert not s_value.listdef.listitem.mutated
+                assert s_value.listdef.listitem.range_step
+
+    def test_prebuilt_long_that_is_not_too_long(self):
+        small_constant = 12L
+        def f():
+            return small_constant
+        a = self.RPythonAnnotator()
+        s = a.build_types(f, [])
+        assert s.const == 12
+        assert s.nonneg
+        assert not s.unsigned
+        #
+        small_constant = -23L
+        def f():
+            return small_constant
+        a = self.RPythonAnnotator()
+        s = a.build_types(f, [])
+        assert s.const == -23
+        assert not s.nonneg
+        assert not s.unsigned
+
+    def test_isinstance_double_const(self):
+        class X(object):
+            def _freeze_(self):
+                return True
+
+        x = X()
+
+        def f(i):
+            if i:
+                x1 = x
+            else:
+                x1 = None
+            print "hello"  # this is to force the merge of blocks
+            return isinstance(x1, X)
+
+        a = self.RPythonAnnotator()
+        s = a.build_types(f, [annmodel.SomeInteger()])
+        assert isinstance(s, annmodel.SomeBool)

--- a/rpython/flowspace/flowcontext.py
+++ b/rpython/flowspace/flowcontext.py
@@ -1,6 +1,6 @@
 """Implements the core parts of flow graph creation.
 """
-
+from __future__ import print_function
 import sys
 import collections
 import types
@@ -13,7 +13,7 @@ from rpython.flowspace.model import (Constant, Variable, Block, Link,
     c_last_exception, const, FSException)
 from rpython.flowspace.framestate import FrameState
 from rpython.flowspace.specialcase import (rpython_print_item,
-    rpython_print_newline)
+    rpython_print_newline, rpython_print_end)
 from rpython.flowspace.operation import op
 from rpython.flowspace.bytecode import BytecodeCorruption
 
@@ -956,14 +956,44 @@ class FlowContext(object):
             key = w_key.value
             keywords[key] = w_value
         arguments = self.popvalues(n_arguments)
-        args = CallSpec(arguments, keywords, w_star)
         w_function = self.popvalue()
+        try:
+            # py3-style print function
+            if w_function.value == print:
+                return self.handle_print_function(arguments, keywords, w_star)
+        except (AttributeError, TypeError):
+            pass
+
+        args = CallSpec(arguments, keywords, w_star)
         if args.keywords or isinstance(args.w_stararg, Variable):
             shape, args_w = args.flatten()
             hlop = op.call_args(w_function, Constant(shape), *args_w)
         else:
             hlop = op.simple_call(w_function, *args.as_list())
         self.pushvalue(hlop.eval(self))
+
+    def handle_print_function(self, arguments, keywords, w_star):
+        if w_star:
+            raise FlowingError(
+                "print function with *args is not RPython"
+            )
+
+        bad_kwargs = [k for k in keywords if k != "end"]
+        if bad_kwargs:
+            raise FlowingError(
+                "print function with {}= is not RPython"
+                .format(bad_kwargs[0])
+            )
+
+        for w_arg in arguments:
+            w_s = op.str(w_arg).eval(self)
+            self.appcall(rpython_print_item, w_s)
+
+        if "end" in keywords:
+            self.appcall(rpython_print_end, keywords["end"])
+        else:
+            self.appcall(rpython_print_newline)
+        self.pushvalue(Constant(None))
 
     def CALL_FUNCTION(self, oparg):
         self.call_function(oparg)

--- a/rpython/flowspace/specialcase.py
+++ b/rpython/flowspace/specialcase.py
@@ -79,6 +79,24 @@ def rpython_print_item(s):
     buf.append(' ')
 rpython_print_item._annenforceargs_ = (str,)
 
+def rpython_print_end(s):
+    buf = stdoutbuffer.linebuf
+    if not s:
+        return
+
+    if s[0] == '\n':
+        rpython_print_newline()
+    elif buf:
+        buf[-1] = s[0]
+    else:
+        buf.append(s[0])
+
+    for c in s[1:]:
+        if c == '\n':
+            rpython_print_newline()
+        else:
+            buf.append(c)
+
 def rpython_print_newline():
     buf = stdoutbuffer.linebuf
     if buf:

--- a/rpython/flowspace/specialcase.py
+++ b/rpython/flowspace/specialcase.py
@@ -70,39 +70,27 @@ if hasattr(os.path, 'splitdrive'):
 # a simplified version of the basic printing routines, for RPython programs
 class StdOutBuffer:
     linebuf = []
+    final = True
 stdoutbuffer = StdOutBuffer()
 
 def rpython_print_item(s):
     buf = stdoutbuffer.linebuf
+    if not stdoutbuffer.final:
+        buf.append(' ')
     for c in s:
         buf.append(c)
-    buf.append(' ')
+    stdoutbuffer.final = False
 rpython_print_item._annenforceargs_ = (str,)
 
 def rpython_print_end(s):
     buf = stdoutbuffer.linebuf
-    if not s:
-        return
-
-    if s[0] == '\n':
-        rpython_print_newline()
-    elif buf:
-        buf[-1] = s[0]
-    else:
-        buf.append(s[0])
-
-    for c in s[1:]:
+    stdoutbuffer.final = True
+    for c in s:
         buf.append(c)
         if c == '\n':
-            rpython_print_newline()
+            w = ''.join(buf)
+            del buf[:]
+            os.write(1, w)
 
 def rpython_print_newline():
-    buf = stdoutbuffer.linebuf
-    if buf:
-        buf[-1] = '\n'
-        s = ''.join(buf)
-        del buf[:]
-    else:
-        s = '\n'
-    import os
-    os.write(1, s)
+    rpython_print_end('\n')

--- a/rpython/flowspace/specialcase.py
+++ b/rpython/flowspace/specialcase.py
@@ -92,10 +92,9 @@ def rpython_print_end(s):
         buf.append(s[0])
 
     for c in s[1:]:
+        buf.append(c)
         if c == '\n':
             rpython_print_newline()
-        else:
-            buf.append(c)
 
 def rpython_print_newline():
     buf = stdoutbuffer.linebuf

--- a/rpython/flowspace/test/test_objspace.py
+++ b/rpython/flowspace/test/test_objspace.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+from __future__ import print_function, with_statement
 import types
 import py
 from contextlib import contextmanager
@@ -114,16 +114,25 @@ class TestFlowObjSpace(Base):
 
     #__________________________________________________________
     def print_(i):
-        print i
+        print(i, end=" ")
+        print(i)
 
     def test_print(self):
         x = self.codetest(self.print_)
 
     def test_bad_print(self):
         def f(x):
-            print >> x, "Hello"
+            print("Hello", file=x)
         with py.test.raises(FlowingError):
             self.codetest(f)
+
+    def test_bad_print2(self):
+        def f(x):
+            args = ["Hello", x]
+            print(*args)
+        with py.test.raises(FlowingError):
+            self.codetest(f)
+
     #__________________________________________________________
     def while_(i):
         while i > 0:
@@ -444,14 +453,6 @@ class TestFlowObjSpace(Base):
         assert ops[0].args == [const(g), const(error)]
 
     #__________________________________________________________
-    def raise2(msg):
-        raise IndexError, msg
-
-    def test_raise2(self):
-        x = self.codetest(self.raise2)
-        # XXX can't check the shape of the graph, too complicated...
-
-    #__________________________________________________________
     def raise3(msg):
         raise IndexError(msg)
 
@@ -465,13 +466,6 @@ class TestFlowObjSpace(Base):
 
     def test_raise4(self):
         x = self.codetest(self.raise4)
-
-    #__________________________________________________________
-    def raisez(z, tb):
-        raise z.__class__,z, tb
-
-    def test_raisez(self):
-        x = self.codetest(self.raisez)
 
     #__________________________________________________________
     def raise_and_catch_1(exception_instance):

--- a/rpython/flowspace/test/test_objspace_py2.py
+++ b/rpython/flowspace/test/test_objspace_py2.py
@@ -1,0 +1,37 @@
+"""In which we test that various pieces of py2-only syntax are supported."""
+from __future__ import with_statement
+import py
+
+from rpython.flowspace.flowcontext import FlowingError
+from .test_objspace import Base
+
+
+class TestFlowObjSpacePy2(Base):
+
+    #__________________________________________________________
+    def raise2(msg):
+        raise IndexError, msg
+
+    def test_raise2(self):
+        x = self.codetest(self.raise2)
+        # XXX can't check the shape of the graph, too complicated...
+
+   #__________________________________________________________
+    def raisez(z, tb):
+        raise z.__class__,z, tb
+
+    def test_raisez(self):
+        x = self.codetest(self.raisez)
+
+    #__________________________________________________________
+    def print_(i):
+        print i
+
+    def test_print(self):
+        x = self.codetest(self.print_)
+
+    def test_bad_print(self):
+        def f(x):
+            print >> x, "Hello"
+        with py.test.raises(FlowingError):
+            self.codetest(f)

--- a/rpython/flowspace/test/test_print_function.py
+++ b/rpython/flowspace/test/test_print_function.py
@@ -1,0 +1,91 @@
+"""We test the print function logic in flowspace/specialcase.py"""
+import os
+
+import pytest
+
+from rpython.flowspace.specialcase import (
+    stdoutbuffer,
+    rpython_print_end,
+    rpython_print_item,
+    rpython_print_newline,
+)
+
+
+class TestPrintFunctionLogic(object):
+
+    def _write_spy(self, monkeypatch):
+        spied = []
+        monkeypatch.setattr(stdoutbuffer, "linebuf", [])
+        monkeypatch.setattr(os, "write", lambda *args: spied.append(args))
+        return spied
+
+    def test_rpython_print_end(self, monkeypatch):
+        spied = self._write_spy(monkeypatch)
+
+        rpython_print_item("spam")
+        rpython_print_item("eggs\n")
+        rpython_print_item("spam")
+        rpython_print_end("@")
+
+        assert stdoutbuffer.linebuf == list("spam eggs\n spam@")
+        assert len(spied) == 0  # writes are buffered
+
+    def test_rpython_print_newline(self, monkeypatch):
+        spied = self._write_spy(monkeypatch)
+
+        # empty print() call
+        rpython_print_newline()
+        assert len(spied) == 1
+        assert spied[-1] == (1, "\n")
+        assert stdoutbuffer.linebuf == []
+
+        # print call with a few items in it
+        rpython_print_item("spam")
+        rpython_print_item("eggs\n")
+        rpython_print_item("spam")
+        rpython_print_newline()
+
+        assert len(spied) == 2
+        assert spied[-1] == (1, "spam eggs\n spam\n")
+        assert stdoutbuffer.linebuf == []
+
+    @pytest.mark.parametrize(
+        ("first", "end", "second", "expected"),
+        (
+            (("one", "two"), "", ("three", "four"), "one twothree four\n"),
+            (("one", "two"), " ", ("three", "four"), "one two three four\n"),
+            (("one", "two"), "", (), "one two\n"),
+            (("one", "two"), " ", (), "one two \n"),
+            ((), "", ("three", "four"), "three four\n"),
+            ((), " ", ("three", "four"), " three four\n"),
+        ),
+    )
+    def test_rpython_print_newline_end_mixed(self, monkeypatch, first, end, second, expected):
+        spied = self._write_spy(monkeypatch)
+
+        # Tests the equivalent of
+        # print(*first, end=end)
+        # print(*second)
+
+        for item in first:
+            rpython_print_item(item)
+        rpython_print_end(end)
+        for item in second:
+            rpython_print_item(item)
+        rpython_print_newline()
+        assert len(spied) == 1
+        assert spied[-1] == (1, expected)
+
+    def test_rpython_print_newline_end_complex(self, monkeypatch):
+        spied = self._write_spy(monkeypatch)
+
+        rpython_print_item("one")
+        rpython_print_item("two")
+        rpython_print_end(" point\nfive")
+        rpython_print_item("three")
+        rpython_print_item("four")
+        rpython_print_newline()
+
+        assert len(spied) == 2
+        assert spied[0] == (1, "one two point\n")
+        assert spied[1] == (1, "fivethree four\n")

--- a/rpython/translator/c/test/test_standalone.py
+++ b/rpython/translator/c/test/test_standalone.py
@@ -78,7 +78,7 @@ class StandaloneTests(object):
         return t, cbuilder
 
 
-class TestStandalone(StandaloneTests):
+class StandaloneTestsVerified(StandaloneTests):
 
     def compile(self, *args, **kwds):
         t, builder = StandaloneTests.compile(self, *args, **kwds)
@@ -113,6 +113,9 @@ class TestStandalone(StandaloneTests):
                 assert name in seen, "did not see '%r' exported" % name
         #
         return t, builder
+
+
+class TestStandalone(StandaloneTestsVerified):
 
     def test_hello_world(self):
         def entry_point(argv):

--- a/rpython/translator/c/test/test_standalone_print_function.py
+++ b/rpython/translator/c/test/test_standalone_print_function.py
@@ -17,8 +17,13 @@ class TestStandalonePrintFunction(test_standalone.StandaloneTestsVerified):
             argv = argv[1:]
             print("argument count:", len(argv))
             print("arguments:", argv)
+            # with a space
+            print("argument lengths:", end=" ")
+            print([len(s) for s in argv])
+            # with no space
             print("argument lengths:", end="")
             print([len(s) for s in argv])
+            # strange ending
             print("end", "is", end="\nstrange!\r\n")
             return 0
 
@@ -29,6 +34,7 @@ class TestStandalonePrintFunction(test_standalone.StandaloneTestsVerified):
             "argument count: 2\n"
             "arguments: [hi, there]\n"
             "argument lengths: [2, 5]\n"
+            "argument lengths:[2, 5]\n"
             "end is\nstrange!\n"
         )
         # NB. RPython has only str, not repr, so str() on a list of strings

--- a/rpython/translator/c/test/test_standalone_print_function.py
+++ b/rpython/translator/c/test/test_standalone_print_function.py
@@ -1,0 +1,35 @@
+"""In which we test py3 print function syntax
+(incompatible with py2 syntax in the same file)"""
+
+from __future__ import print_function
+
+from rpython.translator.c.test import test_standalone
+
+setup_module = test_standalone.setup_module
+teardown_module = test_standalone.teardown_module
+
+
+class TestStandalonePrintFunction(test_standalone.StandaloneTestsVerified):
+
+    def test_print_function(self):
+        def entry_point(argv):
+            print("hello simpler world")
+            argv = argv[1:]
+            print("argument count:", len(argv))
+            print("arguments:", argv)
+            print("argument lengths:", end="")
+            print([len(s) for s in argv])
+            print("end", "is", end="\nstrange!\r\n")
+            return 0
+
+        t, cbuilder = self.compile(entry_point)
+        data = cbuilder.cmdexec("hi there")
+        assert data.startswith(
+            "hello simpler world\n"
+            "argument count: 2\n"
+            "arguments: [hi, there]\n"
+            "argument lengths: [2, 5]\n"
+            "end is\nstrange!\n"
+        )
+        # NB. RPython has only str, not repr, so str() on a list of strings
+        # gives the strings unquoted in the list

--- a/rpython/translator/goal/targetprintfunction.py
+++ b/rpython/translator/goal/targetprintfunction.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+
+# __________  Entry point  __________
+
+def entry_point(argv):
+    if len(argv) > 1:
+        name = argv[1]
+    else:
+        name = "print-function"
+
+    print("Hello,", name + "!")
+
+    return 0
+
+# _____ Define and setup target ___
+
+def target(*args):
+    return entry_point


### PR DESCRIPTION
Recreates https://github.com/pypy/pypy/pull/4835 (after I deleted + recreated my fork)

This is mostly selfish because my code editor no longer supports the python2 print syntax. It makes both of the following valid rpython snippets (so long as they live in separate files):

```python
from __future__ import print_function

print("oh no!", end="")
```

```python
print "foo",
```

Have to admit I also have my eye on making "six-compatible" python valid rpython - for future editor, linter support etc.