### PR TITLE
extra_tests: Fix test_sqlite3 test_connection_del

### DIFF
--- a/extra_tests/test_sqlite3.py
+++ b/extra_tests/test_sqlite3.py
@@ -144,8 +144,10 @@ def test_connection_del(tmpdir):
                     con[i] = None
                     gc.collect(); gc.collect()
 
-        with pytest.raises(_sqlite3.OperationalError):
-            open_many(False)
+        def assert_fds_limit_triggers_operational_error():
+            with pytest.raises(_sqlite3.OperationalError):
+                open_many(False)
+        assert_fds_limit_triggers_operational_error()
         gc.collect(); gc.collect()
         open_many(True)
     finally:


### PR DESCRIPTION
This commit fixes the failing `test_connection_del` test case in `test_sqlite3.py`.

The test case relies on `gc.collect()` to invoke the `Connection.__del__` method.  But, the `con` list in the `open_many` function is still reachable after the first `open_many(False)` invocation.  (Note: It seems that the exception holds a backtrace, the backtrace holds the frame object, the frame object keeps the `con` list and the `Connection` objects reachable.)

This commit fixes the problem by wrapping the first invocation in a function so that the propagating exception object can be freed before we call `gc.collect()`.