### PR TITLE
make pypy translate with boehm again

### DIFF
--- a/pypy/goal/targetpypystandalone.py
+++ b/pypy/goal/targetpypystandalone.py
@@ -320,10 +320,11 @@ class PyPyTarget(object):
             config.objspace.lonepycfiles = False
 
         if config.objspace.usemodules.cpyext:
-            if config.translation.gc not in ('incminimark', 'boehm'):
-                raise Exception("The 'cpyext' module requires the 'incminimark'"
-                    " or 'boehm' GC.  You need either 'targetpypystandalone.py"
-                    " --withoutmod-cpyext', or use one of these two GCs.")
+            if config.translation.gc != 'incminimark':
+                raise Exception("The 'cpyext' module requires the default"
+                    " 'incminimark' GC.  You need 'targetpypystandalone.py"
+                    " --withoutmod-cpyext' with other GCs.  (It almost"
+                    " works with Boehm, the fix should be quick)")
 
         config.translating = True
 

--- a/rpython/translator/c/src/mem.h
+++ b/rpython/translator/c/src/mem.h
@@ -171,6 +171,7 @@ RPY_EXTERN void *boehm_fq_next_dead(struct boehm_fq_s **);
 #define OP_GC_DUMP_RPY_HEAP(fd, r)       r = 0
 #define OP_GC_SET_EXTRA_THRESHOLD(x, r)  /* nothing */
 #define OP_GC_IGNORE_FINALIZER(x, r)     /* nothing */
+#define OP_GC_INCREASE_ROOT_STACK_DEPTH(x, r)   /* nothing */
 
 /****************************/
 /* misc stuff               */


### PR DESCRIPTION
Note that cpyext must be disabled for now, until we fix the issue.