### PR TITLE
Add array.typecodes

### DIFF
--- a/pypy/module/array/interp_array.py
+++ b/pypy/module/array/interp_array.py
@@ -897,6 +897,9 @@ for k, v in types.items():
     v.typecode = k
 unroll_typecodes = unrolling_iterable(types.keys())
 
+typecodes = 'bBuhHiIlLqQfd'
+assert set(typecodes) == set(types.keys())
+
 class ArrayBuffer(RawBuffer):
     _immutable_ = True
     readonly = False

--- a/pypy/module/array/moduledef.py
+++ b/pypy/module/array/moduledef.py
@@ -5,6 +5,7 @@ class Module(MixedModule):
         'array': 'interp_array.W_ArrayBase',
         'ArrayType': 'interp_array.W_ArrayBase',
         '_array_reconstructor': 'reconstructor.array_reconstructor',
+        'typecodes': 'space.newtext(interp_array.typecodes)',
     }
 
     appleveldefs = {


### PR DESCRIPTION
Copy `array.typecodes` from CPython, but assert that they match the set of typecodes used in PyPy code.

Addresses part of #4962.