### PR TITLE
Fix trace_limit checking logic

### DIFF
--- a/rpython/rlib/jit.py
+++ b/rpython/rlib/jit.py
@@ -866,9 +866,8 @@ def set_user_param(driver, text):
                     try:
                         set_param(driver, name1, ivalue)
                     except ValueError:
-                        if name1 == 'trace_limit' and ivalue >= 0:
-                            # turn it into a somewhat more understandable exception
-                            raise TraceLimitTooHigh
+                        # turn it into a somewhat more understandable exception
+                        raise TraceLimitTooHigh
                     break
             else:
                 raise ValueError


### PR DESCRIPTION
Calling `jit.set_param(driver, 'trace_limit', limit)` always raises an exception after a7dc0e6201. (The diff is partially shown below for convenience.)

The problem seems to be from `int(value) > 2**14` being replaced into `ivalue >= 0` in `rpython/rlib/jit.py`. Also, since the value is checked in `set_param_trace_limit` in `rpython/jit/metainterp/warmstate.py`, the line seems to be unnecessary in the first place.

The diff that caused the bug:

```diff
diff --git a/rpython/jit/metainterp/warmstate.py b/rpython/jit/metainterp/warmstate.py
index d3dcf94a22..828f684ffc 100644
--- a/rpython/jit/metainterp/warmstate.py
+++ b/rpython/jit/metainterp/warmstate.py
@@ -265,6 +265,10 @@ class WarmEnterState(object):
         self.increment_trace_eagerness = self._compute_threshold(value)

     def set_param_trace_limit(self, value):
+        if value < 0:
+            raise ValueError
+        if value > self.warmrunnerdesc.metainterp_sd.opencoder_model.MAX_TRACE_LIMIT:
+            raise ValueError
         self.trace_limit = value

     def set_param_decay(self, decay):
diff --git a/rpython/rlib/jit.py b/rpython/rlib/jit.py
index edeb3cefa7..9a93acefe3 100644
--- a/rpython/rlib/jit.py
+++ b/rpython/rlib/jit.py
@@ -860,11 +860,15 @@ def set_user_param(driver, text):
             for name1, _ in unroll_parameters:
                 if name1 == name and name1 != 'enable_opts':
                     try:
-                        if name1 == 'trace_limit' and int(value) > 2**14:
-                            raise TraceLimitTooHigh
-                        set_param(driver, name1, int(value))
+                        ivalue = int(value)
                     except ValueError:
                         raise
+                    try:
+                        set_param(driver, name1, ivalue)
+                    except ValueError:
+                        if name1 == 'trace_limit' and ivalue >= 0:
+                            # turn it into a somewhat more understandable exception
+                            raise TraceLimitTooHigh
                     break
             else:
                 raise ValueError
```