### PR TITLE
Fixes for latest cffi testing

### DIFF
--- a/extra_tests/cffi_tests/cffi1/test_zdist.py
+++ b/extra_tests/cffi_tests/cffi1/test_zdist.py
@@ -45,7 +45,8 @@ class TestDist(object):
         pathlist = sys.path[:]
         if cwd is None:
             pathlist.insert(0, self.rootdir)
-        env['PYTHONPATH'] = os.pathsep.join(pathlist)
+        if sys.version_info > (3, 0, 0):
+            env['PYTHONPATH'] = os.pathsep.join(pathlist)
         try:
             subprocess.check_call([self.executable] + args, cwd=cwd, env=env)
         finally:

--- a/pypy/module/_cffi_backend/test/_backend_test_c.py
+++ b/pypy/module/_cffi_backend/test/_backend_test_c.py
@@ -1,6 +1,8 @@
 # Copied from <cffi>/c/test_c.py
 # Make sure the files are identical starting from the # ________ line below
 
+import contextlib
+import traceback
 
 # ____________________________________________________________
 
@@ -54,6 +56,8 @@ def find_and_load_library(name, flags=RTLD_NOW):
         path = None
     else:
         path = ctypes.util.find_library(name)
+        if path is None and sys.platform == 'darwin' and sys.version_info[:2] == (3, 8):
+            pytest.xfail("find_library usually broken on MacOS Python 3.8")
         if path is None and name == 'c':
             assert sys.platform == 'win32'
             assert (sys.version_info >= (3,) or
@@ -1343,8 +1347,8 @@ def test_callback_exception():
         return x * 3
     BShort = new_primitive_type("short")
     BFunc = new_function_type((BShort,), BShort, False)
+
     f = callback(BFunc, Zcb1, -42)
-    #
     seen = []
     oops_result = None
     def oops(*args):

--- a/pypy/module/_cffi_backend/test/test_file.py
+++ b/pypy/module/_cffi_backend/test/test_file.py
@@ -4,7 +4,7 @@ import urllib2, py
 def test_same_file():
     # '_backend_test_c.py' is a copy of 'c/test_c.py' from the CFFI repo,
     # with the header lines (up to '# _____') stripped.
-    url = 'https://foss.heptapod.net/pypy/cffi/raw/branch/default/c/test_c.py'
+    url = 'https://raw.githubusercontent.com/python-cffi/cffi/main/src/c/test_c.py'
     source = urllib2.urlopen(url).read()
     #
     dest = py.path.local(__file__).join('..', '_backend_test_c.py').read()

--- a/rpython/jit/backend/zarch/test/conftest.py
+++ b/rpython/jit/backend/zarch/test/conftest.py
@@ -17,7 +17,7 @@ def pytest_ignore_collect(path, config):
         if os.path.commonprefix([path, THIS_DIR]) == THIS_DIR:  # workaround for bug in pytest<3.0.5
             return True
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file():
     if not IS_ZARCH:
         # We end up here when calling py.test .../test_foo.py with a wrong cpu
         # It's OK to kill the whole session with the following line


### PR DESCRIPTION
PR #4891 merged latest cffi changes to pypy main. There were some failures on main. This PR
- fixes the test_zdist failures
- updates the URL for `test_c.py` to the github-based cffi repo
- starts to re-sync the test_c.py to `_backend_test_c.py`. More work is needed for `test_callback_exception`.

Edit: The PR also contains a fix for a rpython test collection mess up