### PR TITLE
Fix typos in .rst files with codespell

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+# A basic workflow to run pre-commit on code changes.
+# https://pre-commit.com and https://github.com/pre-commit/action
+
+name: pre-commit
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# Learn more about this config here: https://pre-commit.com/
+
+# To enable these pre-commit hooks run:
+# `pipx install pre-commit` or `brew install pre-commit`
+# Then in the project root directory run `pre-commit install`
+
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: ["--toml=pyproject.toml"]
+        types: [rst]
+        additional_dependencies:
+          - tomli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.codespell]
+ignore-words-list = "buildd,clos,gameboy,ist,som"
+skip = "pypy/doc/contributor.rst"

--- a/pypy/doc/architecture.rst
+++ b/pypy/doc/architecture.rst
@@ -109,7 +109,7 @@ RPython is not apparent at first.  Built-in modules are written in
 ``pypy/module/*``.  Some modules that CPython implements in C are
 simply written in pure Python; they are in the top-level ``lib_pypy``
 directory.  The standard library of Python (with a few changes to
-accomodate PyPy) is in ``lib-python``.
+accommodate PyPy) is in ``lib-python``.
 
 JIT Compiler
 ~~~~~~~~~~~~

--- a/pypy/doc/build.rst
+++ b/pypy/doc/build.rst
@@ -207,7 +207,7 @@ are shorthand for::
 
     pypy ../../rpython/bin/rpython <rpython options> targetpypystandalone.py <pypy options>
 
-More help is availabe via ``--help`` at either option position, and more info
+More help is available via ``--help`` at either option position, and more info
 can be found in the :doc:`config/index` section.
 
 (You can use ``python`` instead of ``pypy`` here, which will take longer
@@ -216,7 +216,7 @@ but works too.)
 If everything works correctly this will:
 
 1. Run the rpython `translation chain`_, producing a database of the
-   entire pypy interpreter. This step is currently singe threaded, and RAM
+   entire pypy interpreter. This step is currently single threaded, and RAM
    hungry. As part of this step,  the chain creates a large number of C code
    files and a Makefile to compile them in a
    directory controlled by the ``PYPY_USESSION_DIR`` environment variable.

--- a/pypy/doc/coding-guide.rst
+++ b/pypy/doc/coding-guide.rst
@@ -373,7 +373,7 @@ on some classes being old-style.
 
 We just maintain those changes in place,
 to see what is changed we have a branch called `vendor/stdlib`
-wich contains the unmodified cpython stdlib
+which contains the unmodified cpython stdlib
 
 
 .. _mixed module mechanism:

--- a/pypy/doc/dev_method.rst
+++ b/pypy/doc/dev_method.rst
@@ -2,7 +2,7 @@ Distributed and agile development in PyPy
 =========================================
 
 .. note::
-  This page describes the mode of development that preceeds the current models
+  This page describes the mode of development that precedes the current models
   of Open Source development. While people are welcome to join our (now yearly)
   sprints, we encourage engagement via the GitHub repo at
   https://github.com/pypy/pypy/. Issues can be filed and discussed in the
@@ -64,7 +64,7 @@ Other typical sprint factors:
     conditions, releases and such like. What we do have is a local organizer,
     often a developer living in the area and one more developer who prepares
     and organizes sprint. They do not "manage" the sprint when its started -
-    their role is more of the logistic nature. This doesn't mean that we wont
+    their role is more of the logistic nature. This doesn't mean that we won't
     have use for the coach technique or something similar in the future).
 
   * only coding (this is a tough one. There have been projects who have used

--- a/pypy/doc/discussion/jit-profiler.rst
+++ b/pypy/doc/discussion/jit-profiler.rst
@@ -7,7 +7,7 @@ percentage of the time have been spent in which loops.
 Long term goal: integrate the data collected by the profiler with the
 jitviewer.
 
-The idea is record an event in the PYPYLOG everytime we enter and exit a loop
+The idea is record an event in the PYPYLOG every time we enter and exit a loop
 or a bridge.
 
 Expected output

--- a/pypy/doc/discussion/rawrefcount.rst
+++ b/pypy/doc/discussion/rawrefcount.rst
@@ -21,7 +21,7 @@ PyObject.  There are two kinds of link:
 
 rawrefcount.create_link_pypy(p, ob)
 
-    Makes a link between an exising object gcref 'p' and a newly
+    Makes a link between an existing object gcref 'p' and a newly
     allocated PyObject structure 'ob'.  ob->ob_refcnt must be
     initialized to either REFCNT_FROM_PYPY, or
     REFCNT_FROM_PYPY_LIGHT.  (The second case is an optimization:

--- a/pypy/doc/faq.rst
+++ b/pypy/doc/faq.rst
@@ -262,7 +262,7 @@ various corner cases in your code.  This is a bad case for JIT
 compilers.  Note also that our JIT has a very high warm-up cost, meaning
 that any program is slow at the beginning.  If you want to compare the
 timings with CPython, even relatively simple programs need to run *at
-least* one second, preferrably at least a few seconds.  Large,
+least* one second, preferably at least a few seconds.  Large,
 complicated programs need even more time to warm-up the JIT.
 
 .. _benchmarking site: https://speed.pypy.org
@@ -468,7 +468,7 @@ In more details:
   virtual machine where the problem occurs.
 
 * If giving us access would require us to use tools other than ssh,
-  make appointments, or sign a NDA, then we can consider a commerical
+  make appointments, or sign a NDA, then we can consider a commercial
   support contract for a small sum of money.
 
 * If even that is not possible for you, then sorry, we can't help.

--- a/pypy/doc/gc_info.rst
+++ b/pypy/doc/gc_info.rst
@@ -14,7 +14,7 @@ objects, where allocation is very cheap, being just a pointer bump. The nursery
 size is a very crucial variable - depending on your workload (one or many
 processes) and cache sizes you might want to experiment with it via
 *PYPY_GC_NURSERY* environment variable. When the nursery is full, a minor
-collection is performed. Freed objects are no longer referencable and
+collection is performed. Freed objects are no longer referenceable and
 just die, just by not being referenced any more; on the other hand, objects
 found to still be alive must survive and are copied from the nursery
 to the old generation. Either to arenas, which are collections

--- a/pypy/doc/how-to-release.rst
+++ b/pypy/doc/how-to-release.rst
@@ -11,11 +11,11 @@ release is tagged, for instance release-pypy3.5-v4.0.1.
 The release version number should be bumped. A micro release increment means
 there were no changes that justify rebuilding c-extension wheels, since
 the wheels are marked with only major.minor version numbers. It is ofen not
-clear what constitues a "major" release verses a "minor" release, the release
+clear what constitutes a "major" release verses a "minor" release, the release
 manager can make that call.
 
 After release, inevitably there are bug fixes. It is the responsibility of
-the commiter who fixes a bug to make sure this fix is on the release branch,
+the committer who fixes a bug to make sure this fix is on the release branch,
 so that we can then create a tagged bug-fix release, which will hopefully
 happen more often than stable releases.
 
@@ -58,7 +58,7 @@ when we do a merge::
 Then, we need to do the same for the 3.x branch::
 
   $ hg up -r py3.5
-  $ hg merge default # this brings the version fo 7.1.0-alpha0
+  $ hg merge default # this brings the version of 7.1.0-alpha0
   $ hg branch release-pypy3.5-v7.x
   $ # edit the version to 7.0.0-final
   $ hg ci
@@ -78,7 +78,7 @@ To change the version, you need to edit three files:
 
   - ``doc/conf.py``
 
-Add tags to the repo. Never change tags once commited: it breaks downstream
+Add tags to the repo. Never change tags once committed: it breaks downstream
 packaging workflows.
 
   - Make sure the version checks pass (they ensure ``version.py`` and

--- a/pypy/doc/jit-hooks.rst
+++ b/pypy/doc/jit-hooks.rst
@@ -32,7 +32,7 @@ understanding what pypy's JIT is doing while running your program:
     jit hook won't be called for that.
 
     if operations=False, no list of operations will be available. Useful
-    if the hook is supposed to be very lighweight.
+    if the hook is supposed to be very lightweight.
 
 .. function:: set_abort_hook(hook)
 
@@ -120,7 +120,7 @@ Resetting the JIT
 
 .. function:: set_param(*args, **keywords)
 
-    Configure the tunable JIT parameters, paramter names are listed in :ref:`Jit Help<jit-help>` :
+    Configure the tunable JIT parameters, parameter names are listed in :ref:`Jit Help<jit-help>` :
 
     * ``set_param(name=value, ...)`` as keyword arguments
 

--- a/pypy/doc/objspace.rst
+++ b/pypy/doc/objspace.rst
@@ -257,7 +257,7 @@ Creation of Application Level objects
    Creates a Unicode string from an rpython byte string, decoded as
    "utf-8-nosg".  On PyPy3 it is the same as :py:function::`newtext`.
 
-Many more space operations can be found in `pypy/interpeter/baseobjspace.py` and
+Many more space operations can be found in `pypy/interpreter/baseobjspace.py` and
 `pypy/objspace/std/objspace.py`.
 
 Conversions from Application Level to Interpreter Level

--- a/pypy/doc/project-ideas.rst
+++ b/pypy/doc/project-ideas.rst
@@ -107,7 +107,7 @@ immediately, but only when (and if) ``myslice`` or ``mylist`` are mutated.
 NumPy rebooted
 --------------
 
-Our cpyext C-API compatiblity layer can now run upstream NumPy unmodified.
+Our cpyext C-API compatibility layer can now run upstream NumPy unmodified.
 We need to refactor the way `NumPy adds docstrings`_.
 
 .. _`NumPy adds docstrings`: https://github.com/numpy/numpy/issues/10167
@@ -158,7 +158,7 @@ The world is moving on, we should too. Work in this direction has begun on the
 things that are known to need careful refactoring:
 
 - a single character in python3 is an int, not a byte
-- we use ``str``/``unicode`` to distiguish between different modes of
+- we use ``str``/``unicode`` to distinguish between different modes of
   operation for windows in ``make_win32_traits``.
 
 There are probably more. The branch currently does not pass rpython tests so

--- a/pypy/doc/release-1.8.0.rst
+++ b/pypy/doc/release-1.8.0.rst
@@ -5,7 +5,7 @@ PyPy 1.8 - business as usual
 We're pleased to announce the 1.8 release of PyPy. As habitual this
 release brings a lot of bugfixes, together with performance and memory
 improvements over the 1.7 release. The main highlight of the release
-is the introduction of `list strategies`_ which makes homogenous lists
+is the introduction of `list strategies`_ which makes homogeneous lists
 more efficient both in terms of performance and memory. This release
 also upgrades us from Python 2.7.1 compatibility to 2.7.2. Otherwise
 it's "business as usual" in the sense that performance improved

--- a/pypy/doc/release-1.9.0.rst
+++ b/pypy/doc/release-1.9.0.rst
@@ -62,7 +62,7 @@ Highlights
 
 * Many bugs were corrected for Windows 32 bit.  This includes new
   functionality to test the validity of file descriptors; and
-  correct handling of the calling convensions for ctypes.  (Still not
+  correct handling of the calling conventions for ctypes.  (Still not
   much progress on Win64.) A lot of work on this has been done by Matti Picus
   and Amaury Forgeot d'Arc.
 

--- a/pypy/doc/release-2.0.0-beta1.rst
+++ b/pypy/doc/release-2.0.0-beta1.rst
@@ -58,7 +58,7 @@ Reasons why this is not PyPy 2.0:
   call from C.
 
 * ``numpypy`` lazy computation was disabled for the sake of simplicity.
-  We should reenable this for the final 2.0 release.
+  We should re-enable this for the final 2.0 release.
 
 Highlights
 ==========

--- a/pypy/doc/release-2.0.0-beta2.rst
+++ b/pypy/doc/release-2.0.0-beta2.rst
@@ -18,7 +18,7 @@ make it happen before the 2.0 final. The new major features are:
 * This is the first PyPy release that includes `cffi`_ as a core library.
   Version 0.6 comes included in the PyPy library. cffi has seen a lot of
   adoption among library authors and we believe it's the best way to wrap
-  C libaries. You can see examples of cffi usage in `_curses.py`_ and
+  C libraries. You can see examples of cffi usage in `_curses.py`_ and
   `_sqlite3.py`_ in the PyPy source code.
 
 You can download the PyPy 2.0 beta 2 release here:

--- a/pypy/doc/release-2.3.0.rst
+++ b/pypy/doc/release-2.3.0.rst
@@ -107,7 +107,7 @@ New Platforms and Features
 
 * Support for precompiled headers in the build process for MSVC
 
-* Tweak support of errno in cpyext (the PyPy implemenation of the capi)
+* Tweak support of errno in cpyext (the PyPy implementation of the capi)
 
 
 NumPy

--- a/pypy/doc/release-2.4.0.rst
+++ b/pypy/doc/release-2.4.0.rst
@@ -85,7 +85,7 @@ for more information see `whats-new`_:
   this mostly affects errno handling on linux, which makes external calls
   faster.
 
-* Move to a mixed polling and mutex GIL model that make mutlithreaded jitted
+* Move to a mixed polling and mutex GIL model that make multithreaded jitted
   code run *much* faster
 
 * Optimize errno handling in linux (x86 and x86-64 only)

--- a/pypy/doc/release-2.5.0.rst
+++ b/pypy/doc/release-2.5.0.rst
@@ -11,7 +11,7 @@ You can download the PyPy 2.5.0 release here:
 
 We would like to thank our donors for the continued support of the PyPy
 project, and for those who donate to our three sub-projects, as well as our
-volunteers and contributors (10 new commiters joined PyPy since the last
+volunteers and contributors (10 new committers joined PyPy since the last
 release).
 We've shown quite a bit of progress, but we're slowly running out of funds.
 Please consider donating more, or even better convince your employer to donate,
@@ -55,7 +55,7 @@ Highlights
 * The past months have seen pypy mature and grow, as rpython becomes the goto
   solution for writing fast dynamic language interpreters. Our separation of
   rpython and the python interpreter PyPy is now much clearer in the
-  `PyPy documentation`_  and we now have seperate `RPython documentation`_.
+  `PyPy documentation`_  and we now have separate `RPython documentation`_.
 
 * We have improved warmup time as well as jitted code performance: more than 10%
   compared to pypy-2.4.0, due to internal cleanup and gc nursery improvements.
@@ -72,7 +72,7 @@ Highlights
   support the lapack/blas linalg module of numpy. This dovetails with work in the
   pypy/numpy repository to support linalg both through the (slower) cpyext capi
   interface and also via (the faster) pure python cffi interface, using an
-  extended frompyfunc() api. We will soon post a seperate blog post specifically
+  extended frompyfunc() api. We will soon post a separate blog post specifically
   about linalg and PyPy.
 
 * Dictionaries are now ordered by default, see the `blog post`_

--- a/pypy/doc/release-2.5.1.rst
+++ b/pypy/doc/release-2.5.1.rst
@@ -64,7 +64,7 @@ Highlights
 * The past months have seen pypy mature and grow, as rpython becomes the goto
   solution for writing fast dynamic language interpreters. Our separation of
   Rpython and the python interpreter PyPy is now much clearer in the
-  `PyPy documentation`_  and we now have seperate `RPython documentation`_.
+  `PyPy documentation`_  and we now have separate `RPython documentation`_.
   Tell us what still isn't clear, or even better help us improve the documentation.
 
 * We merged version 2.7.9 of python's stdlib. From the python release notice:

--- a/pypy/doc/release-2.6.0.rst
+++ b/pypy/doc/release-2.6.0.rst
@@ -3,7 +3,7 @@ PyPy 2.6.0 - Cameo Charm
 ========================
 
 We're pleased to announce PyPy 2.6.0, only two months after PyPy 2.5.1.
-We are particulary happy to update `cffi`_ to version 1.1, which makes the
+We are particularly happy to update `cffi`_ to version 1.1, which makes the
 popular ctypes-alternative even easier to use, and to support the new vmprof_
 statistical profiler.
 
@@ -89,7 +89,7 @@ Highlights
 * New features:
 
   * Add preliminary support for a new lightweight statistical profiler
-    `vmprof`_, which has been designed to accomodate profiling JITted code
+    `vmprof`_, which has been designed to accommodate profiling JITted code
 
 * Numpy:
 

--- a/pypy/doc/release-4.0.0.rst
+++ b/pypy/doc/release-4.0.0.rst
@@ -74,7 +74,7 @@ CFFI
 
 While not applicable only to PyPy, `cffi`_ is arguably our most significant
 contribution to the python ecosystem. Armin Rigo continued improving it,
-and PyPy reaps the benefits of `cffi-1.3`_: improved manangement of object
+and PyPy reaps the benefits of `cffi-1.3`_: improved management of object
 lifetimes, __stdcall on Win32, ffi.memmove(), and percolate ``const``,
 ``restrict`` keywords from cdef to C code.
 
@@ -130,7 +130,7 @@ Other Highlights (since 2.6.1 release two months ago)
 
   * Use gcrootfinder=shadowstack by default, asmgcc on linux only
 
-  * Fix ndarray.copy() for upstream compatability when copying non-contiguous arrays
+  * Fix ndarray.copy() for upstream compatibility when copying non-contiguous arrays
 
   * Fix assumption that lltype.UniChar is unsigned
 
@@ -175,12 +175,12 @@ Other Highlights (since 2.6.1 release two months ago)
 
   * Reuse hashed keys across dictionaries and sets
 
-  * Refactor JIT interals to improve warmup time by 20% or so at the cost of a
+  * Refactor JIT internals to improve warmup time by 20% or so at the cost of a
     minor regression in JIT speed
 
   * Recognize patterns of common sequences in the JIT backends and optimize them
 
-  * Make the garbage collecter more incremental over external_malloc() calls
+  * Make the garbage collector more incremental over external_malloc() calls
 
   * Share guard resume data where possible which reduces memory usage
 

--- a/pypy/doc/release-5.0.0.rst
+++ b/pypy/doc/release-5.0.0.rst
@@ -115,7 +115,7 @@ Other Highlights (since 4.0.1 released in November 2015)
   * Fix (de)pickling long values by simplifying the implementation
 
   * Fix RPython rthread so that objects stored as threadlocal do not force minor
-    GC collection and are kept alive automatically. This improves perfomance of
+    GC collection and are kept alive automatically. This improves performance of
     short-running Python callbacks and prevents resetting such object between
     calls
 
@@ -212,7 +212,7 @@ Other Highlights (since 4.0.1 released in November 2015)
 
   * Refactor rtyper debug code into python.rtyper.debug
 
-  * Seperate structmember.h from Python.h Also enhance creating api functions
+  * Separate structmember.h from Python.h Also enhance creating api functions
     to specify which header file they appear in (previously only pypy_decl.h)
 
   * Fix tokenizer to enforce universal newlines, needed for Python 3 support

--- a/pypy/doc/release-5.1.1.rst
+++ b/pypy/doc/release-5.1.1.rst
@@ -3,7 +3,7 @@ PyPy 5.1.1
 ==========
 
 We have released a bugfix for PyPy 5.1, due to a regression_ in
-installing third-party packages dependant on numpy (using our numpy fork
+installing third-party packages dependent on numpy (using our numpy fork
 available at https://bitbucket.org/pypy/numpy ).
 
 Thanks to those who reported the issue. We also fixed a regression in

--- a/pypy/doc/release-pypy2.7-v5.3.0.rst
+++ b/pypy/doc/release-pypy2.7-v5.3.0.rst
@@ -3,9 +3,9 @@ PyPy2.7 v5.3
 ============
 
 We have released PyPy2.7 v5.3, about six weeks after PyPy 5.1 and a week after
-`PyPy3.3 v5.2 alpha 1`_, the first PyPy release targetting 3.3
+`PyPy3.3 v5.2 alpha 1`_, the first PyPy release targeting 3.3
 compatibility. This new PyPy2.7 release includes further improvements for the
-CAPI compatibility layer which we call cpyext. In addtion to complete support
+CAPI compatibility layer which we call cpyext. In addition to complete support
 for lxml, we now pass most (more than 90%) of the upstream numpy test suite,
 and much of SciPy is supported as well.
 
@@ -75,7 +75,7 @@ Other Highlights (since 5.1 released in April 2016)
         PyAnySet_CheckExact, PyUnicode_Concat, PyDateTime_TZInfo
       - improve support for PyGILState_Ensure, PyGILState_Release, and thread
         primitives, also find a case where CPython will allow thread creation
-        before PyEval_InitThreads is run, dissallow on PyPy 
+        before PyEval_InitThreads is run, disallow on PyPy 
       - create a PyObject-specific list strategy
       - rewrite slot assignment for typeobjects
       - improve tracking of PyObject to rpython object mapping
@@ -88,7 +88,7 @@ Other Highlights (since 5.1 released in April 2016)
   * CPyExt tweak: instead of "GIL not held when a CPython C extension module
     calls PyXxx", we now silently acquire/release the GIL.  Helps with
     CPython C extension modules that call some PyXxx() functions without
-    holding the GIL (arguably, they are theorically buggy).
+    holding the GIL (arguably, they are theoretically buggy).
 
   * Add rgc.FinalizerQueue, documented in pypy/doc/discussion/finalizer-order.rst.
     It is a more flexible way to make RPython finalizers. Use this mechanism to

--- a/pypy/doc/release-pypy2.7-v5.4.0.rst
+++ b/pypy/doc/release-pypy2.7-v5.4.0.rst
@@ -4,7 +4,7 @@ PyPy2.7 v5.4
 
 We have released PyPy2.7 v5.4, a little under two months after PyPy2.7 v5.3.
 This new PyPy2.7 release includes incremental improvements to our C-API
-compatability layer (cpyext), enabling us to pass over 99% of the upstream
+compatibility layer (cpyext), enabling us to pass over 99% of the upstream
 numpy test suite. We updated built-in cffi_ support to version 1.8,
 which now supports the "limited API" mode for c-extensions on 
 CPython >=3.2.

--- a/pypy/doc/release-pypy3-2.1.0-beta1.rst
+++ b/pypy/doc/release-pypy3-2.1.0-beta1.rst
@@ -16,7 +16,7 @@ You can download the PyPy3 2.1 beta 1 release here:
 Highlights
 ==========
 
-* The first release of PyPy3: support for Python 3, targetting CPython 3.2.3!
+* The first release of PyPy3: support for Python 3, targeting CPython 3.2.3!
 
   - There are some `known issues`_ including performance regressions (issues
     `#1540`_ & `#1541`_) slated to be resolved before the final release.

--- a/pypy/doc/release-pypy3-2.4.0.rst
+++ b/pypy/doc/release-pypy3-2.4.0.rst
@@ -93,7 +93,7 @@ directly related to Summer of Code.
   this mostly affects errno handling on linux, which makes external calls
   faster.
 
-* Move to a mixed polling and mutex GIL model that make mutlithreaded jitted
+* Move to a mixed polling and mutex GIL model that make multithreaded jitted
   code run *much* faster
 
 * Optimize errno handling in linux (x86 and x86-64 only)

--- a/pypy/doc/release-v5.10.1.rst
+++ b/pypy/doc/release-v5.10.1.rst
@@ -17,7 +17,7 @@ due to the following issues:
 
   * Fix the winreg module for unicode entries in the registry on windows
 
-Note that many of these fixes are for our new beta verison of PyPy3.5 on
+Note that many of these fixes are for our new beta version of PyPy3.5 on
 windows. There may be more unicode problems in the windows beta version
 especially around the subject of directory- and file-names with non-ascii
 characters.

--- a/pypy/doc/release-v5.7.0.rst
+++ b/pypy/doc/release-v5.7.0.rst
@@ -136,7 +136,7 @@ See also issues that were resolved_
   * fix for ``ctypes.c_bool`` returning ``bool`` restype, issue 2475_
   * fix in corner cases with the GIL and C-API functions
   * allow overriding thread.local.__init__ in a subclass, issue 2501_
-  * allow ``PyClass_New`` to be called with NULL as the first arguemnt, issue 2504_
+  * allow ``PyClass_New`` to be called with NULL as the first argument, issue 2504_
 
 
 * Performance improvements:
@@ -144,7 +144,7 @@ See also issues that were resolved_
   * clean-ups in the jit optimizeopt
   * optimize ``if x is not None: return x`` or ``if x != 0: return x``
   * add ``jit.conditional_call_elidable()``, a way to tell the JIT 
-    "conditonally call this function" returning a result
+    "conditionally call this function" returning a result
   * try harder to propagate ``can_be_None=False`` information
   * add ``rarithmetic.ovfcheck_int32_add/sub/mul``
   * add and use ``rgc.may_ignore_finalizer()``: an optimization hint that makes
@@ -177,7 +177,7 @@ Development moved from the py3k branch to the py3.5 branch in the PyPy bitbucket
 * New features
 
   * this first PyPy3.5 release implements most of Python 3.5.3, exceptions are listed below
-  * PEP 456 allowing secure and interchangable hash algorithms
+  * PEP 456 allowing secure and interchangeable hash algorithms
   * use cryptography_'s cffi backend for SSL
 
 

--- a/pypy/doc/release-v5.8.0.rst
+++ b/pypy/doc/release-v5.8.0.rst
@@ -151,7 +151,7 @@ Note that these are also merged into PyPy 3.5
   * Support posix_fallocate and posix_fadvise, expose them on PyPy3.5
   * Test and fix for int_and() propagating wrong bounds
   * Improve the generated machine code by tracking the (constant) value of
-    r11 across intructions.  This lets us avoid reloading r11 with another
+    r11 across instructions.  This lets us avoid reloading r11 with another
     (apparently slowish) "movabs" instruction, replacing it with either
     nothing or a cheaper variant.
   * Performance tweaks in the x86 JIT-generated machine code: rarely taken
@@ -192,7 +192,7 @@ Highlights of the PyPy3.5 release (since 5.7 beta released March 2017)
     lib-python/3/test runs
   * Call ``sys.__interactivehook__`` at startup
   * Let ``OrderedDict.__init__`` behave like CPython wrt. subclasses
-    overridding ``__setitem__``
+    overriding ``__setitem__``
 
 * Performance improvements:
 

--- a/pypy/doc/release-v7.2.0.rst
+++ b/pypy/doc/release-v7.2.0.rst
@@ -157,7 +157,7 @@ Changes shared across versions
   ``translate``, forrmatting, ``__int__``, ``str(<int>)``, ``startswith``,
   ``endswith``,
 * Reduce the probability of a deadlock when acquiring a semaphore by
-  moving global state changes closer to the actual aquire (`issue 2953`_)
+  moving global state changes closer to the actual acquire (`issue 2953`_)
 * Cleanup and refactor parts of the JIT code
 * Cleanup ``optimizeopt``
 * Support the ``z15`` variant of the ``s390x`` CPU.
@@ -178,7 +178,7 @@ Changes shared across versions
   using `Lehmer's algorithm`_ and use it in the ``math`` module
 * Add ``RFile.closed`` to mirror standard `file` behaviour
 * Add a ``-D`` pytest option to run tests directly on the host python without
-  any knowlege of PyPy internals. This allows using ``pypy3 pytest.py ...``
+  any knowledge of PyPy internals. This allows using ``pypy3 pytest.py ...``
   for a subset of tests (called **app-level testing**)
 * Accept arguments to ``subprocess.Popen`` that are not directly subscriptable
   (like iterators) (`issue 3050`_)

--- a/pypy/doc/release-v7.3.0.rst
+++ b/pypy/doc/release-v7.3.0.rst
@@ -30,7 +30,7 @@ rather than c-extensions to interact with C.
 The built-in ``_cppyy`` module was upgraded to 1.10.6, which
 provides, among others, better template resolution, stricter ``enum`` handling,
 anonymous struct/unions, cmake fragments for distribution, optimizations for
-PODs, and faster wrapper calls. We reccomend using cppyy_ for performant
+PODs, and faster wrapper calls. We recommend using cppyy_ for performant
 wrapping of C++ code for Python.
 
 The vendored pyrepl package for interaction inside the REPL was updated.

--- a/pypy/doc/release-v7.3.11.rst
+++ b/pypy/doc/release-v7.3.11.rst
@@ -14,7 +14,7 @@ PyPy v7.3.11: release of python 2.7, 3.8, and 3.9
 The PyPy team is proud to release version 7.3.11 of PyPy. As could be expected,
 the first release of macOS arm64 impacted the macOS x86-64 build, so this is
 a bug release to restore the ability of macOS users to run PyPy on ``macOS <
-11.0``. It also incoporates the latest CPython stdlib updates released the day
+11.0``. It also incorporates the latest CPython stdlib updates released the day
 after 7.3.10 went out, and a few more bug fixes. The release includes three
 different interpreters:
 
@@ -138,7 +138,7 @@ Python 3.8+
 
 Python 3.9
 ----------
-- Fix pure-python implmentation of ``functools`` (issue 3869_). see also cpython GH-100242_
+- Fix pure-python implementation of ``functools`` (issue 3869_). see also cpython GH-100242_
 - Remove ``type.__ne__``, the inherited behaviour from ``object.__ne__`` is the
   correct one (issue 3879_)
 - Fix invalid parsing rule for ``genexps`` as the non-singular argument in a call (issue 3873_)

--- a/pypy/doc/release-v7.3.14.rst
+++ b/pypy/doc/release-v7.3.14.rst
@@ -4,7 +4,7 @@ PyPy v7.3.14: release of python 2.7, 3.9, and 3.10
 
 The PyPy team is proud to release version 7.3.14 of PyPy.
 
-Hightlights of this release are compatibility with HPy-0.9_, cffi 1.16,
+Highlights of this release are compatibility with HPy-0.9_, cffi 1.16,
 additional C-API interfaces, and more python3.10 fixes.
 
 The release includes three different interpreters:

--- a/pypy/doc/release-v7.3.4.rst
+++ b/pypy/doc/release-v7.3.4.rst
@@ -265,7 +265,7 @@ Python 3.7+
 - Fix for surrogates in ``winreg`` input value (issue 3345_)
 - In ``sysconfig``, ``INCLUDEPY`` and ``INCLUDEDIR`` should point to the
   original directory even in a virtualenv (issue 3364_)
-- Add ``LDLIBRARY`` to ``sysconfig`` for posgresql
+- Add ``LDLIBRARY`` to ``sysconfig`` for postgresql
 - Prevent overflow in ``_hash_long`` on win64 using method from CPython
 - Raise ``ValueError`` when ``argv[0]`` of ``execv`` and friends is empty (`bpo
   28732`_)

--- a/pypy/doc/release-v7.3.5.rst
+++ b/pypy/doc/release-v7.3.5.rst
@@ -7,7 +7,7 @@ PyPy 7.3.4 was the first release that runs on windows 64-bit, so that support
 is still "beta". We are releasing it in the hopes that we can garner momentum
 for its continued support, but are already aware of some problems, for instance
 it errors in the NumPy test suite (issue 3462_). Please help out with testing
-the releae and reporting successes and failures, financially supporting our
+the release and reporting successes and failures, financially supporting our
 ongoing work, and helping us find the source of these problems.
 
 - The new windows 64-bit builds improperly named c-extension modules

--- a/pypy/doc/release-v7.3.6.rst
+++ b/pypy/doc/release-v7.3.6.rst
@@ -162,7 +162,7 @@ Speedups and enhancements shared across versions
 
 C-API (cpyext) and C-extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-We are no longer backporting changes to the ``cpyext`` compatiblity layer to
+We are no longer backporting changes to the ``cpyext`` compatibility layer to
 PyPy2.7.
 
 
@@ -181,10 +181,10 @@ Python 3.7+ bugfixes
 
 Python 3.7+ speedups and enhancements
 -------------------------------------
-- Speep up cached imports by re-implementing (a subset of) `bpo 22557`_. This
+- Speed up cached imports by re-implementing (a subset of) `bpo 22557`_. This
   brings PyPy3.7 very close to the speed of PyPy2 (issue 3431_)
 - Ignore finalizers on built-in ``io`` classes if we know the stream is closed.
-  Also find some other optimizations aroudn ``io`` operations.
+  Also find some other optimizations around ``io`` operations.
 - Add more fields to ``sysconfig.get_config_var`` via ``_sysconfigdata`` (issue
   3483_)
 - Add a ``sys.implementation._multiarch`` field like CPython on linux and

--- a/pypy/doc/release-v7.3.7.rst
+++ b/pypy/doc/release-v7.3.7.rst
@@ -16,7 +16,7 @@ Additionally, a few smaller bugs were fixed:
 
 - Use ``uint`` for the ``request`` argument of ``fcntl.ioctl`` (issue 3568_)
 - Fix incorrect tracing of `while True`` body in 3.8 (issue 3577_)
-- Properly close resources when using a ``conncurrent.futures.ProcessPool``
+- Properly close resources when using a ``concurrent.futures.ProcessPool``
   (issue 3317_)
 - Fix the value of ``LIBDIR`` in ``_sysconfigdata`` in 3.8 (issue 3582_)
 

--- a/pypy/doc/stackless.rst
+++ b/pypy/doc/stackless.rst
@@ -62,7 +62,7 @@ frame.  Then you have removed from the normal stack all intermediate
 frames, and turned them into one stand-alone cycle.  By doing the same
 permutation again you restore the original situation.
 
-In practice, in PyPy, you cannot change the ``f_back`` of an abitrary
+In practice, in PyPy, you cannot change the ``f_back`` of an arbitrary
 frame, but only of frames stored in ``continulets``.
 
 Continulets are internally implemented using stacklets_.  Stacklets are a
@@ -300,7 +300,7 @@ uses coroutines for two unrelated purposes may run into conflicts caused
 by unexpected interactions.
 
 To illustrate the problem, consider the following example (simplified
-code using a theorical ``coroutine`` class).  First, a simple usage of
+code using a theoretical ``coroutine`` class).  First, a simple usage of
 coroutine::
 
     main_coro = coroutine.getcurrent()    # the main (outer) coroutine

--- a/pypy/doc/stm.rst
+++ b/pypy/doc/stm.rst
@@ -56,7 +56,7 @@ more in parallel should ideally run faster than in a regular PyPy
 * ``pypy-stm`` provides (but does not impose) a special API to the
   user in the pure Python module ``transaction``.  This module is based
   on the lower-level module ``pypystm``, but also provides some
-  compatibily with non-STM PyPy's or CPython's.
+  compatibility with non-STM PyPy's or CPython's.
 
 * Building on top of the way the GIL is removed, we will talk
   about `How to write multithreaded programs: the 10'000-feet view`_
@@ -163,7 +163,7 @@ Current status (stmgc-c7)
   edge ``stmgc-c8`` is better at that.)
 
 * Weakrefs might appear to work a bit strangely for now, sometimes
-  staying alive throught ``gc.collect()``, or even dying but then
+  staying alive through ``gc.collect()``, or even dying but then
   un-dying for a short time before dying again.  A similar problem can
   show up occasionally elsewhere with accesses to some external
   resources, where the (apparent) serialized order doesn't match the
@@ -278,7 +278,7 @@ unchanged: although running on multiple cores in parallel, ``pypy-stm``
 gives the illusion that threads are run serially, with switches only
 occurring between bytecodes, not in the middle of them.  Programs can
 rely on this: using ``shared_list.append()/pop()`` or
-``shared_dict.setdefault()`` as synchronization mecanisms continues to
+``shared_dict.setdefault()`` as synchronization mechanisms continues to
 work as expected.
 
 This works by internally considering the points where a standard PyPy or
@@ -442,7 +442,7 @@ Common causes of conflicts:
   ``rtyper_makekey()`` method will be called many times for the same
   object; the code used to repeatedly set the flag to ``True``, but
   now it first checks and only does the write if it is ``False``.
-  Similarly, in the second half of the checkin, the method
+  Similarly, in the second half of the check in, the method
   ``setup_block_entry()`` used to both assign the ``concretetype``
   fields and return a list, but its two callers were different: one
   would really need the ``concretetype`` fields initialized, whereas
@@ -476,7 +476,7 @@ Here is a direct usage example::
         lst1.append(x)
 
 In this example, we are sure that the item popped off one end of
-the list is appened again at the other end atomically.  It means that
+the list is appended again at the other end atomically.  It means that
 another thread can run ``len(lst1)`` or ``x in lst1`` without any
 particular synchronization, and always see the same results,
 respectively ``10`` and ``True``.  It will never see the intermediate
@@ -653,7 +653,7 @@ queue should eventually be designed.)
 A conflict occurs as follows: when a transaction commits (i.e. finishes
 successfully) it may cause other transactions that are still in progress
 to abort and retry.  This is a waste of CPU time, but even in the worst
-case senario it is not worse than a GIL, because at least one
+case scenario it is not worse than a GIL, because at least one
 transaction succeeds (so we get at worst N-1 CPUs doing useless jobs and
 1 CPU doing a job that commits successfully).
 

--- a/pypy/doc/whatsnew-1.9.rst
+++ b/pypy/doc/whatsnew-1.9.rst
@@ -124,7 +124,7 @@ content merged into "lib-python/2.7".
 
 .. branch: step-one-xrange
 
-The common case of a xrange iterator with no step argument specifed
+The common case of a xrange iterator with no step argument specified
 was somewhat optimized. The tightest loop involving it,
 sum(xrange(n)), is now 18% faster on average.
 

--- a/pypy/doc/whatsnew-2.0.rst
+++ b/pypy/doc/whatsnew-2.0.rst
@@ -7,7 +7,7 @@ What's new in PyPy 2.0
 
 .. branch: split-rpython
 
-Split rpython and pypy into seperate directories
+Split rpython and pypy into separate directories
 
 .. branch: callback-jit
 

--- a/pypy/doc/whatsnew-2.4.0.rst
+++ b/pypy/doc/whatsnew-2.4.0.rst
@@ -73,4 +73,4 @@ Upgrades from 2.7.6 to 2.7.8
 
 .. branch: cpybug-seq-radd-rmul
 
-Fix issue #1861 - cpython compatability madness
+Fix issue #1861 - cpython compatibility madness

--- a/pypy/doc/whatsnew-2.5.0.rst
+++ b/pypy/doc/whatsnew-2.5.0.rst
@@ -42,7 +42,7 @@ Kill multimethod machinery, all multimethods were removed earlier.
 
 .. branch nditer-external_loop
 
-Implement `external_loop` arguement to numpy's nditer
+Implement `external_loop` argument to numpy's nditer
 
 .. branch kill-rctime
 

--- a/pypy/doc/whatsnew-2.5.1.rst
+++ b/pypy/doc/whatsnew-2.5.1.rst
@@ -9,7 +9,7 @@ What's new in PyPy 2.5.1
 Non-blocking file reads sometimes raised EAGAIN even though they
 had buffered data waiting, fixed in b1c4fcb04a42
 
-Fix a bug in cpyext in multithreded programs acquiring/releasing the GIL
+Fix a bug in cpyext in multithreaded programs acquiring/releasing the GIL
 
 .. branch: vmprof
 

--- a/pypy/doc/whatsnew-2.6.0.rst
+++ b/pypy/doc/whatsnew-2.6.0.rst
@@ -33,7 +33,7 @@ Fix isspace as called by rpython unicode.strip()
 
 issue2023:
 In the cpyext 'Concrete Object Layer' API,
-don't call methods on the object (which can be overriden),
+don't call methods on the object (which can be overridden),
 but directly on the concrete base type.
 
 issue2029:
@@ -96,7 +96,7 @@ Implement np.can_cast, np.min_scalar_type and missing dtype comparison operation
 .. branch: numpy-fixes
 
 branch numpy-fixes:
-Fix some error related to object dtype, non-contiguous arrays, inplement parts of 
+Fix some error related to object dtype, non-contiguous arrays, implement parts of 
 __array_interface__, __array_priority__, __array_wrap__
 
 .. branch: cells-local-stack

--- a/pypy/doc/whatsnew-4.0.0.rst
+++ b/pypy/doc/whatsnew-4.0.0.rst
@@ -38,7 +38,7 @@ keep adding up between them.
 
 .. branch: remember-tracing-counts
 
-Reenable jithooks
+Re-enable jithooks
 
 .. branch: detect_egd2
 

--- a/pypy/doc/whatsnew-5.0.0.rst
+++ b/pypy/doc/whatsnew-5.0.0.rst
@@ -30,7 +30,7 @@ to allow for alternate ``int``-like implementations (e.g., ``future.types.newint
 
 .. branch: faster-rstruct
 
-Improve the performace of struct.unpack, which now directly reads inside the
+Improve the performance of struct.unpack, which now directly reads inside the
 string buffer and directly casts the bytes to the appropriate type, when
 allowed. Unpacking of floats and doubles is about 15 times faster now, while
 for integer types it's up to ~50% faster for 64bit integers.
@@ -151,7 +151,7 @@ Refactor vmprof to work cross-operating-system.
 
 .. branch: seperate-strucmember_h
 
-Seperate structmember.h from Python.h Also enhance creating api functions
+Separate structmember.h from Python.h Also enhance creating api functions
 to specify which header file they appear in (previously only pypy_decl.h) 
 
 .. branch: llimpl

--- a/pypy/doc/whatsnew-5.1.0.rst
+++ b/pypy/doc/whatsnew-5.1.0.rst
@@ -7,7 +7,7 @@ What's new in PyPy 5.1
 
 .. branch: s390x-backend
 
-The jit compiler backend implementation for the s390x architecutre.
+The jit compiler backend implementation for the s390x architecture.
 The backend manages 64-bit values in the literal pool of the assembly instead of loading them as immediates.
 It includes a simplification for the operation 'zero_array'. Start and length parameters are bytes instead of size.
 
@@ -57,7 +57,7 @@ annoying special-purpose code for pinned pointers.
 
 .. branch: cleanup-includes
 
-Remove old uneeded numpy headers, what is left is only for testing. Also 
+Remove old unneeded numpy headers, what is left is only for testing. Also 
 generate pypy_numpy.h which exposes functions to directly use micronumpy
 ndarray and ufuncs
 

--- a/pypy/doc/whatsnew-pypy2-5.3.0.rst
+++ b/pypy/doc/whatsnew-pypy2-5.3.0.rst
@@ -40,7 +40,7 @@ to cpyext:
   - PyAnySet_CheckExact, PyUnicode_Concat
   - improve support for PyGILState_Ensure, PyGILState_Release, and thread
     primitives, also find a case where CPython will allow thread creation
-    before PyEval_InitThreads is run, dissallow on PyPy 
+    before PyEval_InitThreads is run, disallow on PyPy 
   - create a PyObject-specific list strategy
   - rewrite slot assignment for typeobjects
   - improve tracking of PyObject to rpython object mapping
@@ -61,7 +61,7 @@ generated subclasses.
 CPyExt tweak: instead of "GIL not held when a CPython C extension module
 calls PyXxx", we now silently acquire/release the GIL.  Helps with
 CPython C extension modules that call some PyXxx() functions without
-holding the GIL (arguably, they are theorically buggy).
+holding the GIL (arguably, they are theoretically buggy).
 
 .. branch: cpyext-test-A
 

--- a/pypy/doc/whatsnew-pypy2-5.7.0.rst
+++ b/pypy/doc/whatsnew-pypy2-5.7.0.rst
@@ -33,7 +33,7 @@ Clean-ups in the jit optimizeopt
 
 .. branch: conditional_call_value_4
 
-Add jit.conditional_call_elidable(), a way to tell the JIT "conditonally
+Add jit.conditional_call_elidable(), a way to tell the JIT "conditionally
 call this function" returning a result.
 
 .. branch: desc-specialize
@@ -55,7 +55,7 @@ class loader, etc.) remain the same.  A libcppyy_backend.so library is still
 needed but is now available through PyPI with pip: PyPy-cppyy-backend.
 
 The Cling-backend brings support for modern C++ (11, 14, etc.), dynamic
-template instantations, and improved integration with CFFI for better
+template instantiations, and improved integration with CFFI for better
 performance.  It also provides interactive C++ (and bindings to that).
 
 .. branch: better-PyDict_Next

--- a/pypy/doc/whatsnew-pypy2-6.0.0.rst
+++ b/pypy/doc/whatsnew-pypy2-6.0.0.rst
@@ -43,7 +43,7 @@ Improve way to describe memory
 
 .. branch: msvc14
 
-Allow compilaiton with Visual Studio 2017 compiler suite on windows
+Allow compilation with Visual Studio 2017 compiler suite on windows
 
 .. branch: refactor-slots
 

--- a/pypy/doc/whatsnew-pypy2-7.2.0.rst
+++ b/pypy/doc/whatsnew-pypy2-7.2.0.rst
@@ -20,7 +20,7 @@ Add ``DateTime_FromTimestamp`` and ``Date_FromTimestamp``
 .. branch: semlock-deadlock
 
 Test and reduce the probability of a deadlock when acquiring a semaphore by
-moving global state changes closer to the actual aquire.
+moving global state changes closer to the actual acquire.
 
 .. branch: shadowstack-issue2722
 

--- a/pypy/doc/whatsnew-pypy2-7.3.4.rst
+++ b/pypy/doc/whatsnew-pypy2-7.3.4.rst
@@ -63,7 +63,7 @@ e.g. it's always constant-folded away
 
 .. branch: map-improvements
 
-Optimize instances with integer or float fields to have more efficent field
+Optimize instances with integer or float fields to have more efficient field
 reads and writes. They also use less memory if they have at least two such
 fields.
 

--- a/pypy/doc/whatsnew-pypy3-7.3.6.rst
+++ b/pypy/doc/whatsnew-pypy3-7.3.6.rst
@@ -34,7 +34,7 @@ identifiers.
 
 .. branch: py3.7-import-speedup
 
-Speep up cached imports by re-implementing (a subset of) BPO-22557. This brings
+Speed up cached imports by re-implementing (a subset of) BPO-22557. This brings
 it very close to PyPy2 standards.
 
 .. branch: py3.7-ignore-finalizer-files-after-close

--- a/pypy/doc/windows.rst
+++ b/pypy/doc/windows.rst
@@ -118,14 +118,14 @@ i.e. x86_64-w64-mingw32-gcc for the 64 bit compiler creating a 64 bit target.
 
 You probably want to set the CPATH, LIBRARY_PATH, and PATH environment
 variables to the header files, lib or dlls, and dlls respectively of the
-locally installed packages if they are not in the mingw directory heirarchy.
+locally installed packages if they are not in the mingw directory hierarchy.
 
 
 libffi for the mingw compiler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To enable the _rawffi (and ctypes) module, you need to compile a mingw
-version of libffi.  Here is one way to do this, wich should allow you to try
+version of libffi.  Here is one way to do this, which should allow you to try
 to build for win64 or win32:
 
 #. Download and unzip a `mingw32 build`_ or `mingw64 build`_, say into c:\mingw

--- a/pypy/doc/windows64.rst
+++ b/pypy/doc/windows64.rst
@@ -12,7 +12,7 @@ large enough to (occasionally) contain a pointer value cast to an
 integer. On most platforms the corresponding C type of ``long`` satisfies this
 condition. But on 64-bit windows, a ``long`` is 32-bits, while
 ``sizeof(void*)`` is 64-bits. The simplest fix is to make sure that
-``rffi.Signed`` can hold a 64-bit integer, which resutls in a python2 with the
+``rffi.Signed`` can hold a 64-bit integer, which results in a python2 with the
 following incompatibility between CPython and PyPy on Win64:
 
 CPython: ``sys.maxint == 2**31-1, sys.maxsize == 2**63-1``
@@ -30,7 +30,7 @@ until it fits this model: replace the field in PyIntObject with a ``long
 long`` field, and change the value of ``sys.maxint``.  This is available in
 `nulano's branch of cpython`_ (again: this is **python2**).
 
-This hacked pyton was used in the next steps.  We'll call it CPython64/64.
+This hacked python was used in the next steps.  We'll call it CPython64/64.
 
 First the tests in
 ``rpython/translator/c/test/``, like ``test_standalone.py`` and

--- a/rpython/doc/jit/backend.rst
+++ b/rpython/doc/jit/backend.rst
@@ -61,7 +61,7 @@ Front-end and optimization pass
 
 Not discussed here in detail.  This produces loops and bridges using an
 instruction set that is "high-level" in some sense: it contains
-intructions like "new"/"new_array", and
+instructions like "new"/"new_array", and
 "setfield"/"setarrayitem"/"setinteriorfield" which describe the action
 of storing a value in a precise field of the structure or array.  For
 example, the "setfield" action might require implicitly a GC write

--- a/rpython/doc/jit/overview.rst
+++ b/rpython/doc/jit/overview.rst
@@ -27,7 +27,7 @@ This transformation is of course completely transparent to the user,
 i.e. the programmer writing Python programs.  The goal (which we
 achieved) is to support *all* Python features -- including, for example,
 random frame access and debuggers.  But it is also mostly transparent to
-the language implementor, i.e. to the source code of the Python
+the language implementer, i.e. to the source code of the Python
 interpreter.  It only needs a bit of guidance: we had to put a small
 number of hints in the source code of our interpreter.  Based on these
 hints, the *JIT compiler generator* produces a JIT compiler which has

--- a/rpython/doc/jit/pyjitpl5.rst
+++ b/rpython/doc/jit/pyjitpl5.rst
@@ -147,7 +147,7 @@ A *virtual* value is an array, struct, or RPython level instance that is created
 during the loop and does not escape from it via calls or longevity past the
 loop.  Since it is only used by the JIT, it can be "optimized out"; the value
 doesn't have to be allocated at all and its fields can be stored as first class
-values instead of deferencing them in memory.  Virtuals allow temporary objects
+values instead of dereferencing them in memory.  Virtuals allow temporary objects
 in the interpreter to be unwrapped.  For example, a W_IntObject in the PyPy interpreter can
 be unwrapped to just be its integer value as long as the object is known not to
 escape the machine code.
@@ -174,7 +174,7 @@ article:
 .. __: https://foss.heptapod.net/pypy/extradoc/-/tree/branch/extradoc/icooolps2009/bolz-tracing-jit-final.pdf
 
 Chapters 5 and 6 of `Antonio Cuni's PhD thesis`__ contain an overview of how
-Tracing JITs work in general and more informations about the concrete case of
+Tracing JITs work in general and more information about the concrete case of
 PyPy's JIT.
 
 .. __: http://antocuni.eu/download/antocuni-phd-thesis.pdf

--- a/rpython/doc/jit/vectorization.rst
+++ b/rpython/doc/jit/vectorization.rst
@@ -19,8 +19,8 @@ Features
 
 Currently the following operations can be vectorized if the trace contains parallel operations:
 
-* float32/float64: add, substract, multiply, divide, negate, absolute
-* int8/int16/int32/int64 arithmetic: add, substract, multiply, negate, absolute
+* float32/float64: add, subtract, multiply, divide, negate, absolute
+* int8/int16/int32/int64 arithmetic: add, subtract, multiply, negate, absolute
 * int8/int16/int32/int64 logical: and, or, xor
 
 Reduction
@@ -33,7 +33,7 @@ Reduction is implemented:
 Constant & Variable Expansion
 -----------------------------
 
-Packed arithmetic operations expand scalar variables or contants into vector registers.
+Packed arithmetic operations expand scalar variables or constants into vector registers.
 
 Guard Strengthening
 -------------------
@@ -79,7 +79,7 @@ Future Work and Limitations
   The opcode needed spans over multiple instructions. In terms of performance
   there might only be little to non advantage to use SIMD instructions for this
   conversions.
-* For a guard that checks true/false on a vector integer regsiter, it would be handy
+* For a guard that checks true/false on a vector integer register, it would be handy
   to have 2 xmm registers (one filled with zero bits and the other with one every bit).
   This cuts down 2 instructions for guard checking, trading for higher register pressure.
 * prod, sum are only supported by 64 bit data types

--- a/rpython/doc/translation.rst
+++ b/rpython/doc/translation.rst
@@ -622,7 +622,7 @@ and complicated beast, formed from many separate components.
    subgraph legend {
      "Input or Output" [shape=ellipse, style=filled]
      "Transformation Step" [shape=box, style="rounded,filled"]
-     // Invisible egde to make sure they are placed vertically
+     // Invisible edge to make sure they are placed vertically
      "Input or Output" -> "Transformation Step" [style=invis]
    }
 


### PR DESCRIPTION
# https://pypi.org/project/codespell
% `codespell **/*.rst --ignore-words-list=buildd,clos,gameboy,ist,som --skip=pypy/doc/contributor.rst`
```
pypy/doc/architecture.rst:112: accomodate ==> accommodate
pypy/doc/build.rst:210: availabe ==> available
pypy/doc/build.rst:219: singe ==> single
pypy/doc/coding-guide.rst:376: wich ==> which
pypy/doc/dev_method.rst:5: preceeds ==> precedes, proceeds
pypy/doc/dev_method.rst:67: wont ==> won't
pypy/doc/discussion/jit-profiler.rst:10: everytime ==> every time
pypy/doc/discussion/rawrefcount.rst:24: exising ==> existing
pypy/doc/faq.rst:265: preferrably ==> preferably
pypy/doc/faq.rst:471: commerical ==> commercial
pypy/doc/gc_info.rst:17: referencable ==> referenceable
pypy/doc/how-to-release.rst:14: constitues ==> constitutes
pypy/doc/how-to-release.rst:18: commiter ==> committer
pypy/doc/how-to-release.rst:61: fo ==> of, for, to, do, go
pypy/doc/how-to-release.rst:81: commited ==> committed
pypy/doc/jit-hooks.rst:35: lighweight ==> lightweight
pypy/doc/jit-hooks.rst:123: paramter ==> parameter
pypy/doc/objspace.rst:260: interpeter ==> interpreter
pypy/doc/project-ideas.rst:110: compatiblity ==> compatibility
pypy/doc/project-ideas.rst:161: distiguish ==> distinguish
pypy/doc/release-1.8.0.rst:8: homogenous ==> homogeneous
pypy/doc/release-1.9.0.rst:65: convensions ==> conventions, conversions
pypy/doc/release-2.0.0-beta1.rst:61: reenable ==> re-enable
pypy/doc/release-2.0.0-beta2.rst:21: libaries ==> libraries
pypy/doc/release-2.3.0.rst:110: implemenation ==> implementation
pypy/doc/release-2.4.0.rst:88: mutlithreaded ==> multithreaded
pypy/doc/release-2.5.0.rst:14: commiters ==> committers
pypy/doc/release-2.5.0.rst:58: seperate ==> separate
pypy/doc/release-2.5.0.rst:75: seperate ==> separate
pypy/doc/release-2.5.1.rst:67: seperate ==> separate
pypy/doc/release-2.6.0.rst:6: particulary ==> particularly
pypy/doc/release-2.6.0.rst:92: accomodate ==> accommodate
pypy/doc/release-4.0.0.rst:77: manangement ==> management
pypy/doc/release-4.0.0.rst:133: compatability ==> compatibility
pypy/doc/release-4.0.0.rst:178: interals ==> internals, intervals, integrals
pypy/doc/release-4.0.0.rst:183: collecter ==> collector, collected
pypy/doc/release-5.0.0.rst:118: perfomance ==> performance
pypy/doc/release-5.0.0.rst:215: Seperate ==> Separate
pypy/doc/release-5.1.1.rst:6: dependant ==> dependent
pypy/doc/release-pypy2.7-v5.3.0.rst:6: targetting ==> targeting
pypy/doc/release-pypy2.7-v5.3.0.rst:8: addtion ==> addition
pypy/doc/release-pypy2.7-v5.3.0.rst:78: dissallow ==> disallow
pypy/doc/release-pypy2.7-v5.3.0.rst:91: theorically ==> theoretically
pypy/doc/release-pypy2.7-v5.4.0.rst:7: compatability ==> compatibility
pypy/doc/release-pypy3-2.1.0-beta1.rst:19: targetting ==> targeting
pypy/doc/release-pypy3-2.4.0.rst:96: mutlithreaded ==> multithreaded
pypy/doc/release-v5.10.1.rst:20: verison ==> version
pypy/doc/release-v5.7.0.rst:139: arguemnt ==> argument
pypy/doc/release-v5.7.0.rst:147: conditonally ==> conditionally
pypy/doc/release-v5.7.0.rst:180: interchangable ==> interchangeable
pypy/doc/release-v5.8.0.rst:154: intructions ==> instructions
pypy/doc/release-v5.8.0.rst:195: overridding ==> overriding
pypy/doc/release-v7.2.0.rst:160: aquire ==> acquire
pypy/doc/release-v7.2.0.rst:181: knowlege ==> knowledge
pypy/doc/release-v7.3.0.rst:33: reccomend ==> recommend
pypy/doc/release-v7.3.11.rst:17: incoporates ==> incorporates
pypy/doc/release-v7.3.11.rst:141: implmentation ==> implementation
pypy/doc/release-v7.3.14.rst:7: Hightlights ==> Highlights
pypy/doc/release-v7.3.4.rst:268: posgresql ==> postgresql
pypy/doc/release-v7.3.5.rst:10: releae ==> release
pypy/doc/release-v7.3.6.rst:165: compatiblity ==> compatibility
pypy/doc/release-v7.3.6.rst:184: Speep ==> Sleep, Speed
pypy/doc/release-v7.3.6.rst:187: aroudn ==> around
pypy/doc/release-v7.3.7.rst:19: conncurrent ==> concurrent
pypy/doc/stackless.rst:65: abitrary ==> arbitrary
pypy/doc/stackless.rst:303: theorical ==> theoretical
pypy/doc/stm.rst:59: compatibily ==> compatibility, compatibly
pypy/doc/stm.rst:166: throught ==> thought, through, throughout
pypy/doc/stm.rst:281: mecanisms ==> mechanisms
pypy/doc/stm.rst:445: checkin ==> checking, check in
pypy/doc/stm.rst:479: appened ==> append, appended, happened
pypy/doc/stm.rst:656: senario ==> scenario
pypy/doc/whatsnew-1.9.rst:127: specifed ==> specified
pypy/doc/whatsnew-2.0.rst:10: seperate ==> separate
pypy/doc/whatsnew-2.4.0.rst:76: compatability ==> compatibility
pypy/doc/whatsnew-2.5.0.rst:45: arguement ==> argument
pypy/doc/whatsnew-2.5.1.rst:12: multithreded ==> multithreaded
pypy/doc/whatsnew-2.6.0.rst:36: overriden ==> overridden
pypy/doc/whatsnew-2.6.0.rst:99: inplement ==> implement
pypy/doc/whatsnew-4.0.0.rst:41: Reenable ==> Re-enable
pypy/doc/whatsnew-5.0.0.rst:33: performace ==> performance
pypy/doc/whatsnew-5.0.0.rst:154: Seperate ==> Separate
pypy/doc/whatsnew-5.1.0.rst:10: architecutre ==> architecture
pypy/doc/whatsnew-5.1.0.rst:60: uneeded ==> unneeded, unheeded, needed
pypy/doc/whatsnew-pypy2-5.3.0.rst:43: dissallow ==> disallow
pypy/doc/whatsnew-pypy2-5.3.0.rst:64: theorically ==> theoretically
pypy/doc/whatsnew-pypy2-5.7.0.rst:36: conditonally ==> conditionally
pypy/doc/whatsnew-pypy2-5.7.0.rst:58: instantations ==> instantiations
pypy/doc/whatsnew-pypy2-6.0.0.rst:46: compilaiton ==> compilation
pypy/doc/whatsnew-pypy2-7.2.0.rst:23: aquire ==> acquire
pypy/doc/whatsnew-pypy2-7.3.4.rst:66: efficent ==> efficient
pypy/doc/whatsnew-pypy3-7.3.6.rst:37: Speep ==> Sleep, Speed
pypy/doc/windows.rst:121: heirarchy ==> hierarchy
pypy/doc/windows.rst:128: wich ==> which
pypy/doc/windows64.rst:15: resutls ==> results
pypy/doc/windows64.rst:33: pyton ==> python
rpython/doc/jit/backend.rst:64: intructions ==> instructions
rpython/doc/jit/overview.rst:30: implementor ==> implementer
rpython/doc/jit/pyjitpl5.rst:150: deferencing ==> dereferencing
rpython/doc/jit/pyjitpl5.rst:177: informations ==> information
rpython/doc/jit/vectorization.rst:22: substract ==> subtract
rpython/doc/jit/vectorization.rst:23: substract ==> subtract
rpython/doc/jit/vectorization.rst:36: contants ==> constants, contents
rpython/doc/jit/vectorization.rst:82: regsiter ==> register
rpython/doc/translation.rst:625: egde ==> edge
105
```
% `codespell **/*.rst --ignore-words-list=buildd,clos,gameboy,ist,som --skip=pypy/doc/contributor.rst --write-changes`
