### PR TITLE
make test_transformed_gc tests more stable

### DIFF
--- a/rpython/memory/test/test_transformed_gc.py
+++ b/rpython/memory/test/test_transformed_gc.py
@@ -52,6 +52,12 @@ class GCTest(object):
     taggedpointers = False
     gchooks = None
 
+    def setup(self):
+        # This snippet is an attempt to clean the WeakKeyDict
+        # rpython.memory.gcheader.header2obj between tests
+        import gc
+        gc.collect()
+
     def setup_class(cls):
         cls.marker = lltype.malloc(rffi.CArray(lltype.Signed), 1,
                                    flavor='raw', zero=True)


### PR DESCRIPTION
this is based on a hunch that the flake in these tests is due to deferred gc of spurious entries in the header2obj WeakKeyDictionary (which would be why cpython runs of the tests are more stable) ... to test the theory I need to trigger a lot of CI runs

closes #4866 