### PR TITLE
move uint_mul_high to rarithmetic and add support for it in the metainterp

### DIFF
--- a/rpython/jit/codewriter/jtransform.py
+++ b/rpython/jit/codewriter/jtransform.py
@@ -2031,6 +2031,11 @@ class Transformer(object):
                                  [Constant(0, lltype.Signed), v_x],
                                  op.result)
             return self.rewrite_operation(op0)
+        elif oopspec_name == 'int.uint_mul_high':
+            op0 = SpaceOperation('uint_mul_high',
+                                 args,
+                                 op.result)
+            return self.rewrite_operation(op0)
         else:
             # int.py_div, int.udiv, int.py_mod, int.umod
             opname = oopspec_name.replace('.', '_')

--- a/rpython/jit/codewriter/test/test_jtransform.py
+++ b/rpython/jit/codewriter/test/test_jtransform.py
@@ -1459,3 +1459,14 @@ def test_likely_unlikely():
     assert tr.rewrite_operation(op) is None
     op = SpaceOperation('unlikely', [v1], v2)
     assert tr.rewrite_operation(op) is None
+
+def test_uint_mul_high():
+    v3 = varoftype(lltype.Signed)
+    for v1 in [varoftype(lltype.Signed), const(42)]:
+        for v2 in [varoftype(lltype.Signed), const(42)]:
+            op = SpaceOperation('direct_call', [Constant('uint_mul_high'), v1], v3)
+            op = Transformer(FakeCPU())._handle_int_special(op, 'int.uint_mul_high',
+                                                                [v1, v2])
+            assert op.opname == 'uint_mul_high'
+            assert op.args == [v1, v2]
+            assert op.result == v3

--- a/rpython/jit/metainterp/blackhole.py
+++ b/rpython/jit/metainterp/blackhole.py
@@ -11,7 +11,8 @@ from rpython.rlib import longlong2float
 from rpython.rlib.debug import ll_assert, make_sure_not_resized
 from rpython.rlib.debug import check_annotation
 from rpython.rlib.objectmodel import we_are_translated, specialize
-from rpython.rlib.rarithmetic import intmask, LONG_BIT, r_uint, ovfcheck
+from rpython.rlib.rarithmetic import (intmask, LONG_BIT, r_uint, ovfcheck,
+    uint_mul_high)
 from rpython.rlib.unroll import unrolling_iterable
 from rpython.rtyper.lltypesystem import lltype, llmemory, rffi
 from rpython.rtyper import rclass
@@ -469,7 +470,7 @@ class BlackholeInterpreter(object):
         from rpython.jit.metainterp.optimizeopt import intdiv
         a = r_uint(a)
         b = r_uint(b)
-        c = intdiv.unsigned_mul_high(a, b)
+        c = uint_mul_high(a, b)
         return intmask(c)
 
     @arguments("L", "i", "i", returns="iL")

--- a/rpython/jit/metainterp/optimizeopt/test/test_intdiv.py
+++ b/rpython/jit/metainterp/optimizeopt/test/test_intdiv.py
@@ -5,7 +5,6 @@ from hypothesis import given, strategies
 from rpython.jit.metainterp.optimizeopt.intdiv import magic_numbers, LONG_BIT
 from rpython.jit.metainterp.optimizeopt.intdiv import division_operations
 from rpython.jit.metainterp.optimizeopt.intdiv import modulo_operations
-from rpython.jit.metainterp.optimizeopt.intdiv import unsigned_mul_high
 from rpython.jit.metainterp.history import ConstInt
 from rpython.jit.metainterp.resoperation import InputArgInt
 from rpython.jit.metainterp.executor import execute
@@ -21,13 +20,6 @@ def test_magic_numbers(n, m):
     k = int(k)    # and no longer r_uint, with wrap-around semantics
     a = (n * k) >> (LONG_BIT + i)
     assert a == n // m
-
-
-@given(strategies.integers(min_value=0, max_value=2*sys.maxint+1),
-       strategies.integers(min_value=0, max_value=2*sys.maxint+1))
-def test_unsigned_mul_high(a, b):
-    c = unsigned_mul_high(a, b)
-    assert c == ((a * b) >> LONG_BIT)
 
 
 @given(strategies.integers(min_value=-sys.maxint-1, max_value=sys.maxint),

--- a/rpython/jit/metainterp/pyjitpl.py
+++ b/rpython/jit/metainterp/pyjitpl.py
@@ -279,6 +279,7 @@ class MIFrame(object):
                     'int_and', 'int_or', 'int_xor', 'int_signext',
                     'int_rshift', 'int_lshift', 'uint_rshift',
                     'uint_lt', 'uint_le', 'uint_gt', 'uint_ge',
+                    'uint_mul_high',
                     'float_add', 'float_sub', 'float_mul', 'float_truediv',
                     'float_lt', 'float_le', 'float_eq',
                     'float_ne', 'float_gt', 'float_ge',

--- a/rpython/jit/metainterp/test/test_ajit.py
+++ b/rpython/jit/metainterp/test/test_ajit.py
@@ -3346,6 +3346,14 @@ class BasicTests:
         # used to be 22
         assert len(get_stats().loops[0].operations[4]._descr.rd_numb.code) == 12
 
+    def test_uint_mul_high(self):
+        from rpython.rlib.rarithmetic import uint_mul_high, intmask, r_uint
+        def f(x, y):
+            return intmask(uint_mul_high(r_uint(x), r_uint(y)))
+        res = self.interp_operations(f, [40, 2])
+        assert res == 0
+        self.check_operations_history(uint_mul_high=1)
+
 
 class BaseLLtypeTests(BasicTests):
 

--- a/rpython/rlib/test/test_rarithmetic.py
+++ b/rpython/rlib/test/test_rarithmetic.py
@@ -775,3 +775,18 @@ def test_mulmod(a, b, c):
         assert mulmod(a, b, c) == (a * b) % c
     finally:
         rarithmetic.check_support_int128 = prev
+
+@given(strategies.integers(min_value=0, max_value=2**LONG_BIT - 1),
+       strategies.integers(min_value=0, max_value=2**LONG_BIT - 1))
+def test_uint_mul_high(a, b):
+    ua = r_uint(a)
+    ub = r_uint(b)
+    assert uint_mul_high(ua, ub) == (a * b) >> LONG_BIT
+    #
+    import rpython.rlib.rbigint  # import before patching check_support_int128
+    prev = rarithmetic.check_support_int128
+    try:
+        rarithmetic.check_support_int128 = lambda: False
+        assert uint_mul_high(ua, ub) == (a * b) >> LONG_BIT
+    finally:
+        rarithmetic.check_support_int128 = prev


### PR DESCRIPTION
the optimizer and the backends already had support for it. has no effect on pypy, but I want to use it in pydrofoil.