### PR TITLE
use simple interactive console if stdin is closed (issue 2981)

### DIFF
--- a/lib_pypy/_pypy_interact.py
+++ b/lib_pypy/_pypy_interact.py
@@ -27,7 +27,7 @@ def interactive_console(mainmodule=None, quiet=False, future_flags=0):
             pass
     #
     try:
-        if not os.isatty(sys.stdin.fileno()):
+        if not (sys.stdin.closed or os.isatty(sys.stdin.fileno())):
             # Bail out if stdin is not tty-like, as pyrepl wouldn't be happy
             # For example, with:
             # subprocess.Popen(['pypy', '-i'], stdin=subprocess.PIPE)


### PR DESCRIPTION
This fixes #2981.