### PR TITLE
fix release script to define bz2 command

### DIFF
--- a/pypy/tool/release/repackage.sh
+++ b/pypy/tool/release/repackage.sh
@@ -143,6 +143,7 @@ function repackage_source {
     echo "node: $githash" > ../.hg_archival.txt
     echo "branch: $branchname" >> ../.hg_archival.txt
     echo "tag: $tagname" >> ../.hg_archival.txt
+    git config tar.tar.bz2.command "bzip2 -c"
     $(cd ..; git archive --prefix $rel-src/ --add-file=.hg_archival.txt --output=${cwd}/$rel-src.tar.bz2 $tagname)
     $(cd ..; git archive --prefix $rel-src/ --add-file=.hg_archival.txt --output=${cwd}/$rel-src.zip $tagname)
 }


### PR DESCRIPTION
Explicitly configure git-archive to support .tar.bz2 format when running the release script.  There is no harm to redefine it, so just do it unconditionally.