### PR TITLE
Add array.typecodes, take 2

### DIFF
--- a/pypy/module/array/interp_array.py
+++ b/pypy/module/array/interp_array.py
@@ -887,6 +887,9 @@ for k, v in types.items():
     v.typecode = k
 unroll_typecodes = unrolling_iterable(types.keys())
 
+typecodes = 'bBuhHiIlLqQfd'
+assert set(typecodes) == set(types.keys())
+
 class ArrayBuffer(RawBuffer):
     _immutable_ = True
     readonly = False

--- a/pypy/module/array/moduledef.py
+++ b/pypy/module/array/moduledef.py
@@ -5,6 +5,7 @@ class Module(MixedModule):
         'array': 'interp_array.W_ArrayBase',
         'ArrayType': 'interp_array.W_ArrayBase',
         '_array_reconstructor': 'reconstructor.array_reconstructor',
+        'typecodes': 'space.newtext(interp_array.typecodes)',
     }
 
     appleveldefs = {


### PR DESCRIPTION
Copy `array.typecodes` from CPython, but assert that they match the set of typecodes used in PyPy code.

Hopefully targeting the correct branch this time :)

Addresses part of https://github.com/pypy/pypy/issues/4962.