### PR TITLE
Add RISC-V JIT backend

### DIFF
--- a/pypy/module/micronumpy/test/test_ndarray.py
+++ b/pypy/module/micronumpy/test/test_ndarray.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+import platform
 import py
 import sys
 
@@ -1879,12 +1880,18 @@ class AppTestNumArray(BaseNumpyAppTest):
             assert a.view('S16')[0] == '\x01' + '\x00' * 7 + '\x02'
 
     def test_half_conversions(self):
-        from numpy import array, arange
+        from numpy import array
         from math import isnan, isinf
         e = array([0, -1, -float('inf'), float('nan'), 6], dtype='float16')
         assert map(isnan, e) == [False, False, False, True, False]
         assert map(isinf, e) == [False, False, True, False, False]
         assert e.argmax() == 3
+
+    def test_half_conversions_preserve_nan_payload_float32(self):
+        if platform.machine().startswith('riscv'):
+            py.test.skip('riscv does not preserve nan payload in '
+                         'float64->float32 conversion')
+        from numpy import array, arange
         # numpy preserves value for uint16 -> cast_as_float16 ->
         #     convert_to_float64 -> convert_to_float16 -> uint16
         #  even for float16 various float16 nans
@@ -1892,6 +1899,19 @@ class AppTestNumArray(BaseNumpyAppTest):
         all_f16.dtype = 'float16'
         all_f32 = array(all_f16, dtype='float32')
         b = array(all_f32, dtype='float16')
+        c = b.view(dtype='uint16')
+        d = all_f16.view(dtype='uint16')
+        assert (c == d).all()
+
+    def test_half_conversions_preserve_nan_payload_float64(self):
+        from numpy import array, arange
+        # numpy preserves value for uint16 -> cast_as_float16 ->
+        #     convert_to_float64 -> convert_to_float16 -> uint16
+        #  even for float16 various float16 nans
+        all_f16 = arange(0xfe00, 0xffff, dtype='uint16')
+        all_f16.dtype = 'float16'
+        all_f64 = array(all_f16, dtype='float64')
+        b = array(all_f64, dtype='float16')
         c = b.view(dtype='uint16')
         d = all_f16.view(dtype='uint16')
         assert (c == d).all()

--- a/pypy/module/micronumpy/test/test_ufuncs.py
+++ b/pypy/module/micronumpy/test/test_ufuncs.py
@@ -1,3 +1,6 @@
+import platform
+import py
+
 from pypy.module.micronumpy.test.test_base import BaseNumpyAppTest
 from pypy.module.micronumpy.ufuncs import W_UfuncGeneric, unary_ufunc
 from pypy.module.micronumpy.support import _parse_signature
@@ -808,8 +811,19 @@ class AppTestUfuncs(BaseNumpyAppTest):
         assert ([ninf, -2.0, -2.0, -1.0, 0.0, 1.0, 1.0, 0.0, inf] == floor(a)).all()
         assert ([ninf, -1.0, -1.0, -1.0, 0.0, 1.0, 2.0, 1.0, inf] == ceil(a)).all()
         assert ([ninf, -1.0, -1.0, -1.0, 0.0, 1.0, 1.0, 0.0, inf] == trunc(a)).all()
+
+    def test_floorceiltrunc_nan(self):
+        from numpy import floor, ceil, trunc
+        import math
         assert all([math.isnan(f(float("nan"))) for f in floor, ceil, trunc])
         assert all([math.copysign(1, f(abs(float("nan")))) == 1 for f in floor, ceil, trunc])
+
+    def test_floorceiltrunc_nan_negative(self):
+        if platform.machine().startswith('riscv'):
+            py.test.skip('riscv floor/ceil/trunc canonicalizes nan to '
+                         'positive nan')
+        from numpy import floor, ceil, trunc
+        import math
         assert all([math.copysign(1, f(-abs(float("nan")))) == -1 for f in floor, ceil, trunc])
 
     def test_round(self):

--- a/rpython/doc/index.rst
+++ b/rpython/doc/index.rst
@@ -35,6 +35,7 @@ RPython.
    :maxdepth: 1
 
    arm
+   riscv
    logging
 
 

--- a/rpython/doc/riscv.rst
+++ b/rpython/doc/riscv.rst
@@ -1,0 +1,264 @@
+.. _riscv:
+
+Cross-Translating for RISC-V
+============================
+
+This document describes how to translate RPython to RISC-V 64-bit backend.
+
+
+Creating a Debian RISC-V 64-bit Chroot
+--------------------------------------
+
+This section describes how to set up RISC-V 64-bit chroot on a x86 host.  You
+can skip this section if you would like to develop on a RISC-V 64-bit board
+directly.
+
+First, we must install dependencies below on the host:
+
+* ``debootstrap`` -- Debian tool to create a Debian root file system in a
+  directory.
+* ``schroot`` -- A chroot management daemon that helps us switch between
+  chroots.
+* ``qemu-user-static`` -- The binary translator that allow us to run RISC-V
+  64-bit executables on x86-64.
+* ``binfmt-support`` -- A utility package that helps the Linux kernel to invoke
+  ``qemu-user-static`` for RISC-V 64-bit executables.
+* ``ubuntu-keyring`` -- The public key for Ubuntu archive.
+
+Run the command below to install all of them:
+
+::
+
+    sudo apt-get install debootstrap qemu-user-static binfmt-support schroot
+
+    # For non-Ubuntu host:
+    sudo apt-get install ubuntu-keyring
+
+Second, we must decide where we would like to set up the chroot.  In the
+example below, ``/srv/chroot/rv64_ubuntu_24_04`` will be used:
+
+Now, we create the root file system by calling:
+
+::
+
+    sudo mkdir -p /srv/chroot
+
+    sudo debootstrap --arch=riscv64 \
+        --keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg \
+        --include=ubuntu-keyring \
+        noble \
+        /srv/chroot/rv64_ubuntu_24_04 \
+        http://ports.ubuntu.com/ubuntu-ports
+
+    # Rename /etc/resolv.conf so that schroot can copy the host resolv.conf
+    # into chroot.
+    sudo mv /srv/chroot/rv64_ubuntu_24_04/etc/resolv.conf{,.bak}
+
+Third, create a ``default_shm`` schroot profile, which allows the usage of
+semaphore and shared memory:
+
+::
+
+    sudo cp /etc/schroot/default /etc/schroot/default_shm
+
+    # Uncomment shm fstab lines
+    sudo sed -i 's_#/run_/run_g' /etc/schroot/default_shm/fstab
+    sudo sed -i 's_#/dev/shm_/dev/shm_g' /etc/schroot/default_shm/fstab
+
+Fourth, we create a ``schroot`` configuration file for the root file system
+we've just created.  The command below creates a configuration file at
+``/etc/schroot/chroot.d/rv64_ubuntu_24_04``:
+
+::
+
+    echo "[rv64_ubuntu_24_04]
+    description=Ubuntu Noble (24.04) RISC-V
+    directory=/srv/chroot/rv64_ubuntu_24_04
+    root-users=$(whoami)
+    users=$(whoami)
+    type=directory
+    profile=default_shm" | sudo tee /etc/schroot/chroot.d/rv64_ubuntu_24_04
+
+Now, you can test the chroot with:
+
+::
+
+    schroot -l
+
+You should see the output:
+
+::
+
+    chroot:rv64_ubuntu_24_04
+
+You can enter the chroot with:
+
+::
+
+    schroot -c rv64_ubuntu_24_04
+
+Inside the chroot, if you run ``uname -m``, you should see ``riscv64``:
+
+::
+
+    $ uname -m
+    riscv64
+
+You can enter the chroot as the ``root`` user with the ``-u root`` option:
+
+::
+
+    schroot -c rv64_ubuntu_24_04 -u root
+
+You may sometimes need this when you want to install Debian packages to the
+chroot.
+
+
+Build CPython 2.7 for Bootstrapping
+-----------------------------------
+
+To run the RPython toolchain, we need a Python 2.7 implementation.  This
+section describes how to build a CPython 2.7 from its source code.  You can
+skip this section if you already have ``python2.7``.
+
+.. note::
+
+   CPython 2.7 is no longer supported nor maintained.  The instructions below
+   is based on my experiment around early 2024.  These are provided as-is and
+   without warranty.  Please adjust them if needed.
+
+
+First, install the build dependencies for CPython:
+
+::
+
+    schroot -c rv64_ubuntu_24_04 -u root -- apt-get install \
+        build-essential gcc gdb g++ \
+        libbz2-dev libdb-dev libexpat1-dev libffi-dev libgdbm-dev \
+        libncursesw5-dev libreadline-dev libsqlite3-dev libssl-dev \
+        libtinfo-dev tk-dev zlib1g-dev
+
+Secoond, create the final installation directory for CPython:
+
+::
+
+    schroot -c rv64_ubuntu_24_04 -u root -- mkdir /opt/python2
+
+    schroot -c rv64_ubuntu_24_04 -u root -- chown $(whoami):$(whoami) /opt/python2
+
+Third, clone the patched CPython 2.7 repository:
+
+::
+
+    git clone https://github.com/loganchien/cpython27-deprecated -b release_27
+
+    cd cpython27-deprecated
+
+Fourth, build CPython 2.7 in the chroot:
+
+::
+
+    schroot -c rv64_ubuntu_24_04
+
+::
+
+    $ ./configure --prefix=/opt/python2 \
+                  --enable-shared \
+                  --enable-optimizations \
+                  --with-system-ffi LDFLAGS="-Wl,-rpath,/opt/python2/lib"
+
+    $ make -j8
+
+    $ make install -j8
+
+Fifth, set up Python packages:
+
+::
+
+    $ export PATH=/opt/python2/bin:$PATH
+
+    $ python2.7 -mensurepip
+
+    $ python2.7 -mpip install -U pip wheel
+
+Now, you should have a CPython 2.7 that is good enough for RPython translation.
+
+
+Using the RPython Toolchain
+---------------------------
+
+First, install `the dependencies`_ for PyPy development:
+
+.. _`the dependencies`:
+   https://doc.pypy.org/en/latest/build.html#install-build-time-dependencies
+
+::
+
+    schroot -c rv64_ubuntu_24_04 -u root -- apt-get install \
+        build-essential pkg-config libbz2-dev libexpat1-dev libffi-dev \
+        libgc-dev libgdbm-dev liblzma-dev libncurses5-dev libncursesw5-dev \
+        libsqlite3-dev libssl-dev tk-dev zlib1g-dev
+
+In addition, to pass all test suites, you will have to build PyPy with git:
+
+::
+
+    schroot -c rv64_ubuntu_24_04 -u root -- apt-get install git
+
+
+Second, install Python packages for PyPy development:
+
+::
+
+    schroot -c rv64_ubuntu_24_04
+
+    $ export PATH=/opt/python2/bin:$PATH
+
+    $ cd /path/to/pypy/source/tree
+
+    $ python2.7 -mpip install -r requirements.txt
+
+
+Translate a Hello World Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a ``target.py`` file with the following content:
+
+::
+
+    def main(args):
+        print "Hello World"
+        return 0
+
+    def target(*args):
+        return main, None
+
+and call the translator:
+
+::
+
+    $ python2.7 rpython/bin/rpython -O2 target.py
+
+
+If everything worked correctly, this should yield an RISC-V 64-bit binary.
+Running this binary on RISC-V 64-bit should produce the output
+``Hello World``.
+
+
+Translate PyPy Interpreter
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run the command below to translate the full PyPy interpreter with a JIT
+compiler:
+
+::
+
+    $ cd pypy/goal
+
+    $ python2.7 ../../rpython/bin/rpython --opt=jit targetpypystandalone.py
+
+    $ PYTHONPATH=../.. ./pypy-c ../../lib_pypy/pypy_tools/build_cffi_imports.py
+
+    $ cd ../..
+
+    $ python2.7 pypy/tool/release/package.py --archive-name=pypy-VER-PLATFORM

--- a/rpython/jit/backend/riscv/arch.py
+++ b/rpython/jit/backend/riscv/arch.py
@@ -10,6 +10,12 @@ XLEN = 8
 # Floating point register width (in bytes)
 FLEN = 8  # Assume "Standard Extension for Double 'D'" is available.
 
+# Stack slot size that can contain either int/float whenever the register
+# allocator would like to push a scratch value to the stack top.
+#
+# Note: This constant value is used by `regalloc_push` and `regalloc_pop`.
+SCRATCH_STACK_SLOT_SIZE = 8
+
 NUM_REGS = 32
 NUM_FP_REGS = 32
 JITFRAME_FIXED_SIZE = NUM_REGS + NUM_FP_REGS

--- a/rpython/jit/backend/riscv/arch.py
+++ b/rpython/jit/backend/riscv/arch.py
@@ -33,3 +33,6 @@ SHAMT_MAX = 8 * XLEN - 1
 
 # RISC-V ABI requires stack pointer to be aligned to 128-bit.
 ABI_STACK_ALIGN = 16
+
+# Instruction size (in bytes)
+INST_SIZE = 4

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -121,9 +121,14 @@ class AssemblerRISCV(OpAssembler):
             self.mc.mark_op(op)
             opnum = op.getopnum()
 
-            arglocs = regalloc_operations[opnum](regalloc, op)
-            if arglocs is not None:
-                asm_operations[opnum](self, op, arglocs)
+            if rop.has_no_side_effect(opnum) and op not in regalloc.longevity:
+                # If this op does not have side effects and its result is
+                # unused, it is safe to ignore this op.
+                pass
+            else:
+                arglocs = regalloc_operations[opnum](regalloc, op)
+                if arglocs is not None:
+                    asm_operations[opnum](self, op, arglocs)
 
             # Free argument vars of the op (if no longer used).
             regalloc.possibly_free_vars_for_op(op)

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -131,6 +131,8 @@ class AssemblerRISCV(OpAssembler):
                 # If this op does not have side effects and its result is
                 # unused, it is safe to ignore this op.
                 pass
