### PR TITLE
Correct the code that creates the ppc64 c-extension suffixes

### DIFF
--- a/pypy/module/imp/interp_imp.py
+++ b/pypy/module/imp/interp_imp.py
@@ -11,15 +11,12 @@ from pypy.interpreter.error import OperationError
 def extension_suffixes(space):
     suffixes_w = []
     so_ext = importing.get_so_extension(space)
-    if 1:   #if space.config.objspace.usemodules.cpyext:
+    if "powerpc64le" in so_ext or "ppc_64" in so_ext:
+        # force adding a backward-compatible suffix (issue 3833)
+        suffixes_w.append(space.newtext(".pypy39-pp73-ppc_64-linux-gnu.so"))
+        suffixes_w.append(space.newtext(".pypy39-pp73-powerpc64le-linux-gnu.so"))
+    else:   #if space.config.objspace.usemodules.cpyext:
         suffixes_w.append(space.newtext(so_ext))
-    # force adding a backward-compatible suffix on powerpc (issue 3834)
-    # remove this for new Python versions
-    # note that PyPy does not really support big-endian powerpc
-    if "powerpc64le" in so_ext:
-        suffixes_w.append(space.newtext("powerpc64le-linux-gnu"))
-    elif "ppc_64" in so_ext:
-        suffixes_w.append(space.newtext("ppc_64-linux-gnu"))
     return space.newlist(suffixes_w)
 
 def get_magic(space):


### PR DESCRIPTION
Fixes #4878

The fixes for #3833 did not actually fix the issue: the first commits did not translate, and the subsequent fixes broke `importlib.machinery.EXTENSION_SUFFIXES`. This is a better fix.