### PR TITLE
Use Kyiv instead of Kiev

### DIFF
--- a/pypy/module/time/test/test_time.py
+++ b/pypy/module/time/test/test_time.py
@@ -395,9 +395,12 @@ class AppTestTime:
         import os, time
         if not os.name == "posix":
             skip("tzset available only under Unix")
+        if not (os.path.exists('/usr/share/zoneinfo/Europe/Kyiv') or
+                os.path.exists('/usr/lib/zoneinfo/Europe/Kyiv')):
+            skip("Kyiv timezone unavailable")
         org_TZ = os.environ.get('TZ', None)
         try:
-            os.environ['TZ'] = 'Europe/Kiev'
+            os.environ['TZ'] = 'Europe/Kyiv'
             time.tzset()
             localtm = time.localtime(0)
             assert localtm.tm_zone == "MSK"


### PR DESCRIPTION
tzdata provides Kiev as an alternative to Kyiv, but Debian moved it to the tzdata-legacy package, breaking these tests.

cPython also uses this timezone in test_email, and this was fixed in 3.11. I've left that patch out of here, it will get picked up when PyPy switches to 3.11 stdlib.

https://github.com/python/cpython/pull/109251