+            elif not we_are_translated() and op.getopnum() == rop.FORCE_SPILL:
+                regalloc.force_spill_var(op.getarg(0))
             elif (i < len(operations) - 1 and
                   ((can_fuse_into_compare_and_branch(opnum) and
                     regalloc.next_op_can_accept_cc(operations, i)) or
@@ -501,11 +503,15 @@ class AssemblerRISCV(OpAssembler):
     def _mov_reg_to_loc(self, prev_loc, loc):
         if loc.is_core_reg():
             self.mc.MV(loc.value, prev_loc.value)
+        elif loc.is_stack():
+            self.mc.store_int(prev_loc.value, r.jfp.value, loc.value)
         else:
             assert 0, 'unsupported case'
 
     def _mov_fp_reg_to_loc(self, prev_loc, loc):
         if loc.is_fp_reg():
             self.mc.FMV_D(loc.value, prev_loc.value)
+        elif loc.is_stack():
+            self.mc.store_float(prev_loc.value, r.jfp.value, loc.value)
         else:
             assert 0, 'unsupported case'

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -131,9 +131,11 @@ class AssemblerRISCV(OpAssembler):
                 # If this op does not have side effects and its result is
                 # unused, it is safe to ignore this op.
                 pass
-            elif (can_fuse_into_compare_and_branch(opnum) and
-                  i < len(operations) - 1 and
-                  regalloc.next_op_can_accept_cc(operations, i)):
+            elif (i < len(operations) - 1 and
+                  ((can_fuse_into_compare_and_branch(opnum) and
+                    regalloc.next_op_can_accept_cc(operations, i)) or
+                   (op.is_ovf() and
+                    rop.is_guard_overflow(operations[i + 1].getopnum())))):
                 guard_op = operations[i + 1]  # guard_* or cond_call*
                 guard_num = guard_op.getopnum()
                 arglocs, guard_branch_inst = \

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -506,24 +506,25 @@ class AssemblerRISCV(OpAssembler):
         """ This builds a general call slowpath, for whatever call happens to
         come.
 
-        The address of the callee function comes in r.x31.
-        The returning value is stored in r.x31.
+        The address of the callee function comes in r.x30.
+        The returning value is stored in r.x30.
         """
         mc = InstrBuilder()
 
         # Spill registers to JITFRAME
         #
-        # Ignore jfp for _reload_frame_if_necessary and x31 for return.
-        ignore_regs_for_push_pop = [r.jfp, r.x31]
+        # Ignore jfp for _reload_frame_if_necessary, x30 for return, x31 for
+        # scratch.
+        ignore_regs_for_push_pop = [r.jfp, r.x30, r.x31]
         self._push_all_regs_to_jitframe(mc, ignore_regs_for_push_pop,
                                         supports_floats,
                                         callee_only)  # Spills r.ra
 
         # Branch to the callee function.
-        mc.JALR(r.ra.value, r.x31.value, 0)
+        mc.JALR(r.ra.value, r.x30.value, 0)
 
-        # Move return value to r.x31.
-        mc.MV(r.x31.value, r.x10.value)
+        # Move return value to r.x30.
+        mc.MV(r.x30.value, r.x10.value)
 
         # Restore registers from JITFRAME
         self._reload_frame_if_necessary(mc)

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -454,6 +454,8 @@ class AssemblerRISCV(OpAssembler):
                                                         allblocks)
         self.mc.datablockwrapper = self.datablockwrapper
 
+        self._finish_gcmap = jitframe.NULLGCMAP
+
     def teardown(self):
         self.current_clt = None
         self._regalloc = None

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -57,6 +57,9 @@ class AssemblerRISCV(OpAssembler):
         looptoken.compiled_loop_token = clt
 
         self.setup(looptoken)
+        if self.cpu.HAS_CODEMAP:
+            self.codemap_builder.enter_portal_frame(jd_id, unique_id,
+                                                    self.mc.get_relative_pos())
 
         frame_info = self.datablockwrapper.malloc_aligned(
             jitframe.JITFRAMEINFO_SIZE, alignment=XLEN)
@@ -143,6 +146,9 @@ class AssemblerRISCV(OpAssembler):
             assert len(set(inputargs)) == len(inputargs)
 
         self.setup(original_loop_token)
+        if self.cpu.HAS_CODEMAP:
+            self.codemap_builder.inherit_code_from_position(
+                faildescr.adr_jump_offset)
 
         descr_number = compute_unique_id(faildescr)
         if log:
@@ -779,6 +785,9 @@ class AssemblerRISCV(OpAssembler):
         size = self.mc.get_relative_pos()
         rawstart = self.mc.materialize(self.cpu, allblocks,
                                        self.cpu.gc_ll_descr.gcrootmap)
+        # Registers the materialized loop to the codemap.
+        self.cpu.codemap.register_codemap(
+            self.codemap_builder.get_final_bytecode(rawstart, size))
         return rawstart
 
     def _build_failure_recovery(self, exc, withfloats=False):

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -15,7 +15,8 @@ from rpython.jit.backend.riscv.opassembler import (
     OpAssembler, asm_guard_operations, asm_operations)
 from rpython.jit.backend.riscv.regalloc import (
     Regalloc, regalloc_guard_operations, regalloc_operations)
-from rpython.jit.backend.riscv.locations import StackLocation, get_fp_offset
+from rpython.jit.backend.riscv.locations import (
+    ImmLocation, StackLocation, get_fp_offset)
 from rpython.jit.codewriter.effectinfo import EffectInfo
 from rpython.jit.metainterp.history import AbstractFailDescr, FLOAT
 from rpython.jit.metainterp.resoperation import rop
@@ -1242,6 +1243,9 @@ class AssemblerRISCV(OpAssembler):
             self.regalloc_mov(src, tmp)
             return tmp
         return src
+
+    def imm(self, value):
+        return ImmLocation(value)
 
     def new_stack_loc(self, i, tp):
         # Create a StackLocation at `i` of type `tp`.

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -628,7 +628,8 @@ class AssemblerRISCV(OpAssembler):
         if not ignored_regs:
             for reg in regs:
                 mc.store_int(reg.value, r.jfp.value,
-                             base_ofs + reg.value * XLEN)
+                             base_ofs +
+                             self.cpu.all_reg_indexes[reg.value] * XLEN)
         else:
             for reg in ignored_regs:
                 assert reg.is_core_reg()
@@ -636,7 +637,8 @@ class AssemblerRISCV(OpAssembler):
                 if reg in ignored_regs:
                     continue
                 mc.store_int(reg.value, r.jfp.value,
-                             base_ofs + reg.value * XLEN)
+                             base_ofs +
+                             self.cpu.all_reg_indexes[reg.value] * XLEN)
 
         if withfloats:
             # Push floating point registers
@@ -656,7 +658,8 @@ class AssemblerRISCV(OpAssembler):
         if not ignored_regs:
             for reg in regs:
                 mc.load_int(reg.value, r.jfp.value,
-                            base_ofs + reg.value * XLEN)
+                            base_ofs +
+                            self.cpu.all_reg_indexes[reg.value] * XLEN)
         else:
             for reg in ignored_regs:
                 assert reg.is_core_reg()
@@ -664,7 +667,8 @@ class AssemblerRISCV(OpAssembler):
                 if reg in ignored_regs:
                     continue
                 mc.load_int(reg.value, r.jfp.value,
-                            base_ofs + reg.value * XLEN)
+                            base_ofs +
+                            self.cpu.all_reg_indexes[reg.value] * XLEN)
 
         if withfloats:
             # Pop floating point registers
