### PR TITLE
update to cffi1.17.0

### DIFF
--- a/extra_tests/cffi_tests/cffi1/test_zdist.py
+++ b/extra_tests/cffi_tests/cffi1/test_zdist.py
@@ -45,8 +45,7 @@ class TestDist(object):
         pathlist = sys.path[:]
         if cwd is None:
             pathlist.insert(0, self.rootdir)
-        if sys.version_info > (3, 0, 0):
-            env['PYTHONPATH'] = os.pathsep.join(pathlist)
+        env['PYTHONPATH'] = os.pathsep.join(pathlist)
         try:
             subprocess.check_call([self.executable] + args, cwd=cwd, env=env)
         finally:

--- a/extra_tests/cffi_tests/test_c.py
+++ b/extra_tests/cffi_tests/test_c.py
@@ -26,7 +26,7 @@ from _cffi_backend import __version__
 # ____________________________________________________________
 
 import sys
-assert __version__ == "1.17.0.dev0", ("This test_c.py file is for testing a version"
+assert __version__ == "1.17.0", ("This test_c.py file is for testing a version"
                                  " of cffi that differs from the one that we"
                                  " get from 'import _cffi_backend'")
 if sys.version_info < (3,):
@@ -1322,6 +1322,7 @@ def test_write_variable():
     ll.close_lib()
     pytest.raises(ValueError, ll.write_variable, BVoidP, "stderr", stderr)
 
+
 def test_callback():
     BInt = new_primitive_type("int")
     def make_callback():
@@ -1337,8 +1338,10 @@ def test_callback():
     e = pytest.raises(TypeError, f)
     assert str(e.value) == "'int(*)(int)' expects 1 arguments, got 0"
 
+
 def test_callback_exception():
-    pytest.skip("XXX not written for Python 2")
+    if sys.version_info < (3, 0):
+        pytest.skip("XXX not written for Python 2")
     def check_value(x):
         if x == 10000:
             raise ValueError(42)
@@ -2958,8 +2961,6 @@ if sys.version_info >= (3,):
 def test_FILE():
     if sys.platform == "win32":
         pytest.skip("testing FILE not implemented")
-    if sys.platform == "darwin":
-        pytest.skip("testing variadic broken on macos (issue 4937)")
     #
     BFILE = new_struct_type("struct _IO_FILE")
     BFILEP = new_pointer_type(BFILE)

--- a/lib_pypy/cffi.dist-info/METADATA
+++ b/lib_pypy/cffi.dist-info/METADATA
@@ -1,12 +1,20 @@
 Metadata-Version: 2.1
 Name: cffi
-Version: 1.17.0.dev0
+Version: 1.17.0
 Summary: Foreign Function Interface for Python calling C code.
 Home-page: http://cffi.readthedocs.org
 Author: Armin Rigo, Maciej Fijalkowski
 Author-email: python-cffi@googlegroups.com
 License: MIT
-Platform: UNKNOWN
+Project-URL: Documentation, http://cffi.readthedocs.org/
+Project-URL: Source Code, https://github.com/python-cffi/cffi
+Project-URL: Issue Tracker, https://github.com/python-cffi/cffi/issues
+Project-URL: Changelog, https://cffi.readthedocs.io/en/latest/whatsnew.html
+Project-URL: Downloads, https://github.com/python-cffi/cffi/releases
+Project-URL: Contact, https://groups.google.com/forum/#!forum/python-cffi
+Classifier: Programming Language :: Python
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.8
 Classifier: Programming Language :: Python
 Classifier: Programming Language :: Python :: 2
 Classifier: Programming Language :: Python :: 2.7
@@ -16,10 +24,14 @@ Classifier: Programming Language :: Python :: 3.7
 Classifier: Programming Language :: Python :: 3.8
 Classifier: Programming Language :: Python :: 3.9
 Classifier: Programming Language :: Python :: 3.10
+Classifier: Programming Language :: Python :: 3.11
+Classifier: Programming Language :: Python :: 3.12
+Classifier: Programming Language :: Python :: 3.13
 Classifier: Programming Language :: Python :: Implementation :: CPython
 Classifier: Programming Language :: Python :: Implementation :: PyPy
 Classifier: License :: OSI Approved :: MIT License
 License-File: LICENSE
+Requires-Dist: pycparser
 
 
 CFFI

--- a/lib_pypy/cffi/__init__.py
+++ b/lib_pypy/cffi/__init__.py
@@ -5,8 +5,8 @@ from .api import FFI
 from .error import CDefError, FFIError, VerificationError, VerificationMissing
 from .error import PkgConfigError
 
-__version__ = "1.17.0.dev0"
-__version_info__ = (1, 17, 0, 'dev0')
+__version__ = "1.17.0"
+__version_info__ = (1, 17, 0)
 
 # The verifier module file names are based on the CRC32 of a string that
 # contains the following version number.  It may be older than __version__

--- a/lib_pypy/cffi/_embedding.h
+++ b/lib_pypy/cffi/_embedding.h
@@ -225,7 +225,7 @@ static int _cffi_initialize_python(void)
 
         if (f != NULL && f != Py_None) {
             PyFile_WriteString("\nFrom: " _CFFI_MODULE_NAME
-                               "\ncompiled with cffi version: 1.17.0.dev0"
+                               "\ncompiled with cffi version: 1.17.0"
                                "\n_cffi_backend module: ", f);
             modules = PyImport_GetModuleDict();
             mod = PyDict_GetItemString(modules, "_cffi_backend");

--- a/lib_pypy/cffi/recompiler.py
+++ b/lib_pypy/cffi/recompiler.py
@@ -953,7 +953,7 @@ class Recompiler:
                 if cname is None or fbitsize >= 0:
                     offset = '(size_t)-1'
                 elif named_ptr is not None:
-                    offset = '((char *)&((%s)0)->%s) - (char *)0' % (
+                    offset = '((char *)&((%s)4096)->%s) - (char *)4096' % (
                         named_ptr.name, fldname)
                 else:
                     offset = 'offsetof(%s, %s)' % (tp.get_c_name(''), fldname)

--- a/pypy/module/_cffi_backend/__init__.py
+++ b/pypy/module/_cffi_backend/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.17.0.dev0"
+VERSION = "1.17.0"

--- a/pypy/module/_cffi_backend/test/_backend_test_c.py
+++ b/pypy/module/_cffi_backend/test/_backend_test_c.py
@@ -13,7 +13,7 @@ def _assert_unraisable(error_type, message='', traceback_tokens=None):
 # ____________________________________________________________
 
 import sys
-assert __version__ == "1.17.0.dev0", ("This test_c.py file is for testing a version"
+assert __version__ == "1.17.0", ("This test_c.py file is for testing a version"
                                  " of cffi that differs from the one that we"
                                  " get from 'import _cffi_backend'")
 if sys.version_info < (3,):
@@ -2946,9 +2946,10 @@ if sys.version_info >= (3,):
 def test_FILE():
     if sys.platform == "win32":
         pytest.skip("testing FILE not implemented")
+    # XXX patch start
     if sys.platform == "darwin":
         pytest.skip("testing variadic broken on macos (issue 4937)")
-    #
+    # XXX patch end
     BFILE = new_struct_type("struct _IO_FILE")
     BFILEP = new_pointer_type(BFILE)
     BChar = new_primitive_type("char")

--- a/pypy/module/_cffi_backend/test/test_file.py
+++ b/pypy/module/_cffi_backend/test/test_file.py
@@ -11,6 +11,11 @@ def test_same_file():
     #
     source = source[source.index('# _____________'):]
     dest = dest[dest.index('# _____________'):]
+
+    # remove patch for issue 4937
+    pstart = dest.index("# XXX patch start") - 4
+    pend = dest.index("XXX patch end") + len("XXX patch end") + 1
+    dest = dest[:pstart] + dest[pend:]
     if source.strip() != dest.strip():
         raise AssertionError(
             "Update test/_backend_test_c.py by copying it from " +

--- a/pypy/tool/import_cffi.patch
+++ b/pypy/tool/import_cffi.patch
@@ -38,7 +38,8 @@ diff -u1 -r '--exclude=__pycache__' ../pypy-base/extra_tests/cffi_tests/cffi1/te
 diff -u1 -r '--exclude=__pycache__' ../pypy-base/extra_tests/cffi_tests/test_c.py extra_tests/cffi_tests/test_c.py
 --- ../pypy-base/extra_tests/cffi_tests/test_c.py	2024-02-12 13:18:08.732446053 +0000
 +++ extra_tests/cffi_tests/test_c.py	2024-02-12 13:23:06.921031740 +0000
-@@ -1,10 +1,3 @@
+
+@@ -1,12 +1,5 @@
 -from __future__ import annotations
 -
 -import contextlib
@@ -49,8 +50,13 @@ diff -u1 -r '--exclude=__pycache__' ../pypy-base/extra_tests/cffi_tests/test_c.p
  import sys
 -import typing as t
  
-@@ -1346,33 +1339,4 @@
+ is_musl = False
+ if sys.platform == 'linux':
+@@ -30,36 +23,6 @@ except ImportError:
+         pytest.skip("_testunc() not available")
+ from _cffi_backend import __version__
  
+-
 -@contextlib.contextmanager
 -def _assert_unraisable(error_type: type[Exception] | None, message: str = '', traceback_tokens: list[str] | None = None):
 -    """Assert that a given sys.unraisablehook interaction occurred (or did not occur, if error_type is None) while this context was active"""
@@ -80,7 +86,14 @@ diff -u1 -r '--exclude=__pycache__' ../pypy-base/extra_tests/cffi_tests/test_c.p
 -    for t in traceback_tokens or []:
 -        assert t in raised_traceback
 -
--
+ # ____________________________________________________________
+ 
+ import sys
+@@ -1377,6 +1340,7 @@ def test_callback():
+ 
+ 
  def test_callback_exception():
 +    pytest.skip("XXX not written for Python 2")
      def check_value(x):
+         if x == 10000:
+             raise ValueError(42)

--- a/pypy/tool/import_cffi.py
+++ b/pypy/tool/import_cffi.py
@@ -4,6 +4,7 @@ whatever version you provide. Usage:
 
 import_cffi.py <path-to-cffi>
 """
+from __future__ import print_function
 
 import sys, py, os
 
@@ -47,7 +48,15 @@ def main(cffi_dir):
     os.system("cd '%s' && patch -p0 < pypy/tool/import_cffi.patch" % str(rootdir))
 
 if __name__ == '__main__':
+    if sys.version_info > (3, 0):
+        print(__doc__)
+        print("must use python2") 
+        sys.exit(2)
     if len(sys.argv) != 2:
-        print __doc__
+        print(__doc__)
+        sys.exit(2)
+    if not os.path.exists(sys.argv[1]):
+        print(__doc__)
+        print("'%s' is not a valid path" % sys.argv[1])
         sys.exit(2)
     main(sys.argv[1])


### PR DESCRIPTION
- Run `PYTHONPATH=. python2 pypy/tools/release/import_cffi.py` to update extra_tests and lib_pypy
- Fix up lib_pypy/cffi.dist-info/METADATA
- Update pypy/module/_cffi_backend/test/_backend_test_c.py

The test_file test will still fail, since the cffi `main` branch did not update the version, see python-cffi/cffi#116

The METADATA will need re-doing when this is merged to py3.9/py3.10.