### PR TITLE
WIN: Disable WINENV work-around since PyPy does not have a launcher, fix venv creation from a source build

### DIFF
--- a/extra_tests/test_venv.py
+++ b/extra_tests/test_venv.py
@@ -8,6 +8,10 @@ def test_venv_of_venv(tmpdir):
     subprocess.run([sys.executable, '-mvenv', str(tmpdir / 'venv1')])
     # 'bin' or 'Script'
     path = os.path.split(sysconfig.get_path('scripts'))[-1]
+    print(f"{path=}")
+    exe2 = str(tmpdir / 'venv1' / path / exe)
+    print(f"exe '{exe2}'")
+    print(f"exe exists {os.path.exists(exe2)}") 
     subprocess.run([str(tmpdir / 'venv1' / path / exe),
                     '-mvenv', str(tmpdir / 'venv2')])
 
@@ -18,6 +22,8 @@ def test_multiprocessing(tmpdir):
     # 'bin' or 'Script'
     path = os.path.split(sysconfig.get_path('scripts'))[-1]
     exe = str(tmpdir / 'venv' / path / os.path.split(sys.executable)[-1])
+    print(f"exe '{exe}'")
+    print(f"exe exists {os.path.exists(exe)}") 
     result = subprocess.run([exe, '-c',
                              'from multiprocessing import Pool; ' +
                              'print(Pool(1).apply_async(eval, ("__import__(\'sys\').executable",)).get(3))'],

--- a/extra_tests/test_venv.py
+++ b/extra_tests/test_venv.py
@@ -10,4 +10,17 @@ def test_venv_of_venv(tmpdir):
     path = os.path.split(sysconfig.get_path('scripts'))[-1]
     subprocess.run([str(tmpdir / 'venv1' / path / exe),
                     '-mvenv', str(tmpdir / 'venv2')])
-    
+
+
+def test_multiprocessing(tmpdir):
+    # issue 4876
+    subprocess.run([sys.executable, '-mvenv', str(tmpdir / 'venv')])
+    # 'bin' or 'Script'
+    path = os.path.split(sysconfig.get_path('scripts'))[-1]
+    exe = str(tmpdir / 'venv' / path / os.path.split(sys.executable)[-1])
+    result = subprocess.run([exe, '-c',
+                             'from multiprocessing import Pool; ' +
+                             'print(Pool(1).apply_async(eval, ("__import__(\'sys\').executable",)).get(3))'],
+                            capture_output=True)
+    result.check_returncode()
+    assert result.stdout.strip() == exe.encode()

--- a/extra_tests/test_venv.py
+++ b/extra_tests/test_venv.py
@@ -8,10 +8,6 @@ def test_venv_of_venv(tmpdir):
     subprocess.run([sys.executable, '-mvenv', str(tmpdir / 'venv1')])
     # 'bin' or 'Script'
     path = os.path.split(sysconfig.get_path('scripts'))[-1]
-    print(f"{path=}")
-    exe2 = str(tmpdir / 'venv1' / path / exe)
-    print(f"exe '{exe2}'")
-    print(f"exe exists {os.path.exists(exe2)}") 
     subprocess.run([str(tmpdir / 'venv1' / path / exe),
                     '-mvenv', str(tmpdir / 'venv2')])
 
@@ -22,8 +18,6 @@ def test_multiprocessing(tmpdir):
     # 'bin' or 'Script'
     path = os.path.split(sysconfig.get_path('scripts'))[-1]
     exe = str(tmpdir / 'venv' / path / os.path.split(sys.executable)[-1])
-    print(f"exe '{exe}'")
-    print(f"exe exists {os.path.exists(exe)}") 
     result = subprocess.run([exe, '-c',
                              'from multiprocessing import Pool; ' +
                              'print(Pool(1).apply_async(eval, ("__import__(\'sys\').executable",)).get(3))'],

--- a/lib-python/3/multiprocessing/popen_spawn_win32.py
+++ b/lib-python/3/multiprocessing/popen_spawn_win32.py
@@ -22,7 +22,9 @@ WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
 def _path_eq(p1, p2):
     return p1 == p2 or os.path.normcase(p1) == os.path.normcase(p2)
 
-WINENV = not _path_eq(sys.executable, sys._base_executable)
+# PyPy is not affected by bpo-35797
+# WINENV = not _path_eq(sys.executable, sys._base_executable)
+WINENV = False
 
 
 def _close_handles(*handles):

--- a/lib-python/3/venv/__init__.py
+++ b/lib-python/3/venv/__init__.py
@@ -345,8 +345,15 @@ class EnvBuilder:
                     src = os.path.join(dirname, "pypy3.9-c.exe")
                     dst = os.path.join(binpath, exe)
                     copier(src, dst)
+                elif not suffixes:
+                    # dirname is a source build from dirname\pypy\goal
+                    # so add that to dirname and try again
+                    src = os.path.join(dirname, "pypy", "goal", "pypy3.9-c.exe")
+                    dst = os.path.join(binpath, exe)
+                    copier(src, dst)
                 else:
-                    raise RuntimeError("should not happen")
+                    raise RuntimeError(f"problem finding exes in {suffixes}")
+
             if sysconfig.is_python_build(True):
                 # copy init.tcl
                 for root, dirs, files in os.walk(context.python_dir):

--- a/lib-python/3/venv/__init__.py
+++ b/lib-python/3/venv/__init__.py
@@ -336,6 +336,17 @@ class EnvBuilder:
                 if os.path.lexists(src):
                     copier(src, os.path.join(binpath, suffix))
 
+            exe = os.path.split(sys.executable)[1]
+            if exe not in suffixes:
+                if "pypy3.9-c.exe" in suffixes:
+                    # dirname is a source build, with only the
+                    # pypy*-c.exe? Make sure to create
+                    # sys.executable as well
+                    src = os.path.join(dirname, "pypy3.9-c.exe")
+                    dst = os.path.join(binpath, exe)
+                    copier(src, dst)
+                else:
+                    raise RuntimeError("should not happen")
             if sysconfig.is_python_build(True):
                 # copy init.tcl
                 for root, dirs, files in os.walk(context.python_dir):


### PR DESCRIPTION
Fixes #4876 

On CPython, there is a work-around for launching a process inside a virtual environment since CPython uses a launcher and not the python exe directly. PyPy does not use a launcher, so disable the work-around

Also fix a long standing problem in post-build testing, when creating a virtual environment on windows.