### PR TITLE
Add cmath.tau, take 2

### DIFF
--- a/pypy/module/cmath/interp_cmath.py
+++ b/pypy/module/cmath/interp_cmath.py
@@ -7,6 +7,7 @@ from pypy.module.cmath.moduledef import names_and_docstrings
 from rpython.rlib import rcomplex, rfloat
 
 pi   = math.pi
+tau  = math.pi * 2.0
 e    = math.e
 inf  = float('inf')
 nan  = float('nan')

--- a/pypy/module/cmath/moduledef.py
+++ b/pypy/module/cmath/moduledef.py
@@ -39,6 +39,7 @@ class Module(MixedModule):
 
     interpleveldefs = {
         'pi': 'space.newfloat(interp_cmath.pi)',
+        'tau': 'space.newfloat(interp_cmath.tau)',
         'e':  'space.newfloat(interp_cmath.e)',
         'inf':  'space.newfloat(interp_cmath.inf)',
         'nan':  'space.newfloat(interp_cmath.nan)',

--- a/pypy/module/cmath/test/test_cmath.py
+++ b/pypy/module/cmath/test/test_cmath.py
@@ -42,9 +42,11 @@ class AppTestCMath:
         z = cmath.log(100j, 10j)
         assert abs(z - (1.6824165174565446-0.46553647994440367j)) < 1e-10
 
-    def test_pi_e(self):
+    def test_pi_tau_e(self):
         import cmath, math
         assert cmath.pi == math.pi
+        assert cmath.tau == math.tau
+        assert cmath.tau == cmath.pi * 2.0
         assert cmath.e == math.e
 
     def test_rect(self):


### PR DESCRIPTION
Use `math.pi * 2.0` to define it, as `math.tau` isn't available on Python 2.

@mattip said:
> should also inject the constant into the `math` module

But I don't know what that means, or how to do it. Any clues?

Addresses part of https://github.com/pypy/pypy/issues/4962.