### PR TITLE
Fix socket.socket.sendto for AF_PACKET protocol

### DIFF
--- a/pypy/module/_socket/interp_socket.py
+++ b/pypy/module/_socket/interp_socket.py
@@ -120,7 +120,7 @@ def addr_from_object(family, fd, space, w_address):
         else:                 pkttype = 0
         if len(pieces_w) > 3: hatype = space.int_w(pieces_w[3])
         else:                 hatype = 0
-        if len(pieces_w) > 4: haddr = space.text_w(pieces_w[4])
+        if len(pieces_w) > 4: haddr = space.bytes_w(pieces_w[4])
         else:                 haddr = ""
         if len(haddr) > 8:
             raise oefmt(space.w_ValueError,


### PR DESCRIPTION
the hardware address for an AF_PACKET socket is 8 bytes, not a string.

This is how it is in CPython, where a PyArg_ParseTuple with data type y* is used.