### PR TITLE
Fix readonly flag in PyMemoryView_FromMemory

### DIFF
--- a/pypy/module/cpyext/memoryobject.py
+++ b/pypy/module/cpyext/memoryobject.py
@@ -194,7 +194,7 @@ def PyMemoryView_FromMemory(space, mem, size, flags):
     PyBUF_READ or PyBUF_WRITE. view->format is set to "B" (unsigned bytes).
     The memoryview has complete buffer information.
     """
-    readonly = int(widen(flags) == PyBUF_WRITE)
+    readonly = int(widen(flags) == PyBUF_READ)
     view = CPyBuffer(space, cts.cast('void*', mem), size, None,
             readonly=readonly)
     w_mview = W_MemoryView(view)

--- a/pypy/module/cpyext/test/test_memoryobject.py
+++ b/pypy/module/cpyext/test/test_memoryobject.py
@@ -293,13 +293,24 @@ class AppTestBufferProtocol(AppTestCpythonExtensionBase):
         assert module.get_cnt() == 0
         assert module.get_dealloc_cnt() == 1
 
-    def test_FromMemory(self):
+    def test_FromMemory_readonly(self):
         module = self.import_extension('foo', [
             ('new', 'METH_NOARGS', """
              static char s[5] = "hello";
              return PyMemoryView_FromMemory(s, 4, PyBUF_READ);
              """)])
         mv = module.new()
+        assert mv.readonly == True
+        assert mv.tobytes() == b'hell'
+
+    def test_FromMemory_readwrite(self):
+        module = self.import_extension('foo', [
+            ('new', 'METH_NOARGS', """
+             static char s[5] = "hello";
+             return PyMemoryView_FromMemory(s, 4, PyBUF_WRITE);
+             """)])
+        mv = module.new()
+        assert mv.readonly == False
         assert mv.tobytes() == b'hell'
 
     def test_FromBuffer_NULL(self):


### PR DESCRIPTION
Fix issue #4992: the behavior of PyMemoryView_FromMemory is backwards.

**I haven't tested this**, but it seems right.

I'm also not sure of the procedure for making changes here.  I'm targetting this pull request at `py3.9` branch, but note that:

- The bug is also present in `py3.10` branch (as well as older versions.)

- This is an API break, so I don't know whether it's okay to change this in a stable release.
