### PR TITLE
resync test_c.py, skip test_callback_exception

### DIFF
--- a/pypy/module/_cffi_backend/test/_backend_test_c.py
+++ b/pypy/module/_cffi_backend/test/_backend_test_c.py
@@ -4,6 +4,12 @@
 import contextlib
 import traceback
 
+@contextlib.contextmanager
+def _assert_unraisable(error_type, message='', traceback_tokens=None):
+    """Assert that a given sys.unraisablehook interaction occurred (or did not
+    occur, if error_type is None) while this context was active"""
+    raise RuntimeError("python3 only")
+
 # ____________________________________________________________
 
 import sys
@@ -1303,6 +1309,7 @@ def test_write_variable():
     ll.close_lib()
     pytest.raises(ValueError, ll.write_variable, BVoidP, "stderr", stderr)
 
+
 def test_callback():
     BInt = new_primitive_type("int")
     def make_callback():
@@ -1318,27 +1325,8 @@ def test_callback():
     e = pytest.raises(TypeError, f)
     assert str(e.value) == "'int(*)(int)' expects 1 arguments, got 0"
 
+
 def test_callback_exception():
-    try:
-        import cStringIO
-    except ImportError:
-        import io as cStringIO    # Python 3
-    import linecache
-    def matches(istr, ipattern, ipattern38, ipattern311=None):
-        if sys.version_info >= (3, 8):
-            ipattern = ipattern38
-        if sys.version_info >= (3, 11):
-            ipattern = ipattern311 or ipattern38
-        str, pattern = istr, ipattern
-        while '$' in pattern:
-            i = pattern.index('$')
-            assert str[:i] == pattern[:i]
-            j = str.find(pattern[i+1], i)
-            assert i + 1 <= j <= str.find('\n', i)
-            str = str[j:]
-            pattern = pattern[i+1:]
-        assert str == pattern
-        return True
     def check_value(x):
         if x == 10000:
             raise ValueError(42)
@@ -1355,140 +1343,44 @@ def test_callback_exception():
         seen.append(args)
         return oops_result
     ff = callback(BFunc, Zcb1, -42, oops)
-    #
-    orig_stderr = sys.stderr
-    orig_getline = linecache.getline
-    try:
-        linecache.getline = lambda *args: 'LINE'    # hack: speed up PyPy tests
-        sys.stderr = cStringIO.StringIO()
-        if hasattr(sys, '__unraisablehook__'):          # work around pytest
-            sys.unraisablehook = sys.__unraisablehook__ # on recent CPythons
+    with _assert_unraisable(None):
         assert f(100) == 300
-        assert sys.stderr.getvalue() == ''
+    with _assert_unraisable(ValueError, '42', ['in Zcb1', 'in check_value']):
         assert f(10000) == -42
-        assert matches(sys.stderr.getvalue(), """\
-From cffi callback <function$Zcb1 at 0x$>:
-Traceback (most recent call last):
-  File "$", line $, in Zcb1
-    $
-  File "$", line $, in check_value
-    $
-ValueError: 42
-""", """\
-Exception ignored from cffi callback <function$Zcb1 at 0x$>:
-Traceback (most recent call last):
-  File "$", line $, in Zcb1
-    $
-  File "$", line $, in check_value
-    $
-ValueError: 42
-""")
-        sys.stderr = cStringIO.StringIO()
-        bigvalue = 20000
+
+    bigvalue = 20000
+    with _assert_unraisable(OverflowError, "integer 60000 does not fit 'short'", ['callback', 'Zcb1']):
         assert f(bigvalue) == -42
-        assert matches(sys.stderr.getvalue(), """\
-From cffi callback <function$Zcb1 at 0x$>:
-Trying to convert the result back to C:
-OverflowError: integer 60000 does not fit 'short'
-""", """\
-Exception ignored from cffi callback <function$Zcb1 at 0x$>, trying to convert the result back to C:
-Traceback (most recent call last):
-  File "$", line $, in test_callback_exception
-    $
-OverflowError: integer 60000 does not fit 'short'
-""")
-        sys.stderr = cStringIO.StringIO()
-        bigvalue = 20000
-        assert len(seen) == 0
+    assert len(seen) == 0
+
+    with _assert_unraisable(None):
         assert ff(bigvalue) == -42
