### PR TITLE
Revert "make test_transformed_gc tests more stable"

### DIFF
--- a/rpython/memory/test/test_transformed_gc.py
+++ b/rpython/memory/test/test_transformed_gc.py
@@ -52,12 +52,6 @@ class GCTest(object):
     taggedpointers = False
     gchooks = None
 
-    def setup(self):
-        # This snippet is an attempt to clean the WeakKeyDict
-        # rpython.memory.gcheader.header2obj between tests
-        import gc
-        gc.collect()
-
     def setup_class(cls):
         cls.marker = lltype.malloc(rffi.CArray(lltype.Signed), 1,
                                    flavor='raw', zero=True)


### PR DESCRIPTION
Reverts pypy/pypy#4868

This didn't seem to work - so something else must be at play here