### PR TITLE
set html_context and html_baseurl as recommended by readthedocs

### DIFF
--- a/pypy/doc/conf.py
+++ b/pypy/doc/conf.py
@@ -36,6 +36,13 @@ else:
         print('sphinx_rtd_theme is not installed')
         html_theme = 'default'
 
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 # -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/pypy/doc/conf.py
+++ b/pypy/doc/conf.py
@@ -38,6 +38,7 @@ else:
 
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_context = {}
 
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":


### PR DESCRIPTION
As recommended in the upcoming changes [for readthedocs](https://about.readthedocs.com/blog/2024/07/addons-by-default/)