-        assert sys.stderr.getvalue() == ""
-        assert len(seen) == 1
-        exc, val, tb = seen[0]
-        assert exc is OverflowError
-        assert str(val) == "integer 60000 does not fit 'short'"
-        #
-        sys.stderr = cStringIO.StringIO()
-        bigvalue = 20000
-        del seen[:]
-        oops_result = 81
+    assert len(seen) == 1
+    exc, val, tb = seen[0]
+    assert exc is OverflowError
+    assert str(val) == "integer 60000 does not fit 'short'"
+
+    del seen[:]
+    oops_result = 81
+    with _assert_unraisable(None):
         assert ff(bigvalue) == 81
-        oops_result = None
-        assert sys.stderr.getvalue() == ""
-        assert len(seen) == 1
-        exc, val, tb = seen[0]
-        assert exc is OverflowError
-        assert str(val) == "integer 60000 does not fit 'short'"
-        #
-        sys.stderr = cStringIO.StringIO()
-        bigvalue = 20000
-        del seen[:]
-        oops_result = "xy"     # not None and not an int!
+
+    assert len(seen) == 1
+    exc, val, tb = seen[0]
+    assert exc is OverflowError
+    assert str(val) == "integer 60000 does not fit 'short'"
+
+    del seen[:]
+    oops_result = "xy"     # not None and not an int!
+
+    with _assert_unraisable(TypeError, "an integer is required", ["integer 60000 does not fit 'short'"]):
         assert ff(bigvalue) == -42
-        oops_result = None
-        assert matches(sys.stderr.getvalue(), """\
-From cffi callback <function$Zcb1 at 0x$>:
-Trying to convert the result back to C:
-OverflowError: integer 60000 does not fit 'short'
 
-During the call to 'onerror', another exception occurred:
-
-TypeError: $integer$
-""", """\
-Exception ignored from cffi callback <function$Zcb1 at 0x$>, trying to convert the result back to C:
-Traceback (most recent call last):
-  File "$", line $, in test_callback_exception
-    $
-OverflowError: integer 60000 does not fit 'short'
-Exception ignored during handling of the above exception by 'onerror':
-Traceback (most recent call last):
-  File "$", line $, in test_callback_exception
-    $
-TypeError: $integer$
-""")
-        #
-        sys.stderr = cStringIO.StringIO()
-        seen = "not a list"    # this makes the oops() function crash
+    seen = "not a list"    # this makes the oops() function crash
+    oops_result = None
+    with _assert_unraisable(AttributeError, "'str' object has no attribute 'append", ['Zcb1', 'ff', 'oops']):
         assert ff(bigvalue) == -42
-        # the $ after the AttributeError message are for the suggestions that
-        # will be added in Python 3.10
-        assert matches(sys.stderr.getvalue(), """\
-From cffi callback <function$Zcb1 at 0x$>:
-Trying to convert the result back to C:
-OverflowError: integer 60000 does not fit 'short'
 
-During the call to 'onerror', another exception occurred:
-
-Traceback (most recent call last):
-  File "$", line $, in oops
-    $
-AttributeError: 'str' object has no attribute 'append$
-""", """\
-Exception ignored from cffi callback <function$Zcb1 at 0x$>, trying to convert the result back to C:
-Traceback (most recent call last):
-  File "$", line $, in test_callback_exception
-    $
-OverflowError: integer 60000 does not fit 'short'
-Exception ignored during handling of the above exception by 'onerror':
-Traceback (most recent call last):
-  File "$", line $, in oops
-    $
-AttributeError: 'str' object has no attribute 'append$
-""", """\
-Exception ignored from cffi callback <function$Zcb1 at 0x$>, trying to convert the result back to C:
-Traceback (most recent call last):
-  File "$", line $, in test_callback_exception
-    $
-OverflowError: integer 60000 does not fit 'short'
-Exception ignored during handling of the above exception by 'onerror':
-Traceback (most recent call last):
-  File "$", line $, in oops
-    $
-    $
-AttributeError: 'str' object has no attribute 'append$
-""")
-    finally:
-        sys.stderr = orig_stderr
-        linecache.getline = orig_getline
 
 def test_callback_return_type():
     for rettype in ["signed char", "short", "int", "long", "long long",


### PR DESCRIPTION
It is too hard to match the python3/pytest6.2 semantics of the `_assert_unraisable` helper function, so skip the test. 