@@ -679,7 +683,8 @@ class AssemblerRISCV(OpAssembler):
         for reg in selected_regs:
             if reg.is_core_reg():
                 mc.store_int(reg.value, r.jfp.value,
-                             base_ofs + reg.value * XLEN)
+                             base_ofs +
+                             self.cpu.all_reg_indexes[reg.value] * XLEN)
             else:
                 assert reg.is_fp_reg()
                 mc.store_float(reg.value, r.jfp.value,
@@ -692,7 +697,8 @@ class AssemblerRISCV(OpAssembler):
         for reg in selected_regs:
             if reg.is_core_reg():
                 mc.load_int(reg.value, r.jfp.value,
-                            base_ofs + reg.value * XLEN)
+                            base_ofs +
+                            self.cpu.all_reg_indexes[reg.value] * XLEN)
             else:
                 assert reg.is_fp_reg()
                 mc.load_float(reg.value, r.jfp.value,

--- a/rpython/jit/backend/riscv/assembler.py
+++ b/rpython/jit/backend/riscv/assembler.py
@@ -61,9 +61,9 @@ class AssemblerRISCV(OpAssembler):
         clt.frame_info = rffi.cast(jitframe.JITFRAMEINFOPTR, frame_info)
         clt.frame_info.clear()
 
-        #if log:
-        #    operations = self._inject_debugging_code(looptoken, operations,
-        #                                             'e', looptoken.number)
+        if log:
+            operations = self._inject_debugging_code(looptoken, operations,
+                                                     'e', looptoken.number)
 
         regalloc = Regalloc(self)
         allgcrefs = []
@@ -106,14 +106,14 @@ class AssemblerRISCV(OpAssembler):
 
         ops_offset = self.mc.ops_offset
 
-        #if logger:
-        #    log = logger.log_trace(jl.MARK_TRACE_ASM, None, self.mc)
-        #    log.write(inputargs, operations, ops_offset=ops_offset)
-        #
-        #    if logger.logger_ops:
-        #        logger.logger_ops.log_loop(inputargs, operations, 0,
-        #                                   'rewritten', name=loopname,
-        #                                   ops_offset=ops_offset)
+        if logger:
+            log = logger.log_trace(jl.MARK_TRACE_ASM, None, self.mc)
+            log.write(inputargs, operations, ops_offset=ops_offset)
+
+            if logger.logger_ops:
+                logger.logger_ops.log_loop(inputargs, operations, 0,
+                                           'rewritten', name=loopname,
+                                           ops_offset=ops_offset)
 
         debug_start('jit-backend-addr')
         debug_print('Loop %d (%s) has address 0x%x to 0x%x (bootstrap 0x%x)' % (
@@ -143,9 +143,9 @@ class AssemblerRISCV(OpAssembler):
         self.setup(original_loop_token)
 
         descr_number = compute_unique_id(faildescr)
-        #if log:
-        #    operations = self._inject_debugging_code(faildescr, operations,
-        #                                             'b', descr_number)
+        if log:
+            operations = self._inject_debugging_code(faildescr, operations,
+                                                     'b', descr_number)
 
         assert isinstance(faildescr, AbstractFailDescr)
 
@@ -203,17 +203,17 @@ class AssemblerRISCV(OpAssembler):
 
         ops_offset = self.mc.ops_offset
 
-        #if logger:
-        #    log = logger.log_trace(jl.MARK_TRACE_ASM, None, self.mc)
-        #    log.write(inputargs, operations, ops_offset)
-        #    # Log that the already written bridge is stitched to a descr.
-        #    logger.log_patch_guard(descr_number, rawstart)
+        if logger:
+            log = logger.log_trace(jl.MARK_TRACE_ASM, None, self.mc)
+            log.write(inputargs, operations, ops_offset)
+            # Log that the already written bridge is stitched to a descr.
+            logger.log_patch_guard(descr_number, rawstart)
 
-        #    # Legacy
-        #    if logger.logger_ops:
-        #        logger.logger_ops.log_bridge(inputargs, operations,
-        #                                     'rewritten', faildescr,
-        #                                     ops_offset=ops_offset)
+            # Legacy
+            if logger.logger_ops:
+                logger.logger_ops.log_bridge(inputargs, operations,
+                                             'rewritten', faildescr,
+                                             ops_offset=ops_offset)
 
         debug_start("jit-backend-addr")
         debug_print("bridge out of Guard 0x%x has address 0x%x to 0x%x" %

--- a/rpython/jit/backend/riscv/callbuilder.py
+++ b/rpython/jit/backend/riscv/callbuilder.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.callbuilder import AbstractCallBuilder
+from rpython.jit.backend.llsupport.jump import remap_frame_layout
+from rpython.jit.backend.riscv import registers as r
+from rpython.jit.backend.riscv.arch import ABI_STACK_ALIGN, FLEN, XLEN
+from rpython.jit.metainterp.history import FLOAT
+
+
+class RISCVCallBuilder(AbstractCallBuilder):
+    def __init__(self, assembler, fnloc, arglocs, resloc, restype, ressize):
+        AbstractCallBuilder.__init__(self, assembler, fnloc, arglocs,
+                                     resloc, restype, ressize)
+        self.current_sp = 0
+
+    def prepare_arguments(self):
+        arglocs = self.arglocs
+
+        non_float_locs = []
+        non_float_regs = []
+        float_locs = []
+        float_regs = []
+        stack_locs = []
+
+        free_regs = [r.x17, r.x16, r.x15, r.x14, r.x13, r.x12, r.x11, r.x10]
+        free_float_regs = [r.f17, r.f16, r.f15, r.f14, r.f13, r.f12, r.f11,
+                           r.f10]
+
+        # Collect argument registers.
+        stack_adj_offset = 0
+        for arg in arglocs:
+            if arg.type == FLOAT:
+                if free_float_regs:
+                    float_locs.append(arg)
+                    float_regs.append(free_float_regs.pop())
+                elif free_regs:
+                    # If float registers are exhausted but integer registers
+                    # are still available, use integer registers.
+                    non_float_locs.append(arg)
+                    non_float_regs.append(free_regs.pop())
+                else:
+                    stack_adj_offset += FLEN
+                    stack_locs.append(arg)
+            else:
+                if free_regs:
+                    non_float_locs.append(arg)
+                    non_float_regs.append(free_regs.pop())
+                else:
+                    stack_adj_offset += XLEN
+                    stack_locs.append(arg)
+
+        if stack_locs:
+            # Adjust the stack pointer.
+            stack_adj_offset = ((stack_adj_offset + ABI_STACK_ALIGN - 1)
+                                    // ABI_STACK_ALIGN * ABI_STACK_ALIGN)
+            assert stack_adj_offset <= 2**11, 'too many arguments'
+            self.mc.ADDI(r.sp.value, r.sp.value, -stack_adj_offset)
+            self.current_sp = stack_adj_offset
+
+            # Spill argument values to the stack offset.
+            sp_offset = 0
+            for loc in stack_locs:
+                self.asm.mov_loc_to_raw_stack(loc, sp_offset)
+                sp_offset += FLEN if loc.type == FLOAT else XLEN
+
+        # Assign the callee function address to the `ra` register.
+        #
+        # Note: In the RISC-V backend, the `ra` (`x1`) register is not an
+        # allocatable register, thus it is preserved between
+        # `remap_frame_layout` calls.
+        if self.fnloc.is_core_reg():
+            self.mc.MV(r.ra.value, self.fnloc.value)
+        elif self.fnloc.is_imm():
+            self.mc.load_int_imm(r.ra.value, self.fnloc.value)
+        else:
+            assert self.fnloc.is_stack()
+            self.mc.load_int(r.ra.value, r.jfp.value, self.fnloc.value)
+        self.fnloc = r.ra
+
+        # Move augment values to argument registers.
+        scratch_core_reg = r.x31
+        scratch_fp_reg = r.f31
+
+        remap_frame_layout(self.asm, non_float_locs, non_float_regs,
+                           scratch_core_reg)
+        if float_locs:
+            remap_frame_layout(self.asm, float_locs, float_regs,
+                               scratch_fp_reg)
+
+    def push_gcmap(self):
+        pass
+
+    def pop_gcmap(self):
+        pass
+
+    def emit_raw_call(self):
+        assert self.fnloc is r.ra
+        self.mc.JALR(self.fnloc.value, self.fnloc.value, 0)
+
+    def restore_stack_pointer(self):
+        if self.current_sp == 0:
+            return
+        self.mc.ADDI(r.sp.value, r.sp.value, self.current_sp)
+        self.current_sp = 0
+
+    def load_result(self):
+        resloc = self.resloc
+        if self.restype == 'S':
+            assert False, 'unimplemented'
+        elif self.restype == 'L':
+            assert False, 'unimplemented'
+        if resloc is not None and resloc.is_core_reg():
+            self._ensure_result_bit_extension(resloc, self.ressize,
+                                              self.ressign)
+
+    def _ensure_result_bit_extension(self, resloc, size, signed):
+        if size == XLEN:
+            return
+        assert XLEN == 8, 'implementation below assumes 64-bit backend'
+        if size == 4:
+            if signed:
+                self.mc.SLLI(resloc.value, resloc.value, 32)
+                self.mc.SRAI(resloc.value, resloc.value, 32)
+            else:
+                self.mc.SLLI(resloc.value, resloc.value, 32)
+                self.mc.SRLI(resloc.value, resloc.value, 32)
+        elif size == 2:
+            if signed:
+                self.mc.SLLI(resloc.value, resloc.value, 48)
+                self.mc.SRAI(resloc.value, resloc.value, 48)
+            else:
+                self.mc.SLLI(resloc.value, resloc.value, 48)
+                self.mc.SRLI(resloc.value, resloc.value, 48)
+        elif size == 1:
+            if not signed:
+                self.mc.ANDI(resloc.value, resloc.value, 0xFF)
+            else:
+                self.mc.SLLI(resloc.value, resloc.value, 56)
+                self.mc.SRAI(resloc.value, resloc.value, 56)
+
+    def call_releasegil_addr_and_move_real_arguments(self, fastgil):
+        assert False, 'unimplemented'
+
+    def write_real_errno(self, save_err):
+        assert False, 'unimplemented'
+
+    def read_real_errno(self, save_err):
+        assert False, 'unimplemented'
+
+    def move_real_result_and_call_reacqgil_addr(self, fastgil):
+        assert False, 'unimplemented'

--- a/rpython/jit/backend/riscv/callbuilder.py
+++ b/rpython/jit/backend/riscv/callbuilder.py
@@ -88,10 +88,13 @@ class RISCVCallBuilder(AbstractCallBuilder):
                                scratch_fp_reg)
 
     def push_gcmap(self):
-        pass
+        noregs = self.asm.cpu.gc_ll_descr.is_shadow_stack()
+        gcmap = self.asm._regalloc.get_gcmap([r.x10], noregs=noregs)
+        self.asm.push_gcmap(self.mc, gcmap)
 
     def pop_gcmap(self):
-        pass
+        self.asm._reload_frame_if_necessary(self.mc)
+        self.asm.pop_gcmap(self.mc)
 
     def emit_raw_call(self):
         assert self.fnloc is r.ra

--- a/rpython/jit/backend/riscv/callbuilder.py
+++ b/rpython/jit/backend/riscv/callbuilder.py
@@ -100,7 +100,8 @@ class RISCVCallBuilder(AbstractCallBuilder):
         self.asm.push_gcmap(self.mc, gcmap)
 
     def pop_gcmap(self):
-        self.asm._reload_frame_if_necessary(self.mc)
+        scratch_reg = r.x12  # caller-saved scratch reg other than ra, x31
+        self.asm._reload_frame_if_necessary(self.mc, tmplocs=[scratch_reg])
         self.asm.pop_gcmap(self.mc)
 
     def emit_raw_call(self):

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -76,6 +76,30 @@ class AbstractRISCVBuilder(object):
     def FABS_D(self, rd, rs1):
         self.FSGNJX_D(rd, rs1, rs1)
 
+    # Branch if equal to zero
+    def BEQZ(self, rs1, offset):
+        self.BEQ(rs1, r.zero.value, offset)
+
+    # Branch if not equal to zero
+    def BNEZ(self, rs1, offset):
+        self.BNE(rs1, r.zero.value, offset)
+
+    # Branch if less than or equal to zero
+    def BLEZ(self, rs1, offset):
+        self.BGE(r.zero.value, rs1, offset)
+
+    # Branch if greater than or equal to to zero
+    def BGEZ(self, rs1, offset):
+        self.BGE(rs1, r.zero.value, offset)
+
+    # Branch if less than zero
+    def BLTZ(self, rs1, offset):
+        self.BLT(rs1, r.zero.value, offset)
+
+    # Branch if greater than zero
+    def BGTZ(self, rs1, offset):
+        self.BLT(r.zero.value, rs1, offset)
+
     # Load an XLEN-bit integer from imm(rs1)
     def load_int(self, rd, rs1, imm):
         self.LD(rd, rs1, imm)

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -219,6 +219,23 @@ BRANCH_BUILDER = {
 }
 
 
+class OverwritingBuilder(AbstractRISCVBuilder):
+    def __init__(self, cb, start, size):
+        AbstractRISCVBuilder.__init__(self)
+        self.cb = cb
+        self.index = start
+        self.start = start
+        self.end = start + size
+
+    def currpos(self):
+        return self.index
+
+    def writechar(self, char):
+        assert self.index <= self.end
+        self.cb.overwrite(self.index, char)
+        self.index += 1
+
+
 class InstrBuilder(BlockBuilderMixin, AbstractRISCVBuilder):
     def __init__(self):
         AbstractRISCVBuilder.__init__(self)

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -3,7 +3,7 @@
 from rpython.jit.backend.llsupport.asmmemmgr import BlockBuilderMixin
 from rpython.jit.backend.riscv import registers as r
 from rpython.jit.backend.riscv.arch import (
-    PC_REL_MAX, PC_REL_MIN, SINT12_IMM_MAX, SINT12_IMM_MIN, XLEN)
+    INST_SIZE, PC_REL_MAX, PC_REL_MIN, SINT12_IMM_MAX, SINT12_IMM_MIN, XLEN)
 from rpython.jit.backend.riscv.instruction_builder import (
     gen_all_instr_assemblers)
 from rpython.jit.backend.riscv.instruction_util import (
@@ -20,9 +20,7 @@ _SINT64_MIN = -2**63
 _SINT64_MAX = 2**63 - 1
 
 # Maximum number to load an integer immediate to a register.
-MAX_NUM_INSTS_FOR_LOAD_INT_IMM = (
-    (2  # 2 insts for first 32-bit
-     + ((XLEN * 8 - 32 + 12 - 1) // 12) * 2))  # 2 for each 12-bit
+MAX_NUM_INSTS_FOR_LOAD_INT_IMM = 2 + (2 if XLEN == 8 else 0)
 
 
 class AbstractRISCVBuilder(object):
@@ -31,6 +29,16 @@ class AbstractRISCVBuilder(object):
         self.writechar(chr((word >> 8) & 0xff))
         self.writechar(chr((word >> 16) & 0xff))
         self.writechar(chr((word >> 24) & 0xff))
+
+    def write64(self, word):
+        self.writechar(chr(word & 0xff))
+        self.writechar(chr((word >> 8) & 0xff))
+        self.writechar(chr((word >> 16) & 0xff))
+        self.writechar(chr((word >> 24) & 0xff))
+        self.writechar(chr((word >> 32) & 0xff))
+        self.writechar(chr((word >> 40) & 0xff))
+        self.writechar(chr((word >> 48) & 0xff))
+        self.writechar(chr((word >> 56) & 0xff))
 
     # NOP
     def NOP(self):
@@ -237,10 +245,6 @@ class AbstractRISCVBuilder(object):
 
     # Load an integer constant to a register
     def load_int_imm(self, rd, imm):
-        assert _SINT64_MIN <= imm <= _SINT64_MAX
-        self._load_int_imm(rd, imm)
-
-    def _load_int_imm(self, rd, imm):
         if SINT12_IMM_MIN <= imm <= SINT12_IMM_MAX:
             self.ADDI(rd, r.zero.value, imm)
             return
@@ -251,32 +255,28 @@ class AbstractRISCVBuilder(object):
                 self.ADDIW(rd, rd, lower)
             return
 
-        # Implement trailing zeros with slli
-        shamt = 0
-        while imm & 0x1 == 0:
-            shamt += 1
-            imm >>= 1
-        if shamt:
-            self._load_int_imm(rd, imm)
-            self.SLLI(rd, rd, shamt)
-            return
+        # Add constant to constant pool.
+        assert _SINT64_MIN <= imm <= _SINT64_MAX
+        load_inst_pos = self._get_relative_pos_for_load_imm()
+        self.append_pending_int_constant(load_inst_pos, rd, imm)
+        self.EBREAK()
+        self.NOP()
 
-        # Split lower 12-bit
-        lower = imm & 0xfff
-        if lower >= 0x800:
-            lower -= 0x1000
-            imm += 0x1000
+    # Load a float constant to a float register
+    def load_float_imm(self, rd, imm):
+        load_inst_pos = self._get_relative_pos_for_load_imm()
+        self.append_pending_float_constant(load_inst_pos, rd, imm)
+        self.EBREAK()
+        self.NOP()
 
-        # Move trailing zeros to shamt
-        imm >>= 12
-        shamt = 12
-        while imm & 0x1 == 0:
-            shamt += 1
-            imm >>= 1
-
-        self._load_int_imm(rd, imm)
-        self.SLLI(rd, rd, shamt)
-        self.ADDI(rd, rd, lower)
+    def _get_relative_pos_for_load_imm(self):
+        # This is essentially `get_relative_pos`, which returns the relative
+        # position to emit the instruction.  However, we need a separate
+        # function because `get_relative_pos` is inherited from
+        # `BlockBuilderMixin`.  There will be conflicts between
+        # `OverwritingBuilder` and `InstrBuilder` when RPython toolchain
+        # computes the virtual tables.
+        raise NotImplementedError()
 
 gen_all_instr_assemblers(AbstractRISCVBuilder)
 
@@ -308,6 +308,15 @@ class OverwritingBuilder(AbstractRISCVBuilder):
         self.cb.overwrite(self.index, char)
         self.index += 1
 
+    def append_pending_int_constant(self, load_inst_pos, reg, const_value):
+        self.cb.append_pending_int_constant(load_inst_pos, reg, const_value)
+
+    def append_pending_float_constant(self, load_inst_pos, reg, const_value):
+        self.cb.append_pending_float_constant(load_inst_pos, reg, const_value)
+
+    def _get_relative_pos_for_load_imm(self):
+        return self.index
+
 
 class InstrBuilder(BlockBuilderMixin, AbstractRISCVBuilder):
     def __init__(self):
@@ -317,6 +326,10 @@ class InstrBuilder(BlockBuilderMixin, AbstractRISCVBuilder):
         # ops_offset[None] represents the beginning of the code after the last
         # op (i.e., the tail of the loop)
         self.ops_offset = {}
+
+        # Constant pool for large integer constants or float constants
+        self._int_const_pool = {}    # dict[(inst_pos) -> (reg, const_value)]
+        self._float_const_pool = {}  # dict[(inst_pos) -> (reg, const_value)]
 
     def mark_op(self, op):
         self.ops_offset[op] = self.get_relative_pos()
@@ -331,3 +344,60 @@ class InstrBuilder(BlockBuilderMixin, AbstractRISCVBuilder):
             for i in range(self.get_relative_pos()):
                 f.write(data[i])
             f.close()
+
+    def materialize(self, cpu, allblocks, gcrootmap=None):
+        assert not self._int_const_pool and not self._float_const_pool
+        return BlockBuilderMixin.materialize(self, cpu, allblocks, gcrootmap)
+
+    def append_pending_int_constant(self, load_inst_pos, reg, const_value):
+        self._int_const_pool[load_inst_pos] = (reg, const_value)
+
+    def append_pending_float_constant(self, load_inst_pos, reg, const_value):
+        self._float_const_pool[load_inst_pos] = (reg, const_value)
+
+    def _get_relative_pos_for_load_imm(self):
+        return self.get_relative_pos()
+
+# Emit constants in the constant pool and patch the load instructions.
+def _emit_pending_constants(self):
+    int_const_pool = self._int_const_pool
+    if int_const_pool:
+        self._int_const_pool = {}
+
+    float_const_pool = self._float_const_pool
+    if float_const_pool:
+        self._float_const_pool = {}
+
+    if not int_const_pool and not float_const_pool:
+        return
+
+    # Align to 8 bytes
+    for i in range(self._get_relative_pos_for_load_imm() % 8):
+        self.writechar(chr(0))
+
+    const_value_pos_dict = {}  # dict[const_value -> const_pos]
+
+    for is_float, const_pool in [(True, float_const_pool),
+                                 (False, int_const_pool)]:
+        for inst_pos, pair in const_pool.iteritems():
+            reg, const_value = pair
+
+            # Emit the constant at the end.
+            try:
+                # Re-use the same constant address if possible.
+                const_pos = const_value_pos_dict[const_value]
+            except KeyError:
+                const_pos = self._get_relative_pos_for_load_imm()
+                self.write64(const_value)
+                const_value_pos_dict[const_value] = const_pos
+
+            offset = const_pos - inst_pos
+
+            # Patch the load int instructions.
+            pmc = OverwritingBuilder(self, inst_pos, INST_SIZE * 2)
+            if is_float:
+                pmc.load_float_pc_rel(reg, offset)
+            else:
+                pmc.load_int_pc_rel(reg, offset)
+
+InstrBuilder.emit_pending_constants = _emit_pending_constants

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -3,7 +3,7 @@
 from rpython.jit.backend.llsupport.asmmemmgr import BlockBuilderMixin
 from rpython.jit.backend.riscv import registers as r
 from rpython.jit.backend.riscv.arch import (
-    PC_REL_MAX, PC_REL_MIN, SINT12_IMM_MAX, SINT12_IMM_MIN)
+    PC_REL_MAX, PC_REL_MIN, SINT12_IMM_MAX, SINT12_IMM_MIN, XLEN)
 from rpython.jit.backend.riscv.instruction_builder import (
     gen_all_instr_assemblers)
 from rpython.jit.backend.riscv.instruction_util import (
@@ -18,6 +18,11 @@ _SINT32_MIN = -2**31
 _SINT32_MAX = 2**31 - 1
 _SINT64_MIN = -2**63
 _SINT64_MAX = 2**63 - 1
+
+# Maximum number to load an integer immediate to a register.
+MAX_NUM_INSTS_FOR_LOAD_INT_IMM = (
+    (2  # 2 insts for first 32-bit
+     + ((XLEN * 8 - 32 + 12 - 1) // 12) * 2))  # 2 for each 12-bit
 
 
 class AbstractRISCVBuilder(object):

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -24,6 +24,10 @@ class AbstractRISCVBuilder(object):
         self.writechar(chr((word >> 16) & 0xff))
         self.writechar(chr((word >> 24) & 0xff))
 
+    # NOP
+    def NOP(self):
+        self.ADDI(r.zero.value, r.zero.value, 0)
+
     # Move register
     def MV(self, rd, rs1):
         self.ADDI(rd, rs1, 0)

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -172,6 +172,26 @@ class AbstractRISCVBuilder(object):
     def store_float(self, rs2, rs1, imm):
         self.FSD(rs2, rs1, imm)
 
+    # Load an FLEN-bit float from rs1+imm (imm can be a large constant)
+    def load_float_from_base_plus_offset(self, rd, rs1, imm, tmp):
+        assert tmp != rs1
+        if check_imm_arg(imm):
+            self.load_float(rd, rs1, imm)
+        else:
+            self.load_int_imm(tmp, imm)
+            self.ADD(tmp, tmp, rs1)
+            self.load_float(rd, tmp, 0)
+
+    # Store an FLEN-bit float to rs1+imm (imm can be a large constant)
+    def store_float_to_base_plus_offset(self, rs2, rs1, imm, tmp):
+        assert tmp != rs1
+        if check_imm_arg(imm):
+            self.store_float(rs2, rs1, imm)
+        else:
+            self.load_int_imm(tmp, imm)
+            self.ADD(tmp, tmp, rs1)
+            self.store_float(rs2, tmp, 0)
+
     # Load a rffi.INT from imm(rs1)
     def load_rffi_int(self, rd, rs1, imm):
         # Note: On RV64 (LP64), rffi.INT is 32-bit signed integer.

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -114,6 +114,20 @@ class AbstractRISCVBuilder(object):
     def store_int(self, rs2, rs1, imm):
         self.SD(rs2, rs1, imm)
 
+    # Atomic-swap XLEN-bit integer.  Load old value to rd and store new value
+    # from rs2 to memory address 0(rs1).
+    def atomic_swap_int(self, rd, rs2, rs1, acrl):
+        self.AMOSWAP_D(rd, rs2, rs1, acrl)
+
+    # Load-and-reserve XLEN-bit integer from memory address 0(rs1) to rd.
+    def load_reserve_int(self, rd, rs1, acrl):
+        self.LR_D(rd, rs1, acrl)
+
+    # Store-conditional XLEN-bit integer rs2 to memory address 0(rs1) and write
+    # zero to rd on success (conversely, non-zero to rd on failure).
+    def store_conditional_int(self, rd, rs2, rs1, acrl):
+        self.SC_D(rd, rs2, rs1, acrl)
+
     # Load an FLEN-bit float from imm(rs1)
     def load_float(self, rd, rs1, imm):
         self.FLD(rd, rs1, imm)

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -154,6 +154,12 @@ class AbstractRISCVBuilder(object):
         self.AUIPC(rd, upper)
         self.JALR(rd, rd, lower)
 
+    # Absolute jump
+    def jal_abs(self, rd, abs_addr):
+        scratch_reg = r.x31
+        self.load_int_imm(scratch_reg.value, abs_addr)
+        self.JALR(rd, scratch_reg.value, 0)
+
     # Load an integer constant to a register
     def load_int_imm(self, rd, imm):
         assert _SINT64_MIN <= imm <= _SINT64_MAX

--- a/rpython/jit/backend/riscv/codebuilder.py
+++ b/rpython/jit/backend/riscv/codebuilder.py
@@ -6,6 +6,8 @@ from rpython.jit.backend.riscv.arch import (
     PC_REL_MAX, PC_REL_MIN, SINT12_IMM_MAX, SINT12_IMM_MIN)
 from rpython.jit.backend.riscv.instruction_builder import (
     gen_all_instr_assemblers)
+from rpython.jit.backend.riscv.instruction_util import (
+    COND_BEQ, COND_BGE, COND_BGEU, COND_BLT, COND_BLTU, COND_BNE)
 from rpython.rlib.objectmodel import we_are_translated
 from rpython.rtyper.lltypesystem import rffi
 from rpython.tool.udir import udir
@@ -204,6 +206,17 @@ class AbstractRISCVBuilder(object):
         self.ADDI(rd, rd, lower)
 
 gen_all_instr_assemblers(AbstractRISCVBuilder)
+
+BRANCH_BUILDER = {
+    COND_BEQ: AbstractRISCVBuilder.BEQ,
+    COND_BNE: AbstractRISCVBuilder.BNE,
+
+    COND_BGE: AbstractRISCVBuilder.BGE,
+    COND_BLT: AbstractRISCVBuilder.BLT,
+
+    COND_BGEU: AbstractRISCVBuilder.BGEU,
+    COND_BLTU: AbstractRISCVBuilder.BLTU,
+}
 
 
 class InstrBuilder(BlockBuilderMixin, AbstractRISCVBuilder):

--- a/rpython/jit/backend/riscv/instruction_builder.py
+++ b/rpython/jit/backend/riscv/instruction_builder.py
@@ -121,6 +121,33 @@ def _gen_a_type_instr_assembler(opcode, funct25):
         self.write32(bits)
     return assemble
 
+def _gen_f_type_instr_assembler(opcode, funct3, fm):
+    bits = (fm << 28) | (funct3 << 12) | opcode
+    def assemble(self, pred, succ):
+        pred = int(pred) << 24
+        succ = int(succ) << 20
+        self.write32(bits | pred | succ)
+    return assemble
+
+def _gen_amo2_type_instr_assembler(opcode, funct3, funct5):
+    bits = (funct5 << 27) | (funct3 << 12) | opcode
+    def assemble(self, rd, rs1, aqrl):
+        rd = int(rd) << 7
+        rs1 = int(rs1) << 15
+        aqrl = int(aqrl) << 25
+        self.write32(bits | aqrl | rs1 | rd)
+    return assemble
+
+def _gen_amo3_type_instr_assembler(opcode, funct3, funct5):
+    bits = (funct5 << 27) | (funct3 << 12) | opcode
+    def assemble(self, rd, rs2, rs1, aqrl):
+        rd = int(rd) << 7
+        rs1 = int(rs1) << 15
+        rs2 = int(rs2) << 20
+        aqrl = int(aqrl) << 25
+        self.write32(bits | aqrl | rs2 | rs1 | rd)
+    return assemble
+
 _INSTR_TYPE_DICT = {
     'R': _gen_r_type_instr_assembler,
     'I': _gen_i_type_instr_assembler,
@@ -135,6 +162,9 @@ _INSTR_TYPE_DICT = {
     'I12': _gen_i12_type_instr_assembler,
     'I12_RM': _gen_i12_rm_type_instr_assembler,
     'A': _gen_a_type_instr_assembler,
+    'F': _gen_f_type_instr_assembler,
+    'AMO2': _gen_amo2_type_instr_assembler,
+    'AMO3': _gen_amo3_type_instr_assembler,
 }
 
 def _gen_instr_assembler(instr_type, fields):

--- a/rpython/jit/backend/riscv/instruction_util.py
+++ b/rpython/jit/backend/riscv/instruction_util.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from rpython.jit.backend.riscv.arch import SINT12_IMM_MAX, SINT12_IMM_MIN
 from rpython.jit.metainterp.resoperation import rop
 
 
@@ -51,6 +52,9 @@ _NEGATED_BRANCH_INST = [
 def get_negated_branch_inst(branch_inst):
     """Returns the branch op with the negated condition."""
     return _NEGATED_BRANCH_INST[branch_inst]
+
+def check_imm_arg(imm):
+    return imm >= SINT12_IMM_MIN and imm <= SINT12_IMM_MAX
 
 def check_simm21_arg(imm):
     return imm >= -2**20 and imm <= 2**20 - 1 and imm & 0x1 == 0

--- a/rpython/jit/backend/riscv/instruction_util.py
+++ b/rpython/jit/backend/riscv/instruction_util.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+def check_simm21_arg(imm):
+    return imm >= -2**20 and imm <= 2**20 - 1 and imm & 0x1 == 0

--- a/rpython/jit/backend/riscv/instruction_util.py
+++ b/rpython/jit/backend/riscv/instruction_util.py
@@ -1,4 +1,56 @@
 #!/usr/bin/env python
 
+from rpython.jit.metainterp.resoperation import rop
+
+
+_COMPARE_OPS_FOR_BRANCH_INST = {
+    rop.INT_LT: None,
+    rop.INT_LE: None,
+    rop.INT_EQ: None,
+    rop.INT_NE: None,
+    rop.INT_GT: None,
+    rop.INT_GE: None,
+
+    rop.UINT_LT: None,
+    rop.UINT_LE: None,
+    rop.UINT_GT: None,
+    rop.UINT_GE: None,
+
+    rop.INT_IS_ZERO: None,
+    rop.INT_IS_TRUE: None,
+
+    rop.PTR_EQ: None,
+    rop.PTR_NE: None,
+    rop.INSTANCE_PTR_EQ: None,
+    rop.INSTANCE_PTR_NE: None,
+}
+
+def can_fuse_into_compare_and_branch(opnum):
+    """Returns whether a ResOperation can be fused into the following
+    GuardResOp or COND_CALL op."""
+    return opnum in _COMPARE_OPS_FOR_BRANCH_INST
+
+COND_INVALID = 0
+COND_BEQ = 1
+COND_BNE = 2
+COND_BGE = 3
+COND_BLT = 4
+COND_BGEU = 5
+COND_BLTU = 6
+
+_NEGATED_BRANCH_INST = [
+    COND_INVALID,
+    COND_BNE,
+    COND_BEQ,
+    COND_BLT,
+    COND_BGE,
+    COND_BLTU,
+    COND_BGEU,
+]
+
+def get_negated_branch_inst(branch_inst):
+    """Returns the branch op with the negated condition."""
+    return _NEGATED_BRANCH_INST[branch_inst]
+
 def check_simm21_arg(imm):
     return imm >= -2**20 and imm <= 2**20 - 1 and imm & 0x1 == 0

--- a/rpython/jit/backend/riscv/locations.py
+++ b/rpython/jit/backend/riscv/locations.py
@@ -147,20 +147,16 @@ def get_fp_offset(base_ofs, position):
     return base_ofs + XLEN * (position + JITFRAME_FIXED_SIZE)
 
 
-class ConstFloatLoc(AssemblerLocation):
-    """This class represents an imm float value which is stored in memory at
-    the address stored in the field value"""
+class FloatImmLocation(AssemblerLocation):
+    """This class represents an imm float value (bitcasted to integer)"""
     _immutable_ = True
     type = FLOAT
 
     def __init__(self, value):
         self.value = value
 
-    def get_addr(self):
-        return self.value
-
     def __repr__(self):
-        return "imm_float(stored at %d)" % (self.value)
+        return "imm_float(bits=%x)" % (self.value)
 
     def is_imm_float(self):
         return True

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -1287,6 +1287,12 @@ class OpAssembler(BaseAssembler):
                                   resloc=None, restype=VOID, ressize=0)
             cb.emit_no_collect()
 
+    def emit_op_enter_portal_frame(self, op, arglocs):
+        pass
+
+    def emit_op_leave_portal_frame(self, op, arglocs):
+        pass
+
     def emit_op_jit_debug(self, op, arglocs):
         pass
 

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -1146,6 +1146,16 @@ class OpAssembler(BaseAssembler):
         index = op.getarg(0).getint()
         self.load_from_gc_table(res.value, index)
 
+    def emit_op_jit_debug(self, op, arglocs):
+        pass
+
+    def emit_op_increment_debug_counter(self, op, arglocs):
+        base_loc = arglocs[0]
+        scratch_reg = r.x31
+        self.mc.load_int(scratch_reg.value, base_loc.value, 0)
+        self.mc.ADDI(scratch_reg.value, scratch_reg.value, 1)
+        self.mc.store_int(scratch_reg.value, base_loc.value, 0)
+
     def emit_op_label(self, op, arglocs):
         pass
 

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -482,7 +482,7 @@ class OpAssembler(BaseAssembler):
         self.push_gcmap(self.mc, gcmap)
 
         # Load callee function address.
-        callee_func_addr_reg = r.x31
+        callee_func_addr_reg = r.x30
         callee_func_addr = rffi.cast(lltype.Signed, op.getarg(1).getint())
         self.mc.load_int_imm(callee_func_addr_reg.value, callee_func_addr)
 
@@ -508,7 +508,7 @@ class OpAssembler(BaseAssembler):
         # If this is a COND_CALL_VALUE, we need to move the result in place
         # from its current location
         if res_loc is not None:
-            self.mc.MV(res_loc.value, r.x31.value)
+            self.mc.MV(res_loc.value, r.x30.value)
 
         self.pop_gcmap(self.mc)
 

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -599,6 +599,9 @@ class OpAssembler(BaseAssembler):
         exc_tp_loc, exc_val_loc = arglocs
         self._restore_exception(self.mc, exc_val_loc, exc_tp_loc)
 
+    def emit_op_check_memory_error(self, op, arglocs):
+        self.propagate_memoryerror_if_reg_is_null(arglocs[0])
+
     def _emit_op_same_as(self, op, arglocs):
         l0, res = arglocs
         if l0 is not res:

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -30,6 +30,8 @@ class OpAssembler(BaseAssembler):
         else:
             self.mc.ADD(res.value, l0.value, l1.value)
 
+    emit_op_nursery_ptr_increment = emit_op_int_add
+
     def emit_op_int_sub(self, op, arglocs):
         l0, l1, res = arglocs
         assert not l0.is_imm()

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -4,6 +4,7 @@ from rpython.jit.backend.llsupport.assembler import BaseAssembler, GuardToken
 from rpython.jit.backend.llsupport.gcmap import allocate_gcmap
 from rpython.jit.backend.riscv import registers as r
 from rpython.jit.backend.riscv.arch import JITFRAME_FIXED_SIZE
+from rpython.jit.backend.riscv.codebuilder import BRANCH_BUILDER
 from rpython.jit.backend.riscv.rounding_modes import DYN, RTZ
 from rpython.jit.metainterp.history import AbstractFailDescr
 from rpython.jit.metainterp.resoperation import rop
@@ -278,6 +279,16 @@ class OpAssembler(BaseAssembler):
         else:
             self.mc.BEQ(l0.value, l1.value, 8)
         self._emit_pending_guard(op, arglocs[2:])
+
+    def _emit_guard_op_guard_bool_op(self, op, guard_op, arglocs,
+                                     guard_branch_inst):
+        l0 = arglocs[0]
+        l1 = arglocs[1]
+        BRANCH_BUILDER[guard_branch_inst](self.mc, l0.value, l1.value, 8)
+        self._emit_pending_guard(guard_op, arglocs[2:])
+
+    emit_guard_op_guard_true  = _emit_guard_op_guard_bool_op
+    emit_guard_op_guard_false = _emit_guard_op_guard_bool_op
 
     def _emit_op_same_as(self, op, arglocs):
         l0, res = arglocs

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -305,6 +305,14 @@ class OpAssembler(BaseAssembler):
         l0, res = arglocs
         self.mc.FCVT_D_L(res.value, l0.value, DYN.value)
 
+    def emit_op_convert_float_bytes_to_longlong(self, op, arglocs):
+        l0, res = arglocs
+        self.mc.FMV_X_D(res.value, l0.value)
+
+    def emit_op_convert_longlong_bytes_to_float(self, op, arglocs):
+        l0, res = arglocs
+        self.mc.FMV_D_X(res.value, l0.value)
+
     def _build_guard_token(self, op, frame_depth, arglocs, offset):
         descr = op.getdescr()
         assert isinstance(descr, AbstractFailDescr)

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -171,7 +171,10 @@ class OpAssembler(BaseAssembler):
             self.mc.XOR(res.value, l0.value, l1.value)
             self.mc.SEQZ(res.value, res.value)
 
+    emit_op_ptr_eq = emit_op_instance_ptr_eq = emit_op_int_eq
+
     emit_comp_op_int_eq = emit_op_int_eq
+    emit_comp_op_ptr_eq = emit_op_int_eq
 
     def emit_op_int_ne(self, op, arglocs):
         l0, l1, res = arglocs
@@ -186,7 +189,10 @@ class OpAssembler(BaseAssembler):
             self.mc.XOR(res.value, l0.value, l1.value)
             self.mc.SNEZ(res.value, res.value)
 
+    emit_op_ptr_ne = emit_op_instance_ptr_ne = emit_op_int_ne
+
     emit_comp_op_int_ne = emit_op_int_ne
+    emit_comp_op_ptr_ne = emit_op_int_ne
 
     def emit_op_int_is_true(self, op, arglocs):
         l0, res = arglocs

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -179,6 +179,12 @@ class OpAssembler(BaseAssembler):
         l0, res = arglocs
         self.mc.SEQZ(res.value, l0.value)
 
+    def emit_op_int_force_ge_zero(self, op, arglocs):
+        l0, res = arglocs
+        self.mc.MV(res.value, l0.value)
+        self.mc.BGEZ(l0.value, 8)  # Skip next instruction if l0 >= 0
+        self.mc.MV(res.value, r.zero.value)
+
     def emit_op_int_signext(self, op, arglocs):
         l0, l1, res = arglocs
 

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -366,6 +366,10 @@ class OpAssembler(BaseAssembler):
     emit_op_cast_ptr_to_int = _emit_op_same_as
     emit_op_cast_int_to_ptr = _emit_op_same_as
 
+    def math_sqrt(self, op, arglocs):
+        l1, res = arglocs
+        self.mc.FSQRT_D(res.value, l1.value)
+
     def _emit_op_call(self, op, arglocs):
         is_call_release_gil = rop.is_call_release_gil(op.getopnum())
 

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -1440,10 +1440,10 @@ class OpAssembler(BaseAssembler):
             cb.emit_no_collect()
 
     def emit_op_enter_portal_frame(self, op, arglocs):
-        pass
+        self.enter_portal_frame(op)
 
     def emit_op_leave_portal_frame(self, op, arglocs):
-        pass
+        self.leave_portal_frame(op)
 
     def emit_op_keepalive(self, op, arglocs):
         pass

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -1293,6 +1293,9 @@ class OpAssembler(BaseAssembler):
     def emit_op_leave_portal_frame(self, op, arglocs):
         pass
 
+    def emit_op_keepalive(self, op, arglocs):
+        pass
+
     def emit_op_jit_debug(self, op, arglocs):
         pass
 

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -601,7 +601,8 @@ class OpAssembler(BaseAssembler):
         scratch2_reg = r.ra
         offset = self.cpu.vtable_offset
         if offset is not None:
-            self.mc.load_int(scratch_reg.value, obj_loc.value, offset)
+            self.mc.load_int_from_base_plus_offset(scratch_reg.value,
+                                                   obj_loc.value, offset)
             self.mc.load_int_imm(scratch2_reg.value, cls_loc.value)
             self.mc.BEQ(scratch_reg.value, scratch2_reg.value, 8)
         else:
@@ -634,7 +635,8 @@ class OpAssembler(BaseAssembler):
         offset = self.cpu.vtable_offset
         if offset is not None:
             # Test `type(obj) == cls`
-            self.mc.load_int(scratch_reg.value, obj_loc.value, offset)
+            self.mc.load_int_from_base_plus_offset(scratch_reg.value,
+                                                   obj_loc.value, offset)
             self.mc.load_int_imm(scratch2_reg.value, cls_loc.value)
             self.mc.BEQ(scratch_reg.value, scratch2_reg.value, 8)
         else:
@@ -673,10 +675,13 @@ class OpAssembler(BaseAssembler):
         subclassrange_min_offset = self.cpu.subclassrange_min_offset
         if offset is not None:
             # Read this field to get the vtable pointer
-            self.mc.load_int(scratch_reg.value, obj_loc.value, offset)
+            self.mc.load_int_from_base_plus_offset(scratch_reg.value,
+                                                   obj_loc.value, offset)
             # Read the vtable's subclassrange_min field
-            self.mc.load_int(scratch_reg.value, scratch_reg.value,
-                             subclassrange_min_offset)
+            self.mc.load_int_from_base_plus_offset(scratch_reg.value,
+                                                   scratch_reg.value,
+                                                   subclassrange_min_offset,
+                                                   tmp=scratch2_reg)
         else:
             # Read the typeid
             self._emit_load_typeid_from_obj(scratch_reg, obj_loc)

--- a/rpython/jit/backend/riscv/opassembler.py
+++ b/rpython/jit/backend/riscv/opassembler.py
@@ -19,6 +19,7 @@ from rpython.rlib.objectmodel import we_are_translated
 from rpython.rlib.rarithmetic import r_uint
 from rpython.rtyper import rclass
 from rpython.rtyper.lltypesystem import lltype, rffi
+from rpython.rtyper.lltypesystem.lloperation import llop
 
 
 class OpAssembler(BaseAssembler):
@@ -1518,15 +1519,18 @@ class OpAssembler(BaseAssembler):
 
 
 def not_implemented_op(self, op, arglocs):
-    print "[riscv/asm] %s not implemented" % op.getopname()
+    llop.debug_print(lltype.Void,
+                     '[riscv/asm] %s not implemented' % op.getopname())
     raise NotImplementedError(op)
 
 def not_implemented_comp_op(self, op, arglocs):
-    print "[riscv/asm] %s not implemented" % op.getopname()
+    llop.debug_print(lltype.Void,
+                     '[riscv/asm] %s not implemented' % op.getopname())
     raise NotImplementedError(op)
 
 def not_implemented_guard_op(self, op, guard_op, arglocs, guard_branch_inst):
-    print "[riscv/asm] %s not implemented" % op.getopname()
+    llop.debug_print(lltype.Void,
+                     '[riscv/asm] %s not implemented' % op.getopname())
     raise NotImplementedError(op)
 
 asm_operations = [not_implemented_op] * (rop._LAST + 1)

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -801,15 +801,22 @@ class Regalloc(BaseRegalloc):
         _gen_prepare_guard_op_guard_overflow_op(False)
 
     def prepare_op_guard_class(self, op):
-        boxes = op.getarglist()
-        a0, a1 = boxes
-        obj_loc = self.make_sure_var_in_reg(a0, boxes)
-        cls_loc = self.make_sure_var_in_reg(a1, boxes)
+        obj_loc = self.make_sure_var_in_reg(op.getarg(0))
+        cls_loc = ImmLocation(rffi.cast(lltype.Signed, op.getarg(1).getint()))
         # Note[#dont_free_vars]: Do not call `possibly_free_vars_for_op` or
         # `free_temp_vars`.
         return [obj_loc, cls_loc] + self._prepare_guard_arglocs(op)
 
     prepare_op_guard_nonnull_class = prepare_op_guard_class
+
+    prepare_op_guard_gc_type = prepare_op_guard_class
+    prepare_op_guard_subclass = prepare_op_guard_class
+
+    def prepare_op_guard_is_object(self, op):
+        obj_loc = self.make_sure_var_in_reg(op.getarg(0))
+        # Note[#dont_free_vars]: Do not call `possibly_free_vars_for_op` or
+        # `free_temp_vars`.
+        return [obj_loc] + self._prepare_guard_arglocs(op)
 
     def prepare_op_guard_not_invalidated(self, op):
         return self._prepare_guard_arglocs(op)

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -1031,7 +1031,9 @@ class Regalloc(BaseRegalloc):
             arglocs = self._prepare_call(op, save_all_regs=True,
                                          first_arg_index=2)
         elif rop.is_call_assembler(op.getopnum()):
-            assert False, 'unimplemented'
+            locs = self.locs_for_call_assembler(op)
+            resloc = self._call(op, gc_level=2)
+            arglocs = locs + [resloc]
         else:
             assert rop.is_call_may_force(op.getopnum())
             arglocs = self._prepare_call(op, save_all_regs=True)

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -754,7 +754,9 @@ class Regalloc(BaseRegalloc):
         if effectinfo is not None:
             oopspecindex = effectinfo.oopspecindex
             if oopspecindex == EffectInfo.OS_MATH_SQRT:
-                assert False, 'unimplemented'
+                args = self._prepare_op_math_sqrt(op)
+                self.assembler.math_sqrt(op, args)
+                return
             elif oopspecindex == EffectInfo.OS_THREADLOCALREF_GET:
                 assert False, 'unimplemented'
         return self._prepare_call(op)

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -1065,6 +1065,9 @@ class Regalloc(BaseRegalloc):
     def prepare_op_leave_portal_frame(self, op):
         return []
 
+    def prepare_op_keepalive(self, op):
+        return []
+
     def prepare_op_jit_debug(self, op):
         return []
 

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -863,6 +863,16 @@ class Regalloc(BaseRegalloc):
         guard_arglocs = self._prepare_guard_arglocs(guard_op)
         return arglocs + guard_arglocs, len(arglocs)
 
+    def prepare_op_guard_not_forced_2(self, op):
+        self.rm.before_call(force_store=op.getfailargs(), save_all_regs=True)
+        self.fprm.before_call(force_store=op.getfailargs(), save_all_regs=True)
+        arglocs = self._prepare_guard_arglocs(op)
+        return arglocs
+
+    def prepare_op_force_token(self, op):
+        res = self.force_allocate_reg(op)
+        return [res]
+
     def prepare_op_load_from_gc_table(self, op):
         res = self.force_allocate_reg(op)
         return [res]

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -106,10 +106,13 @@ class CoreRegisterManager(RISCVRegisterManager):
         return r.x10
 
     def convert_to_imm(self, c):
+        # Note: `c.value` below have different types.
         if isinstance(c, ConstInt):
             val = rffi.cast(lltype.Signed, c.value)
-            return ImmLocation(val)
-        raise NotImplementedError('imm type not supported')
+        else:
+            assert isinstance(c, ConstPtr)
+            val = rffi.cast(lltype.Signed, c.value)
+        return ImmLocation(val)
 
     def return_constant(self, v, forbidden_vars=[], selected_reg=None):
         self._check_type(v)
@@ -120,7 +123,7 @@ class CoreRegisterManager(RISCVRegisterManager):
                 assert isinstance(v, ConstPtr)
                 reg_type = REF
 
-            if v.value == 0 and selected_reg is None:
+            if not v.nonnull() and selected_reg is None:
                 return r.zero
 
             loc = self.get_scratch_reg(reg_type, forbidden_vars,

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -859,7 +859,7 @@ class Regalloc(BaseRegalloc):
             assert False, 'unimplemented'
         else:
             assert rop.is_call_may_force(op.getopnum())
-            assert False, 'unimplemented'
+            arglocs = self._prepare_call(op, save_all_regs=True)
         guard_arglocs = self._prepare_guard_arglocs(guard_op)
         return arglocs + guard_arglocs, len(arglocs)
 

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -1054,6 +1054,15 @@ class Regalloc(BaseRegalloc):
         res = self.force_allocate_reg(op)
         return [res]
 
+    def prepare_op_jit_debug(self, op):
+        return []
+
+    def prepare_op_increment_debug_counter(self, op):
+        boxes = op.getarglist()
+        a0 = boxes[0]
+        base_loc = self.make_sure_var_in_reg(a0, boxes)
+        return [base_loc]
+
     def compute_hint_frame_locations(self, operations):
         # Fill in the `hint_frame_pos` dictionary of `frame_manager` based on
         # the JUMP at the end of the loop, by looking at where we would like

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -779,6 +779,10 @@ class Regalloc(BaseRegalloc):
         exc_val_loc = self.make_sure_var_in_reg(boxes[1], boxes)
         return [exc_tp_loc, exc_val_loc]
 
+    def prepare_op_check_memory_error(self, op):
+        l0 = self.make_sure_var_in_reg(op.getarg(0))
+        return [l0]
+
     def _prepare_op_same_as(self, op):
         boxes = op.getarglist()
         a0 = boxes[0]

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -811,6 +811,9 @@ class Regalloc(BaseRegalloc):
 
     prepare_op_guard_nonnull_class = prepare_op_guard_class
 
+    def prepare_op_guard_not_invalidated(self, op):
+        return self._prepare_guard_arglocs(op)
+
     def prepare_op_guard_exception(self, op):
         boxes = op.getarglist()
 

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -710,6 +710,12 @@ class Regalloc(BaseRegalloc):
             if var is not None:
                 self.possibly_free_var(var)
 
+    def force_spill_var(self, var):
+        if var.type == FLOAT:
+            self.fprm.force_spill_var(var)
+        else:
+            self.rm.force_spill_var(var)
+
     def free_temp_vars(self):
         self.rm.free_temp_vars()
         self.fprm.free_temp_vars()

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -435,6 +435,23 @@ class Regalloc(BaseRegalloc):
     prepare_op_int_invert = _prepare_op_unary_op
     prepare_op_int_is_zero = _prepare_op_unary_op
 
+    def prepare_op_int_signext(self, op):
+        a0, a1 = op.getarglist()
+        l0 = self.loc(a0)
+        if l0.is_stack():
+            # If a0 is on the stack, we can perform sign extension directly
+            # with LB/LH/LW.
+            pass
+        else:
+            # If a0 is not on the stack, we make sure it is in the register and
+            # perform sign extension with SLLI/SRAI.
+            l0 = self.make_sure_var_in_reg(a0)
+        l1 = self.convert_to_imm(a1)  # num_bytes
+        self.possibly_free_vars_for_op(op)
+        self.free_temp_vars()
+        res = self.force_allocate_reg(op)
+        return [l0, l1, res]
+
     def _gen_prepare_op_float_binary_op(swap_operands):
         def _prepare_op_float_binary_op(self, op):
             boxes = op.getarglist()

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -11,7 +11,7 @@ from rpython.jit.backend.riscv.arch import (
     JITFRAME_FIXED_SIZE, SHAMT_MAX, SINT12_IMM_MAX, SINT12_IMM_MIN, XLEN)
 from rpython.jit.backend.riscv.instruction_util import (
     COND_BEQ, COND_BGE, COND_BGEU, COND_BLT, COND_BLTU, COND_BNE, COND_INVALID,
-    get_negated_branch_inst)
+    check_imm_arg, get_negated_branch_inst)
 from rpython.jit.backend.riscv.locations import (
     ConstFloatLoc, ImmLocation, StackLocation, get_fp_offset)
 from rpython.jit.backend.riscv.opassembler import asm_comp_operations
@@ -182,9 +182,6 @@ class FloatRegisterManager(RISCVRegisterManager):
         self.temp_boxes.append(box)
         return reg
 
-
-def check_imm_arg(imm):
-    return imm >= SINT12_IMM_MIN and imm <= SINT12_IMM_MAX
 
 def check_imm_box(arg):
     if isinstance(arg, ConstInt):

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -758,6 +758,17 @@ class Regalloc(BaseRegalloc):
     prepare_guard_op_guard_no_overflow = \
         _gen_prepare_guard_op_guard_overflow_op(False)
 
+    def prepare_op_guard_class(self, op):
+        boxes = op.getarglist()
+        a0, a1 = boxes
+        obj_loc = self.make_sure_var_in_reg(a0, boxes)
+        cls_loc = self.make_sure_var_in_reg(a1, boxes)
+        # Note[#dont_free_vars]: Do not call `possibly_free_vars_for_op` or
+        # `free_temp_vars`.
+        return [obj_loc, cls_loc] + self._prepare_guard_arglocs(op)
+
+    prepare_op_guard_nonnull_class = prepare_op_guard_class
+
     def prepare_op_guard_exception(self, op):
         boxes = op.getarglist()
 

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -1059,6 +1059,12 @@ class Regalloc(BaseRegalloc):
         res = self.force_allocate_reg(op)
         return [res]
 
+    def prepare_op_enter_portal_frame(self, op):
+        return []
+
+    def prepare_op_leave_portal_frame(self, op):
+        return []
+
     def prepare_op_jit_debug(self, op):
         return []
 

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -943,7 +943,9 @@ class Regalloc(BaseRegalloc):
                 self.assembler.math_sqrt(op, args)
                 return
             elif oopspecindex == EffectInfo.OS_THREADLOCALREF_GET:
-                assert False, 'unimplemented'
+                args = self._prepare_op_threadlocalref_get(op)
+                self.assembler.threadlocalref_get(op, args)
+                return
         return self._prepare_call(op)
 
     prepare_op_call_i = _prepare_op_call

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -801,6 +801,11 @@ class Regalloc(BaseRegalloc):
         func_addr = op.getarg(1)
         assert isinstance(func_addr, Const)
 
+        # Allocate `r.x30` as a scratch reg because `cond_call_slowpath`
+        # returns the result with `r.x30` and uses `r.x31` as a scratch
+        # register internally.
+        self.rm.get_scratch_reg(INT, selected_reg=r.x30)
+
         # Move function arguments to argument registers.
         _FUNC_ARGS = [r.x10, r.x11, r.x12, r.x13, r.x14, r.x15, r.x16, r.x17]
         allocated_arg_vars = []

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -14,7 +14,7 @@ from rpython.jit.backend.riscv.instruction_util import (
     COND_BEQ, COND_BGE, COND_BGEU, COND_BLT, COND_BLTU, COND_BNE, COND_INVALID,
     check_imm_arg, get_negated_branch_inst)
 from rpython.jit.backend.riscv.locations import (
-    ConstFloatLoc, ImmLocation, StackLocation, get_fp_offset)
+    FloatImmLocation, ImmLocation, StackLocation, get_fp_offset)
 from rpython.jit.backend.riscv.opassembler import asm_comp_operations
 from rpython.jit.codewriter import longlong
 from rpython.jit.codewriter.effectinfo import EffectInfo
@@ -161,10 +161,8 @@ class FloatRegisterManager(RISCVRegisterManager):
         return r.f10
 
     def convert_to_imm(self, c):
-        adr = self.assembler.datablockwrapper.malloc_aligned(8, 8)
-        x = c.getfloatstorage()
-        rffi.cast(rffi.CArrayPtr(longlong.FLOATSTORAGE), adr)[0] = x
-        return ConstFloatLoc(adr)
+        imm_bits = longlong.extract_bits(c.getfloatstorage())
+        return FloatImmLocation(imm_bits)
 
     def return_constant(self, v, forbidden_vars=[], selected_reg=None):
         self._check_type(v)

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -515,6 +515,8 @@ class Regalloc(BaseRegalloc):
     prepare_op_float_abs = _prepare_op_unary_op
     prepare_op_cast_float_to_int = _prepare_op_unary_op
     prepare_op_cast_int_to_float = _prepare_op_unary_op
+    prepare_op_convert_float_bytes_to_longlong = _prepare_op_unary_op
+    prepare_op_convert_longlong_bytes_to_float= _prepare_op_unary_op
 
     def _prepare_guard_arglocs(self, op):
         arglocs = [None] * (len(op.getfailargs()) + 1)

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -434,6 +434,7 @@ class Regalloc(BaseRegalloc):
     prepare_op_int_neg = _prepare_op_unary_op
     prepare_op_int_invert = _prepare_op_unary_op
     prepare_op_int_is_zero = _prepare_op_unary_op
+    prepare_op_int_force_ge_zero = _prepare_op_unary_op
 
     def prepare_op_int_signext(self, op):
         a0, a1 = op.getarglist()

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -442,6 +442,12 @@ class Regalloc(BaseRegalloc):
     prepare_comp_op_int_eq = prepare_op_int_eq
     prepare_comp_op_int_ne = prepare_op_int_ne
 
+    prepare_op_ptr_eq = prepare_op_instance_ptr_eq = prepare_op_int_eq
+    prepare_op_ptr_ne = prepare_op_instance_ptr_ne = prepare_op_int_ne
+
+    prepare_comp_op_ptr_eq = prepare_op_int_eq
+    prepare_comp_op_ptr_ne = prepare_op_int_ne
+
     def _prepare_op_unary_op(self, op):
         boxes = op.getarglist()
         a0 = boxes[0]

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -1046,6 +1046,11 @@ class Regalloc(BaseRegalloc):
         arglocs = self._prepare_guard_arglocs(op)
         return arglocs
 
+    def prepare_op_zero_array(self, op):
+        # There are multiple implementations for `zero_array`. Leave the
+        # register allocation to `opassembler.py`.
+        return []
+
     def prepare_op_force_token(self, op):
         res = self.force_allocate_reg(op)
         return [res]

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -854,6 +854,18 @@ class Regalloc(BaseRegalloc):
         op_arglocs = self._prepare_op_cond_call(cond_call_op)
         return (op_arglocs, COND_INVALID)
 
+    def prepare_guard_op_guard_not_forced(self, op, guard_op):
+        if rop.is_call_release_gil(op.getopnum()):
+            arglocs = self._prepare_call(op, save_all_regs=True,
+                                         first_arg_index=2)
+        elif rop.is_call_assembler(op.getopnum()):
+            assert False, 'unimplemented'
+        else:
+            assert rop.is_call_may_force(op.getopnum())
+            assert False, 'unimplemented'
+        guard_arglocs = self._prepare_guard_arglocs(guard_op)
+        return arglocs + guard_arglocs, len(arglocs)
+
     def prepare_op_load_from_gc_table(self, op):
         res = self.force_allocate_reg(op)
         return [res]

--- a/rpython/jit/backend/riscv/regalloc.py
+++ b/rpython/jit/backend/riscv/regalloc.py
@@ -23,6 +23,7 @@ from rpython.jit.metainterp.history import (
 from rpython.jit.metainterp.resoperation import rop
 from rpython.rlib.rarithmetic import r_uint
 from rpython.rtyper.lltypesystem import lltype, rffi
+from rpython.rtyper.lltypesystem.lloperation import llop
 
 
 class TempInt(TempVar):
@@ -1383,15 +1384,18 @@ class Regalloc(BaseRegalloc):
 
 
 def not_implemented(self, op):
-    print '[riscv/regalloc] %s not implemented' % op.getopname()
+    llop.debug_print(lltype.Void,
+                     '[riscv/regalloc] %s not implemented' % op.getopname())
     raise NotImplementedError(op)
 
 def not_implemented_guard_op(self, op, prevop):
-    print '[riscv/regalloc] %s not implemented' % op.getopname()
+    llop.debug_print(lltype.Void,
+                     '[riscv/regalloc] %s not implemented' % op.getopname())
     raise NotImplementedError(op)
 
 def not_implemented_comp_op(self, op):
-    print '[riscv/regalloc] %s not implemented' % op.getopname()
+    llop.debug_print(lltype.Void,
+                     '[riscv/regalloc] %s not implemented' % op.getopname())
     raise NotImplementedError(op)
 
 regalloc_operations = [not_implemented] * (rop._LAST + 1)

--- a/rpython/jit/backend/riscv/registers.py
+++ b/rpython/jit/backend/riscv/registers.py
@@ -53,8 +53,11 @@ callee_saved_registers = [sp] + callee_saved_registers_except_sp
 argument_regs = [x10, x11, x12, x13, x14, x15, x16, x17]
 
 allocatable_registers = [x5, x6, x7, x10, x11, x12, x13, x14, x15, x16, x17,
-                         x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28,
-                         x29, x30]
+                         x18, x19, x20, x21, x22, x23, x24, x25, x28, x29, x30]
+
+# Registers for GIL and shadow stack.  (See also. callbuilder.py)
+thread_id = x26
+shadow_old = x27
 
 caller_saved_fp_registers = [f0, f1, f2, f3, f4, f5, f6, f7, f10, f11, f12, f13,
                              f14, f15, f16, f17, f28, f29, f30, f31]
@@ -96,6 +99,12 @@ if __name__ == '__main__':
     # f31 must not be in the allocatable_fp_registers because we want to use it
     # as a scratch fp register.
     assert f31 not in allocatable_fp_registers
+
+    # Reserve two callee-saved registers for GIL and shadow stack support.
+    assert thread_id not in allocatable_registers
+    assert thread_id in callee_saved_registers
+    assert shadow_old not in allocatable_registers
+    assert shadow_old in callee_saved_registers
 
     print 'Core registers'
     print '* Number of caller saved:', len(caller_saved_registers)

--- a/rpython/jit/backend/riscv/registers.py
+++ b/rpython/jit/backend/riscv/registers.py
@@ -60,13 +60,16 @@ caller_saved_fp_registers = [f0, f1, f2, f3, f4, f5, f6, f7, f10, f11, f12, f13,
                              f14, f15, f16, f17, f28, f29, f30, f31]
 callee_saved_fp_registers = [f8, f9, f18, f19, f20, f21, f22, f23, f24, f25,
                              f26, f27]
-allocatable_fp_registers = caller_saved_fp_registers + callee_saved_fp_registers
+allocatable_fp_registers = [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11,
+                            f12, f13, f14, f15, f16, f17, f18, f19, f20, f21,
+                            f22, f23, f24, f25, f26, f27, f28, f29, f30]
 
 if __name__ == '__main__':
     assert set(registers) == \
             set(caller_saved_registers + callee_saved_registers + [x0, x3, x4])
     assert set(fp_registers) == \
             set(caller_saved_fp_registers + callee_saved_fp_registers)
+    assert set(fp_registers) == set(allocatable_fp_registers + [f31])
 
     # Check whether there are duplicated registers in the lists.
     assert len(set(allocatable_registers)) == len(allocatable_registers)
@@ -89,6 +92,10 @@ if __name__ == '__main__':
     # For example, we keep the address in x31 temporarily when we load constant
     # floating point numbers to fp registers.
     assert x31 not in allocatable_registers
+
+    # f31 must not be in the allocatable_fp_registers because we want to use it
+    # as a scratch fp register.
+    assert f31 not in allocatable_fp_registers
 
     print 'Core registers'
     print '* Number of caller saved:', len(caller_saved_registers)

--- a/rpython/jit/backend/riscv/runner.py
+++ b/rpython/jit/backend/riscv/runner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from rpython.jit.backend.llsupport.llmodel import AbstractLLCPU
+from rpython.jit.backend.riscv import arch
 from rpython.jit.backend.riscv import registers as r
 from rpython.jit.backend.riscv.assembler import AssemblerRISCV
 from rpython.rtyper.lltypesystem import llmemory
@@ -14,6 +15,8 @@ class AbstractRISCVCPU(AbstractLLCPU):
     all_reg_indexes = range(32)
     gen_regs = r.registers  # List of general-purpose registers
     float_regs = r.fp_registers  # List of floating point registers
+
+    JITFRAME_FIXED_SIZE = arch.JITFRAME_FIXED_SIZE
 
     def __init__(self, rtyper, stats, opts=None, translate_support_code=False,
                  gcdescr=None):

--- a/rpython/jit/backend/riscv/runner.py
+++ b/rpython/jit/backend/riscv/runner.py
@@ -38,6 +38,9 @@ class AbstractRISCVCPU(AbstractLLCPU):
                                               operations, original_loop_token,
                                               log=log)
 
+    def redirect_call_assembler(self, oldlooptoken, newlooptoken):
+        self.assembler.redirect_call_assembler(oldlooptoken, newlooptoken)
+
     def invalidate_loop(self, looptoken):
         # Replace `GUARD_NOT_INVALIDATED` in the loop with a branch instruction
         # to the recovery stub.

--- a/rpython/jit/backend/riscv/runner.py
+++ b/rpython/jit/backend/riscv/runner.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python
 
 from rpython.jit.backend.llsupport.llmodel import AbstractLLCPU
+from rpython.jit.backend.riscv import registers as r
 from rpython.jit.backend.riscv.assembler import AssemblerRISCV
 from rpython.rtyper.lltypesystem import llmemory
 
 
 class AbstractRISCVCPU(AbstractLLCPU):
     supports_floats = True
+
+    # These are required by BaseAssembler.store_info_on_descr()
+    frame_reg = r.jfp
+    all_reg_indexes = range(32)
+    gen_regs = r.registers  # List of general-purpose registers
+    float_regs = r.fp_registers  # List of floating point registers
 
     def __init__(self, rtyper, stats, opts=None, translate_support_code=False,
                  gcdescr=None):

--- a/rpython/jit/backend/riscv/runner.py
+++ b/rpython/jit/backend/riscv/runner.py
@@ -19,6 +19,8 @@ class AbstractRISCVCPU(AbstractLLCPU):
 
     JITFRAME_FIXED_SIZE = arch.JITFRAME_FIXED_SIZE
 
+    HAS_CODEMAP = True
+
     def __init__(self, rtyper, stats, opts=None, translate_support_code=False,
                  gcdescr=None):
         AbstractLLCPU.__init__(self, rtyper, stats, opts,
@@ -29,6 +31,8 @@ class AbstractRISCVCPU(AbstractLLCPU):
 
     def setup_once(self):
         self.assembler.setup_once()
+        if self.HAS_CODEMAP:
+            self.codemap.setup()
 
     def compile_bridge(self, faildescr, inputargs, operations,
                        original_loop_token, log=True, logger=None):

--- a/rpython/jit/backend/riscv/runner.py
+++ b/rpython/jit/backend/riscv/runner.py
@@ -29,6 +29,14 @@ class AbstractRISCVCPU(AbstractLLCPU):
     def setup_once(self):
         self.assembler.setup_once()
 
+    def compile_bridge(self, faildescr, inputargs, operations,
+                       original_loop_token, log=True, logger=None):
+        clt = original_loop_token.compiled_loop_token
+        clt.compiling_a_bridge()
+        return self.assembler.assemble_bridge(logger, faildescr, inputargs,
+                                              operations, original_loop_token,
+                                              log=log)
+
     def cast_ptr_to_int(x):
         adr = llmemory.cast_ptr_to_adr(x)
         return AbstractRISCVCPU.cast_adr_to_int(adr)

--- a/rpython/jit/backend/riscv/runner.py
+++ b/rpython/jit/backend/riscv/runner.py
@@ -14,8 +14,18 @@ class AbstractRISCVCPU(AbstractLLCPU):
 
     # These are required by BaseAssembler.store_info_on_descr()
     frame_reg = r.jfp
-    all_reg_indexes = range(32)
-    gen_regs = r.registers  # List of general-purpose registers
+    # Map register to the indices in JITFRAME_FIXED_SIZE. We put x10 (the
+    # return value register at 0 because AbstractFailDescr assumes the return
+    # value is at index 0.
+    all_reg_indexes = [10, 1,  2,  3,  4,  5,  6,  7,
+                       8,  9,  0,  11, 12, 13, 14, 15,
+                       16, 17, 18, 19, 20, 21, 22, 23,
+                       24, 25, 26, 27, 28, 29, 30, 31]
+    # The inverse map that maps indices back to general purpose registers.
+    gen_regs = [r.x10, r.x1,  r.x2,  r.x3,  r.x4,  r.x5,  r.x6,  r.x7,
+                r.x8,  r.x9,  r.x0,  r.x11, r.x12, r.x13, r.x14, r.x15,
+                r.x16, r.x17, r.x18, r.x19, r.x20, r.x21, r.x22, r.x23,
+                r.x24, r.x25, r.x26, r.x27, r.x28, r.x29, r.x30, r.x31]
     float_regs = r.fp_registers  # List of floating point registers
 
     JITFRAME_FIXED_SIZE = arch.JITFRAME_FIXED_SIZE

--- a/rpython/jit/backend/riscv/test/test_basic.py
+++ b/rpython/jit/backend/riscv/test/test_basic.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import py
+from rpython.jit.backend.detect_cpu import getcpuclass
+from rpython.jit.metainterp.test import test_ajit
+from rpython.jit.metainterp.test.support import LLJitMixin
+from rpython.rlib.jit import JitDriver
+
+
+class JitRISCVMixin(LLJitMixin):
+    CPUClass = getcpuclass()
+    # We have to disable unroll
+    enable_opts = "intbounds:rewrite:virtualize:string:earlyforce:pure:heap"
+    basic = False
+
+    def check_jumps(self, maxcount):
+        pass
+
+
+class TestBasic(JitRISCVMixin, test_ajit.BaseLLtypeTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_ajit.py
+
+    def test_bug(self):
+        jitdriver = JitDriver(greens = [], reds = ['n'])
+        class X(object):
+            pass
+        def f(n):
+            while n > -100:
+                jitdriver.can_enter_jit(n=n)
+                jitdriver.jit_merge_point(n=n)
+                x = X()
+                x.arg = 5
+                if n <= 0: break
+                n -= x.arg
+                x.arg = 6  # Prevents 'x.arg' from being annotated as constant
+            return n
+        res = self.meta_interp(f, [31], enable_opts='')
+        assert res == -4
+
+    def test_r_dict(self):
+        # A Struct that belongs to the hash table is not seen as being included
+        # in the larger Array
+        py.test.skip("issue with ll2ctypes")
+
+    def test_free_object(self):
+        py.test.skip("issue of freeing, probably with ll2ctypes")

--- a/rpython/jit/backend/riscv/test/test_call.py
+++ b/rpython/jit/backend/riscv/test/test_call.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test import test_call
+
+
+class TestCall(JitRISCVMixin, test_call.CallTest):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_call.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_calling_convention.py
+++ b/rpython/jit/backend/riscv/test/test_calling_convention.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv import registers as r
+from rpython.jit.backend.riscv.codebuilder import InstrBuilder
+from rpython.jit.backend.test.calling_convention_test import CallingConvTests
+
+
+class TestRISCVCallingConvention(CallingConvTests):
+    # ../../test/calling_convention_test.py
+
+    def make_function_returning_stack_pointer(self):
+        mc = InstrBuilder()
+        mc.MV(r.x10.value, r.sp.value)
+        mc.RET()
+        return mc.materialize(self.cpu, [])
+
+    def get_alignment_requirements(self):
+        return 16

--- a/rpython/jit/backend/riscv/test/test_calling_convention.py
+++ b/rpython/jit/backend/riscv/test/test_calling_convention.py
@@ -3,16 +3,21 @@
 from rpython.jit.backend.riscv import registers as r
 from rpython.jit.backend.riscv.codebuilder import InstrBuilder
 from rpython.jit.backend.test.calling_convention_test import CallingConvTests
+from rpython.rlib import rmmap
 
 
 class TestRISCVCallingConvention(CallingConvTests):
     # ../../test/calling_convention_test.py
 
     def make_function_returning_stack_pointer(self):
-        mc = InstrBuilder()
-        mc.MV(r.x10.value, r.sp.value)
-        mc.RET()
-        return mc.materialize(self.cpu, [])
+        rmmap.enter_assembler_writing()
+        try:
+            mc = InstrBuilder()
+            mc.MV(r.x10.value, r.sp.value)
+            mc.RET()
+            return mc.materialize(self.cpu, [])
+        finally:
+            rmmap.leave_assembler_writing()
 
     def get_alignment_requirements(self):
         return 16

--- a/rpython/jit/backend/riscv/test/test_del.py
+++ b/rpython/jit/backend/riscv/test/test_del.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_del import DelTests
+
+
+class TestDel(JitRISCVMixin, DelTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_del.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_dict.py
+++ b/rpython/jit/backend/riscv/test/test_dict.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_dict import DictTests
+
+
+class TestDict(JitRISCVMixin, DictTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_dict.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_exception.py
+++ b/rpython/jit/backend/riscv/test/test_exception.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_exception import ExceptionTests
+
+
+class TestExceptions(JitRISCVMixin, ExceptionTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_exception.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_fficall.py
+++ b/rpython/jit/backend/riscv/test/test_fficall.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test import test_fficall
+
+
+class TestFfiCall(JitRISCVMixin, test_fficall.FfiCallTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_fficall.py
+
+    def _add_libffi_types_to_ll2types_maybe(self):
+        # This is needed by test_guard_not_forced_fails, because it produces a
+        # loop which reads the value of types.* in a variable, then a guard
+        # fail and we switch to blackhole: the problem is that at this point
+        # the blackhole interp has a real integer, but it needs to convert it
+        # back to a lltype pointer (which is handled by ll2ctypes, deeply in
+        # the logic). The workaround is to teach ll2ctypes in advance which
+        # are the addresses of the various types.* structures.
+        # Try to comment this code out and run the test to see how it fails :)
+        from rpython.rtyper.lltypesystem import rffi, lltype, ll2ctypes
+        from rpython.rlib.jit_libffi import types
+        for key, value in types.__dict__.iteritems():
+            if isinstance(value, lltype._ptr):
+                addr = rffi.cast(lltype.Signed, value)
+                ll2ctypes._int2obj[addr] = value

--- a/rpython/jit/backend/riscv/test/test_float.py
+++ b/rpython/jit/backend/riscv/test/test_float.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_float import FloatTests
+
+
+class TestFloat(JitRISCVMixin, FloatTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_float.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_jitlog.py
+++ b/rpython/jit/backend/riscv/test/test_jitlog.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.backend.test.jitlog_test import LoggerTest
+
+
+class TestJitlog(JitRISCVMixin, LoggerTest):
+    # for the individual tests see
+    # ====> ../../../test/jitlog_test.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_list.py
+++ b/rpython/jit/backend/riscv/test/test_list.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_list import ListTests
+
+
+class TestList(JitRISCVMixin, ListTests):
+    # for individual tests see
+    # ====> ../../../metainterp/test/test_list.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_llop.py
+++ b/rpython/jit/backend/riscv/test/test_llop.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_llop import TestLLOp as _TestLLOp
+
+
+class TestLLOp(JitRISCVMixin, _TestLLOp):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_llop.py
+
+    # Do NOT test the blackhole implementation of gc_store_indexed. It cannot
+    # work inside tests because llmodel.py:bh_gc_store_indexed_* receive a
+    # symbolic as the offset. It is not a problem because it is tested anyway
+    # by the same test in test_metainterp.py
+    TEST_BLACKHOLE = False

--- a/rpython/jit/backend/riscv/test/test_loop_unroll.py
+++ b/rpython/jit/backend/riscv/test/test_loop_unroll.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test import test_loop_unroll
+
+
+class TestLoopSpec(JitRISCVMixin, test_loop_unroll.LoopUnrollTest):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_loop.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_quasiimmut.py
+++ b/rpython/jit/backend/riscv/test/test_quasiimmut.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test import test_quasiimmut
+
+
+class TestLoopSpec(JitRISCVMixin, test_quasiimmut.QuasiImmutTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_loop.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_rawmem.py
+++ b/rpython/jit/backend/riscv/test/test_rawmem.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_rawmem import RawMemTests
+
+
+class TestRawMem(JitRISCVMixin, RawMemTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_rawmem.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_recursive.py
+++ b/rpython/jit/backend/riscv/test/test_recursive.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import py
 from rpython.jit.backend.llsupport.codemap import unpack_traceback
 from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
 from rpython.jit.metainterp.test.test_recursive import RecursiveTests
@@ -11,8 +10,6 @@ class TestRecursive(JitRISCVMixin, RecursiveTests):
     # ====> ../../../metainterp/test/test_recursive.py
 
     def check_get_unique_id(self, codemaps):
-        py.test.skip('codemap unimplemented by RISCV')
-
         assert len(codemaps) == 3
         # we want to create a map of differences, so unpacking the tracebacks
         # byte by byte

--- a/rpython/jit/backend/riscv/test/test_recursive.py
+++ b/rpython/jit/backend/riscv/test/test_recursive.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import py
+from rpython.jit.backend.llsupport.codemap import unpack_traceback
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_recursive import RecursiveTests
+
+
+class TestRecursive(JitRISCVMixin, RecursiveTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_recursive.py
+
+    def check_get_unique_id(self, codemaps):
+        py.test.skip('codemap unimplemented by RISCV')
+
+        assert len(codemaps) == 3
+        # we want to create a map of differences, so unpacking the tracebacks
+        # byte by byte
+        codemaps.sort(lambda a, b: cmp(a[1], b[1]))
+        # biggest is the big loop, smallest is the bridge
+        def get_ranges(c):
+            ranges = []
+            prev_traceback = None
+            for b in range(c[0], c[0] + c[1]):
+                tb = unpack_traceback(b)
+                if tb != prev_traceback:
+                    ranges.append(tb)
+                    prev_traceback = tb
+            return ranges
+        assert get_ranges(codemaps[2]) == [[4], [4, 2], [4]]
+        assert get_ranges(codemaps[1]) == [[2]]
+        assert get_ranges(codemaps[0]) == [[2], []]

--- a/rpython/jit/backend/riscv/test/test_runner.py
+++ b/rpython/jit/backend/riscv/test/test_runner.py
@@ -18,3 +18,28 @@ class TestRISCV(LLtypeBackendTest):
         cpu = CPU(rtyper=None, stats=FakeStats())
         cpu.setup_once()
         return cpu
+
+    # `test_compile_asmlen` expected outputs
+    add_loop_instructions = (
+        'ld; '  # same_as
+        + 'add; '  # int_add
+        + 'bnez; j; '  # guard_true
+        + 'j; '  # jump
+        + 'ebreak;')
+    bridge_loop_instructions = (
+        # Load the current frame depth
+        'ld; '
+        # Load the expected frame depth
+        + 'li; (nop; )*'
+        # Compare current to expected frame depth
+        + 'bge; '
+        # Store gcmap to jf_gcmap
+        + 'lui; addiw; (slli; addi; )*(slli; )*'
+        + 'sd; '
+        # Branch to frame_realloc_slowpath
+        + 'lui; addiw; (slli; addi; )*(slli; )*'
+        + 'jalr; '
+        # Jump to a target token
+        + 'lui; addiw; (slli; addi; )*(slli; )*'
+        + 'jr; '
+        + 'ebreak;')

--- a/rpython/jit/backend/riscv/test/test_runner.py
+++ b/rpython/jit/backend/riscv/test/test_runner.py
@@ -34,12 +34,12 @@ class TestRISCV(LLtypeBackendTest):
         # Compare current to expected frame depth
         + 'bge; '
         # Store gcmap to jf_gcmap
-        + 'lui; addiw; (slli; addi; )*(slli; )*'
+        + '(((auipc; )*ld; )|((lui; )*addiw*; ))'
         + 'sd; '
         # Branch to frame_realloc_slowpath
-        + 'lui; addiw; (slli; addi; )*(slli; )*'
+        + '(((auipc; )*ld; )|((lui; )*addiw*; ))'
         + 'jalr; '
         # Jump to a target token
-        + 'lui; addiw; (slli; addi; )*(slli; )*'
+        + '(((auipc; )*ld; )|((lui; )*addiw*; ))'
         + 'jr; '
         + 'ebreak;')

--- a/rpython/jit/backend/riscv/test/test_rvmprof.py
+++ b/rpython/jit/backend/riscv/test/test_rvmprof.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.backend.test.test_rvmprof import BaseRVMProfTest
+
+
+class TestRVMProfCall(JitRISCVMixin, BaseRVMProfTest):
+    pass

--- a/rpython/jit/backend/riscv/test/test_send.py
+++ b/rpython/jit/backend/riscv/test/test_send.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_send import SendTests
+from rpython.rlib import jit
+
+
+class TestSend(JitRISCVMixin, SendTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_send.py
+
+    def test_call_with_additional_args(self):
+        @jit.dont_look_inside
+        def externfn(a, b, c, d):
+            return a + b * 10 + c * 100 + d * 1000
+        def f(a, b, c, d):
+            return externfn(a, b, c, d)
+        res = self.interp_operations(f, [1, 2, 3, 4])
+        assert res == 4321

--- a/rpython/jit/backend/riscv/test/test_slist.py
+++ b/rpython/jit/backend/riscv/test/test_slist.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import py
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test import test_slist
+
+
+class TestSList(JitRISCVMixin, test_slist.ListTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_slist.py
+
+    def test_list_of_voids(self):
+        py.test.skip("list of voids unsupported by ll2ctypes")

--- a/rpython/jit/backend/riscv/test/test_string.py
+++ b/rpython/jit/backend/riscv/test/test_string.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test import test_string
+
+
+class TestString(JitRISCVMixin, test_string.TestLLtype):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_string.py
+    pass
+
+
+class TestUnicode(JitRISCVMixin, test_string.TestLLtypeUnicode):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_string.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_tl.py
+++ b/rpython/jit/backend/riscv/test/test_tl.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_tl import ToyLanguageTests
+
+
+class TestTL(JitRISCVMixin, ToyLanguageTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_tl.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_tlc.py
+++ b/rpython/jit/backend/riscv/test/test_tlc.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import py
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_tlc import TLCTests
+from rpython.jit.tl import tlc
+
+
+class TestTL(JitRISCVMixin, TLCTests):
+    # for the individual tests see
+    # ====> ../../test/test_tlc.py
+
+    def test_accumulator(self):
+        path = py.path.local(tlc.__file__).dirpath('accumulator.tlc.src')
+        code = path.read()
+        res = self.exec_code(code, 20)
+        assert res == sum(range(20))
+        res = self.exec_code(code, -10)
+        assert res == 10
+
+    def test_fib(self):
+        py.test.skip("AnnotatorError")
+        path = py.path.local(tlc.__file__).dirpath('fibo.tlc.src')
+        code = path.read()
+        res = self.exec_code(code, 7)
+        assert res == 13
+        res = self.exec_code(code, 20)
+        assert res == 6765

--- a/rpython/jit/backend/riscv/test/test_virtual.py
+++ b/rpython/jit/backend/riscv/test/test_virtual.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_virtual import (
+    VirtualTests, VirtualMiscTests)
+
+
+class MyClass:
+    pass
+
+
+class TestsVirtual(JitRISCVMixin, VirtualTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_virtual.py
+    _new_op = 'new_with_vtable'
+    _field_prefix = 'inst_'
+
+    @staticmethod
+    def _new():
+        return MyClass()
+
+
+class TestsVirtualMisc(JitRISCVMixin, VirtualMiscTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_virtual.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_virtualizable.py
+++ b/rpython/jit/backend/riscv/test/test_virtualizable.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import py
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_virtualizable import ImplicitVirtualizableTests
+
+
+class TestVirtualizable(JitRISCVMixin, ImplicitVirtualizableTests):
+    def test_blackhole_should_not_reenter(self):
+        py.test.skip("Assertion error & llinterp mess")

--- a/rpython/jit/backend/riscv/test/test_virtualref.py
+++ b/rpython/jit/backend/riscv/test/test_virtualref.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.riscv.test.test_basic import JitRISCVMixin
+from rpython.jit.metainterp.test.test_virtualref import VRefTests
+
+
+class TestVRef(JitRISCVMixin, VRefTests):
+    # for the individual tests see
+    # ====> ../../../metainterp/test/test_virtualref.py
+    pass

--- a/rpython/jit/backend/riscv/test/test_zrpy_gc.py
+++ b/rpython/jit/backend/riscv/test/test_zrpy_gc.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.zrpy_gc_test import CompileFrameworkTests
+
+
+class TestShadowStack(CompileFrameworkTests):
+    gcrootfinder = 'shadowstack'
+    gc = 'incminimark'

--- a/rpython/jit/backend/riscv/test/test_zrpy_gc_boehm.py
+++ b/rpython/jit/backend/riscv/test/test_zrpy_gc_boehm.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.zrpy_gc_boehm_test import (
+    compile_boehm_test as test_compile_boehm)

--- a/rpython/jit/backend/riscv/test/test_zrpy_releasegil.py
+++ b/rpython/jit/backend/riscv/test/test_zrpy_releasegil.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.zrpy_releasegil_test import ReleaseGILTests
+
+
+class TestShadowStack(ReleaseGILTests):
+    gcrootfinder = 'shadowstack'

--- a/rpython/jit/backend/riscv/test/test_zrpy_vmprof.py
+++ b/rpython/jit/backend/riscv/test/test_zrpy_vmprof.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.zrpy_vmprof_test import CompiledVmprofTest
+
+
+class TestZVMprof(CompiledVmprofTest):
+    gcrootfinder = 'shadowstack'
+    gc = 'incminimark'

--- a/rpython/jit/backend/riscv/test/test_ztranslation_basic.py
+++ b/rpython/jit/backend/riscv/test/test_ztranslation_basic.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.ztranslation_test import TranslationTest
+
+
+class TestTranslationRISCV(TranslationTest):
+    pass

--- a/rpython/jit/backend/riscv/test/test_ztranslation_call_assembler.py
+++ b/rpython/jit/backend/riscv/test/test_ztranslation_call_assembler.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.ztranslation_test import TranslationTestCallAssembler
+import sys
+
+
+# On Windows, this test crashes obscurely, but only if compiled with Boehm, not
+# if run with no GC at all.  So for now we'll assume it is really a Boehm bug,
+# or maybe a Boehm-on-Windows-specific issue, and skip.
+if sys.platform == 'win32':
+    import py
+    py.test.skip("crashes on Windows (Boehm issue?)")
+
+
+class TestTranslationCallAssemblerRISCV(TranslationTestCallAssembler):
+    pass

--- a/rpython/jit/backend/riscv/test/test_ztranslation_jit_stats.py
+++ b/rpython/jit/backend/riscv/test/test_ztranslation_jit_stats.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+from rpython.jit.backend.llsupport.test.ztranslation_test import TranslationTestJITStats
+
+
+class TestTranslationJITStatsRISCV(TranslationTestJITStats):
+    pass

--- a/rpython/jit/backend/test/runner_test.py
+++ b/rpython/jit/backend/test/runner_test.py
@@ -4024,6 +4024,19 @@ class LLtypeBackendTest(BaseBackendTest):
         f17 = float_sub(f0, f1)
         f18 = float_sub(f0, f1)
         f19 = float_sub(f0, f1)
+        f20 = float_sub(f0, f1)
+        f21 = float_sub(f0, f1)
+        f22 = float_sub(f0, f1)
+        f23 = float_sub(f0, f1)
+        f24 = float_sub(f0, f1)
+        f25 = float_sub(f0, f1)
+        f26 = float_sub(f0, f1)
+        f27 = float_sub(f0, f1)
+        f28 = float_sub(f0, f1)
+        f29 = float_sub(f0, f1)
+        f30 = float_sub(f0, f1)
+        f31 = float_sub(f0, f1)
+        f32 = float_sub(f0, f1)
         i3 = float_eq(f2, f3)
         i4 = float_eq(f2, f4)
         i5 = float_eq(f2, f5)
@@ -4041,6 +4054,19 @@ class LLtypeBackendTest(BaseBackendTest):
         i17 = float_eq(f2, f17)
         i18 = float_eq(f2, f18)
         i19 = float_eq(f2, f19)
+        i20 = float_eq(f2, f20)
+        i21 = float_eq(f2, f21)
+        i22 = float_eq(f2, f22)
+        i23 = float_eq(f2, f23)
+        i24 = float_eq(f2, f24)
+        i25 = float_eq(f2, f25)
+        i26 = float_eq(f2, f26)
+        i27 = float_eq(f2, f27)
+        i28 = float_eq(f2, f28)
+        i29 = float_eq(f2, f29)
+        i30 = float_eq(f2, f30)
+        i31 = float_eq(f2, f31)
+        i32 = float_eq(f2, f32)
         guard_true(i3) []
         guard_true(i4) []
         guard_true(i5) []
@@ -4058,6 +4084,19 @@ class LLtypeBackendTest(BaseBackendTest):
         guard_true(i17) []
         guard_true(i18) []
         guard_true(i19) []
+        guard_true(i20) []
+        guard_true(i21) []
+        guard_true(i22) []
+        guard_true(i23) []
+        guard_true(i24) []
+        guard_true(i25) []
+        guard_true(i26) []
+        guard_true(i27) []
+        guard_true(i28) []
+        guard_true(i29) []
+        guard_true(i30) []
+        guard_true(i31) []
+        guard_true(i32) []
         finish(f2)'''
         loop2 = parse(ops)
         looptoken2 = JitCellToken()

--- a/rpython/jit/backend/tool/viewcode.py
+++ b/rpython/jit/backend/tool/viewcode.py
@@ -52,6 +52,7 @@ def machine_code_dump(data, originaddr, backend_name, label_list=None):
         'aarch64': 'aarch64',
         'ppc' : 'powerpc:common64',
         'ppc-64' : 'powerpc:common64',
+        'riscv64': 'riscv:rv64',
         's390x': 's390:64-bit',
     }
     machine_endianness = {

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -23,7 +23,9 @@ IS_SUPPORTED = False
 if sys.platform in ('darwin', 'linux', 'linux2') or sys.platform.startswith('freebsd'):
     try:
         proc = detect_cpu.autodetect()
-        IS_SUPPORTED = proc.startswith('x86') or proc == 'aarch64'
+        IS_SUPPORTED = (proc.startswith('x86')
+                        or proc == 'aarch64'
+                        or proc == 'riscv64')
     except detect_cpu.ProcessorAutodetectError:
         print("PROCESSOR NOT DETECTED, SKIPPING VMPROF")
 

--- a/rpython/rlib/rvmprof/src/shared/vmprof_config.h
+++ b/rpython/rlib/rvmprof/src/shared/vmprof_config.h
@@ -32,6 +32,8 @@
   #define PC_FROM_UCONTEXT uc_mcontext.pc
 #elif defined(__powerpc64__)
   #define PC_FROM_UCONTEXT uc_mcontext.gp_regs[PT_NIP]
+#elif defined(__riscv)
+  #define PC_FROM_UCONTEXT uc_mcontext.__gregs[REG_PC]
 #else
   /* linux, gnuc */
   #define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_RIP]

--- a/rpython/rlib/rvmprof/test/__init__.py
+++ b/rpython/rlib/rvmprof/test/__init__.py
@@ -1,5 +1,5 @@
 import pytest
 import platform
 
-if not (platform.machine() in ('x86', 'aarch64', 'arm64')):
+if not (platform.machine() in ('x86', 'aarch64', 'arm64', 'riscv64')):
     pytest.skip()

--- a/rpython/translator/c/src/stacklet/slp_platformselect.h
+++ b/rpython/translator/c/src/stacklet/slp_platformselect.h
@@ -16,6 +16,8 @@
 #include "switch_ppc64_gcc.h" /* gcc on ppc64 */
 #elif defined(__GNUC__) && defined(__mips__) && defined(_ABI64)
 #include "switch_mips64_gcc.h" /* gcc on mips64 */
+#elif defined(__GNUC__) && defined(__riscv)
+#include "switch_riscv_gcc.h" /* gcc on riscv */
 #elif defined(__GNUC__) && defined(__s390x__)
 #include "switch_s390x_gcc.h"
 #else

--- a/rpython/translator/c/src/stacklet/switch_riscv_gcc.h
+++ b/rpython/translator/c/src/stacklet/switch_riscv_gcc.h
@@ -1,0 +1,142 @@
+#if __riscv_xlen != 64 || __riscv_flen != 64
+#error "slp_switch only supports RV64IMAD now"
+#endif
+
+static void *slp_switch(void *(*save_state)(void*, void*),
+                        void *(*restore_state)(void*, void*),
+                        void *extra) __attribute__((noinline));
+
+static void *slp_switch(void *(*save_state)(void*, void*),
+                        void *(*restore_state)(void*, void*),
+                        void *extra)
+{
+  void *result;
+  /*
+   * Registers to preserve (callee-saved registers):
+   * x8-9, x18-27, f8-9, f18-27
+   *
+   * Registers marked as clobbered (caller-saved registers):
+   * x1 (ra), x5-7, x10-17, x28-31, f0-7, f10-17, f28-f31
+   *
+   * Special registers:
+   *
+   * x0: Constant zero
+   *
+   * x2: Stack pointer is a callee-saved register.  It will be preserved
+   *     around function calls to `save_state` and `restore_state`.  And this
+   *     inline assembly preserve it by sub/add it with the same amount.
+   *
+   * x3: gp (don't use, gcc doesn't change them either)
+   * x4: tp (don't use, gcc doesn't change them either)
+   *
+   * Don't assume gcc saves any register for us when generating code for
+   * slp_switch().
+   *
+   * The values `save_state`, `restore_state` and `extra` are first moved by
+   * gcc to some registers that are not marked as clobbered (some callee-saved
+   * registers).  Similarly, gcc expects `result` to be in a register between
+   * some callee-saved registers.
+   *
+   * This means that three of the values we happen to save and restore will, in
+   * fact, contain the three arguments, and one of these values will, in fact,
+   * not be restored at all but receive `result`.
+   */
+
+  __asm__ volatile (
+    /* Note: The stack is supposed to be aligned as necessary already. */
+
+    /* Save callee-saved registers. */
+    "addi sp,  sp, -192\n"
+    "sd   x8,  0(sp)\n"
+    "sd   x9,  8(sp)\n"
+    "sd   x18, 16(sp)\n"
+    "sd   x19, 24(sp)\n"
+    "sd   x20, 32(sp)\n"
+    "sd   x21, 40(sp)\n"
+    "sd   x22, 48(sp)\n"
+    "sd   x23, 56(sp)\n"
+    "sd   x24, 64(sp)\n"
+    "sd   x25, 72(sp)\n"
+    "sd   x26, 80(sp)\n"
+    "sd   x27, 88(sp)\n"
+    "fsd  f8,  96(sp)\n"
+    "fsd  f9,  104(sp)\n"
+    "fsd  f18, 112(sp)\n"
+    "fsd  f19, 120(sp)\n"
+    "fsd  f20, 128(sp)\n"
+    "fsd  f21, 136(sp)\n"
+    "fsd  f22, 144(sp)\n"
+    "fsd  f23, 152(sp)\n"
+    "fsd  f24, 160(sp)\n"
+    "fsd  f25, 168(sp)\n"
+    "fsd  f26, 176(sp)\n"
+    "fsd  f27, 184(sp)\n"
+
+    "mv   x10, sp\n"                /* arg 1: current (old) stack pointer */
+    "mv   x11, %[extra]\n"          /* arg 2: extra */
+    "jalr ra,  %[save_state], 0\n"  /* call save_state() */
+
+    /* Skip the rest if the return value is null. */
+    "beqz x10, 0f\n"
+
+    "mv   sp,  x10\n"  /* change the stack pointer */
+
+    /* From now on, the stack pointer is modified, but the content of the
+     * stack is not restored yet.  It contains only garbage here.
+     */
+    /* arg 1: current (new) stack pointer is already in x10 */
+    "mv   x11, %[extra]\n"             /* arg 2: extra */
+    "jalr ra,  %[restore_state], 0\n"  /* call restore_state() */
+
+    /* The stack's content is now restored. */
+    "0:\n"
+
+    /* Restore all saved registers */
+    "ld   x8,  0(sp)\n"
+    "ld   x9,  8(sp)\n"
+    "ld   x18, 16(sp)\n"
+    "ld   x19, 24(sp)\n"
+    "ld   x20, 32(sp)\n"
+    "ld   x21, 40(sp)\n"
+    "ld   x22, 48(sp)\n"
+    "ld   x23, 56(sp)\n"
+    "ld   x24, 64(sp)\n"
+    "ld   x25, 72(sp)\n"
+    "ld   x26, 80(sp)\n"
+    "ld   x27, 88(sp)\n"
+    "fld  f8,  96(sp)\n"
+    "fld  f9,  104(sp)\n"
+    "fld  f18, 112(sp)\n"
+    "fld  f19, 120(sp)\n"
+    "fld  f20, 128(sp)\n"
+    "fld  f21, 136(sp)\n"
+    "fld  f22, 144(sp)\n"
+    "fld  f23, 152(sp)\n"
+    "fld  f24, 160(sp)\n"
+    "fld  f25, 168(sp)\n"
+    "fld  f26, 176(sp)\n"
+    "fld  f27, 184(sp)\n"
+    "addi sp,  sp, 192\n"
+
+    /* Move x10 into the final location of `result`. */
+    "mv   %[result], x10\n"
+
+    : /* Output variables */
+      [result]"=r"(result)
+    : /* Input variables */
+      [restore_state]"r"(restore_state),
+      [save_state]"r"(save_state),
+      [extra]"r"(extra)
+    : /* Clobber caller-saved core registers */
+      "x1", "x5", "x6", "x7",
+      "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
+      "x28", "x29", "x30", "x31",
+      /* Clobber caller-saved float registers */
+      "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",
+      "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f17",
+      "f28", "f29", "f30", "f31",
+      "memory"
+  );
+
+  return result;
+}


### PR DESCRIPTION
This pull request adds a RISC-V JIT backend. This backend targets RV64IMAFD.

The RISC-V backend implementation is quite complete now:

* PyPy RISC-V JIT can run on (a) SiFive Unmatched board with Ubuntu 24.04 and (b) `qemu-user-static` with a Ubuntu 24.04 RISC-V root file system.
* All tests are passing or have reasonable workarounds.
* The [benchmark](https://foss.heptapod.net/pypy/benchmarks) results can be found [here](https://github.com/user-attachments/files/16594231/bench-result-pypy-jit-vs-cpython-2.7-base.json).

Please check `rpython/doc/riscv.rst` for the instructions to cross-compile PyPy RISC-V JIT.