### PR TITLE
Faster win mutex

### DIFF
--- a/pypy/module/cpyext/api.py
+++ b/pypy/module/cpyext/api.py
@@ -1549,7 +1549,8 @@ separate_module_files = [source_dir / "varargwrapper.c",
                          source_dir / "tupleobject.c",
                          ]
 if WIN32:
-    separate_module_files.append(source_dir / "pythread_nt.c")
+    # separate_module_files.append(source_dir / "pythread_nt.c")
+    separate_module_files.append(source_dir / "pythread_win7.c")
 else:
     separate_module_files.append(source_dir / "pythread_posix.c")
 

--- a/pypy/module/thread/test/test_lock.py
+++ b/pypy/module/thread/test/test_lock.py
@@ -8,7 +8,7 @@ from platform import machine
 
 class AppTestLock(GenericTestThread):
 
-    def test_lock(self):
+    def test_lock_basic(self):
         import thread
         lock = thread.allocate_lock()
         assert type(lock) is thread.LockType
@@ -135,7 +135,7 @@ def test_compile_lock():
 
 class AppTestLockAgain(GenericTestThread):
     # test it at app-level again to detect strange interactions
-    test_lock_again = AppTestLock.test_lock.im_func
+    test_lock_again = AppTestLock.test_lock_basic.im_func
 
 
 class AppTestRLock(GenericTestThread):

--- a/rpython/rlib/rthread.py
+++ b/rpython/rlib/rthread.py
@@ -251,8 +251,8 @@ def allocate_ll_lock():
     # reason it is set to False is that we get it from all app-level
     # lock objects, as well as from the GIL, which exists at shutdown.
     ll_lock = lltype.malloc(TLOCKP.TO, flavor='raw', track_allocation=False)
-    res = c_thread_lock_init(ll_lock)
-    if rffi.cast(lltype.Signed, res) <= 0:
+    res = rffi.cast(lltype.Signed, c_thread_lock_init(ll_lock))
+    if res <= 0:
         lltype.free(ll_lock, flavor='raw', track_allocation=False)
         raise error("out of resources")
     return ll_lock

--- a/rpython/rlib/test/test_rthread.py
+++ b/rpython/rlib/test/test_rthread.py
@@ -173,7 +173,7 @@ class AbstractThreadTests(AbstractGCTestClass):
         answers = fn()
         assert answers == expected
 
-    def test_acquire_timed(self):
+    def test_acquire_timed_1sec(self):
         import time
         def f():
             l = allocate_lock()

--- a/rpython/translator/c/src/thread.c
+++ b/rpython/translator/c/src/thread.c
@@ -24,5 +24,6 @@
   #else
     #include "src/thread_win7.c"
   #endif
+#else
   #include "src/thread_pthread.c"
 #endif

--- a/rpython/translator/c/src/thread.c
+++ b/rpython/translator/c/src/thread.c
@@ -19,7 +19,10 @@
 
 
 #ifdef _WIN32
-#include "src/thread_nt.c"
-#else
-#include "src/thread_pthread.c"
+  #if 0
+    #include "src/thread_nt.c"
+  #else
+    #include "src/thread_win7.c"
+  #endif
+  #include "src/thread_pthread.c"
 #endif

--- a/rpython/translator/c/src/thread.h
+++ b/rpython/translator/c/src/thread.h
@@ -12,8 +12,13 @@ typedef enum RPyLockStatus {
 } RPyLockStatus;
 
 #ifdef _WIN32
+#if 0
 #define RPYTHREAD_NAME "nt"
 #include "thread_nt.h"
+#else
+#define RPYTHREAD_NAME "win7"
+#include "thread_win7.h"
+#endif
 #else
 
 /* We should check if unistd.h defines _POSIX_THREADS, but sometimes

--- a/rpython/translator/c/src/thread_win7.c
+++ b/rpython/translator/c/src/thread_win7.c
@@ -1,0 +1,624 @@
+/* Copy-and-pasted from CPython at 3.10.14
+ * by following code paths with !_PY_EMULATED_WIN_CV
+ */
+
+
+#include <windows.h>
+#include <stdio.h>
+#include <limits.h>
+#include <process.h>
+
+
+/*
+ * Thread support.
+ */
+/* In rpython, this file is pulled in by thread.c */
+
+/* see thread_win7.h */
+typedef struct RPyOpaque_ThreadLock NRMUTEX, *PNRMUTEX;
+
+/* -------------------------
+ * From Include/pyport.h
+ */
+
+   /* enable more aggressive optimization for MSVC */
+   /* active in both release and debug builds - see bpo-43271 */
+#  pragma optimize("gt", on)
+   /* ignore warnings if the compiler decides not to inline a function */
+#  pragma warning(disable: 4710)
+#  define Py_LOCAL_INLINE(type) static __inline type __fastcall
+
+/* -------------------------
+ * From Include/internal/pycore_condvar.h
+ */
+
+/* Use native Win7 primitives if build target is Win7 or higher */
+
+/* SRWLOCK is faster and better than CriticalSection */
+typedef SRWLOCK PyMUTEX_T;
+
+typedef CONDITION_VARIABLE  PyCOND_T;
+
+/* -------------------------
+ * From Python/condvar.h
+ */
+
+
+Py_LOCAL_INLINE(int)
+PyMUTEX_INIT(PyMUTEX_T *cs)
+{
+    InitializeSRWLock(cs);
+    return 0;
+}
+
+Py_LOCAL_INLINE(int)
+PyMUTEX_FINI(PyMUTEX_T *cs)
+{
+    return 0;
+}
+
+Py_LOCAL_INLINE(int)
+PyMUTEX_LOCK(PyMUTEX_T *cs)
+{
+    AcquireSRWLockExclusive(cs);
+    return 0;
+}
+
+Py_LOCAL_INLINE(int)
+PyMUTEX_UNLOCK(PyMUTEX_T *cs)
+{
+    ReleaseSRWLockExclusive(cs);
+    return 0;
+}
+
+
+Py_LOCAL_INLINE(int)
+PyCOND_INIT(PyCOND_T *cv)
+{
+    InitializeConditionVariable(cv);
+    return 0;
+}
+Py_LOCAL_INLINE(int)
+PyCOND_FINI(PyCOND_T *cv)
+{
+    return 0;
+}
+
+Py_LOCAL_INLINE(int)
+PyCOND_WAIT(PyCOND_T *cv, PyMUTEX_T *cs)
+{
+    return SleepConditionVariableSRW(cv, cs, INFINITE, 0) ? 0 : -1;
+}
+
+/* This implementation makes no distinction about timeouts.  Signal
+ * 2 to indicate that we don't know.
+ */
+Py_LOCAL_INLINE(int)
+PyCOND_TIMEDWAIT(PyCOND_T *cv, PyMUTEX_T *cs, long long us)
+{
+    return SleepConditionVariableSRW(cv, cs, (DWORD)(us/1000), 0) ? 2 : -1;
+}
+
+Py_LOCAL_INLINE(int)
+PyCOND_SIGNAL(PyCOND_T *cv)
+{
+     WakeConditionVariable(cv);
+     return 0;
+}
+
+Py_LOCAL_INLINE(int)
+PyCOND_BROADCAST(PyCOND_T *cv)
+{
+     WakeAllConditionVariable(cv);
+     return 0;
+}
+
+/* -------------------------
+ * Taken from Python/pytime.c
+ */
+
+typedef int64_t _PyTime_t;
+#define _PyTime_MAX INT64_MAX
+
+typedef enum {
+    _PyTime_ROUND_FLOOR=0,
+    _PyTime_ROUND_CEILING=1,
+    _PyTime_ROUND_HALF_EVEN=2,
+    _PyTime_ROUND_UP=3,
+    _PyTime_ROUND_TIMEOUT = _PyTime_ROUND_UP
+} _PyTime_round_t;
+
+
+static _PyTime_t
+_PyTime_Divide(const _PyTime_t t, const _PyTime_t k,
+               const _PyTime_round_t round)
+{
+    assert(k > 1);
+    if (round == _PyTime_ROUND_HALF_EVEN) {
+        _PyTime_t x, r, abs_r;
+        x = t / k;
+        r = t % k;
+        abs_r = Py_ABS(r);
+        if (abs_r > k / 2 || (abs_r == k / 2 && (Py_ABS(x) & 1))) {
+            if (t >= 0) {
+                x++;
+            }
+            else {
+                x--;
+            }
+        }
+        return x;
+    }
+    else if (round == _PyTime_ROUND_CEILING) {
+        if (t >= 0) {
+            return (t + k - 1) / k;
+        }
+        else {
+            return t / k;
+        }
+    }
+    else if (round == _PyTime_ROUND_FLOOR){
+        if (t >= 0) {
+            return t / k;
+        }
+        else {
+            return (t - (k - 1)) / k;
+        }
+    }
+    else {
+        assert(round == _PyTime_ROUND_UP);
+        if (t >= 0) {
+            return (t + k - 1) / k;
+        }
+        else {
+            return (t - (k - 1)) / k;
+        }
+    }
+}
+
+
+_PyTime_t
+_PyTime_AsMicroseconds(_PyTime_t t, _PyTime_round_t round)
+{
+    return _PyTime_Divide(t, NS_TO_US, round);
+}
+
+
+static int
+win_perf_counter_frequency(LONGLONG *pfrequency, int raise)
+{
+    LONGLONG frequency;
+
+    LARGE_INTEGER freq;
+    if (!QueryPerformanceFrequency(&freq)) {
+        return -1;
+    }
+    frequency = freq.QuadPart;
+
+    /* Sanity check: should never occur in practice */
+    if (frequency < 1) {
+        return -1;
+    }
+
+    if (frequency > _PyTime_MAX
+        || frequency > (LONGLONG)_PyTime_MAX / (LONGLONG)SEC_TO_NS)
+    {
+        return -1;
+    }
+
+    *pfrequency = frequency;
+    return 0;
+}
+
+static _PyTime_t
+_PyTime_MulDiv(_PyTime_t ticks, _PyTime_t mul, _PyTime_t div)
+{
+    _PyTime_t intpart, remaining;
+    /* Compute (ticks * mul / div) in two parts to prevent integer overflow:
+       compute integer part, and then the remaining part.
+
+       (ticks * mul) / div == (ticks / div) * mul + (ticks % div) * mul / div
+
+       The caller must ensure that "(div - 1) * mul" cannot overflow. */
+    intpart = ticks / div;
+    ticks %= div;
+    remaining = ticks * mul;
+    remaining /= div;
+    return intpart * mul + remaining;
+}
+
+static int
+py_get_win_perf_counter(_PyTime_t *tp, int raise)
+{
+    static LONGLONG frequency = 0;
+    if (frequency == 0) {
+        if (win_perf_counter_frequency(&frequency, raise) < 0) {
+            return -1;
+        }
+    }
+
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    LONGLONG ticksll = now.QuadPart;
+
+    /* Make sure that casting LONGLONG to _PyTime_t cannot overflow,
+ *        both types are signed */
+    _PyTime_t ticks;
+    assert(sizeof(ticksll) <= sizeof(ticks));
+    ticks = (_PyTime_t)ticksll;
+
+    *tp = _PyTime_MulDiv(ticks, SEC_TO_NS, (_PyTime_t)frequency);
+    return 0;
+}
+
+
+static _PyTime_t
+_PyTime_GetPerfCounter(void)
+{
+    _PyTime_t t;
+    int res;
+    res = py_get_win_perf_counter(&t, NULL, 0);
+    if (res  < 0) {
+        // If win_perf_counter_frequency() or py_get_monotonic_clock() fails:
+        // silently ignore the failure and return 0.
+        t = 0;
+    }
+    return t;
+}
+
+
+/* -------------------------
+ * Taken from Python/thread_nt.h
+ */
+
+#define PyMem_RawMalloc malloc
+#define PyMem_RawFree free
+
+PNRMUTEX
+AllocNonRecursiveMutex()
+{
+    PNRMUTEX m = (PNRMUTEX)PyMem_RawMalloc(sizeof(NRMUTEX));
+    if (!m)
+        return NULL;
+    if (PyCOND_INIT(&m->cv))
+        goto fail;
+    if (PyMUTEX_INIT(&m->cs)) {
+        PyCOND_FINI(&m->cv);
+        goto fail;
+    }
+    m->locked = 0;
+    return m;
+fail:
+    PyMem_RawFree(m);
+    return NULL;
+}
+
+VOID
+FreeNonRecursiveMutex(PNRMUTEX mutex)
+{
+    if (mutex) {
+        PyCOND_FINI(&mutex->cv);
+        PyMUTEX_FINI(&mutex->cs);
+        PyMem_RawFree(mutex);
+    }
+}
+
+DWORD
+EnterNonRecursiveMutex(PNRMUTEX mutex, DWORD milliseconds)
+{
+    DWORD result = WAIT_OBJECT_0;
+    if (PyMUTEX_LOCK(&mutex->cs))
+        return WAIT_FAILED;
+    if (milliseconds == INFINITE) {
+        while (mutex->locked) {
+            if (PyCOND_WAIT(&mutex->cv, &mutex->cs)) {
+                result = WAIT_FAILED;
+                break;
+            }
+        }
+    } else if (milliseconds != 0) {
+        /* wait at least until the target */
+        _PyTime_t now = _PyTime_GetPerfCounter();
+        if (now <= 0) {
+            gil_fatal("_PyTime_GetPerfCounter() <= 0");
+        }
+        _PyTime_t nanoseconds = (_PyTime_t)milliseconds * 1000000;
+        _PyTime_t target = now + nanoseconds;
+        while (mutex->locked) {
+            _PyTime_t microseconds = _PyTime_AsMicroseconds(nanoseconds, _PyTime_ROUND_UP);
+            if (PyCOND_TIMEDWAIT(&mutex->cv, &mutex->cs, microseconds) < 0) {
+                result = WAIT_FAILED;
+                break;
+            }
+            now = _PyTime_GetPerfCounter();
+            if (target <= now)
+                break;
+            nanoseconds = target - now;
+        }
+    }
+    if (!mutex->locked) {
+        mutex->locked = 1;
+        result = WAIT_OBJECT_0;
+    } else if (result == WAIT_OBJECT_0)
+        result = WAIT_TIMEOUT;
+    /* else, it is WAIT_FAILED */
+    PyMUTEX_UNLOCK(&mutex->cs); /* must ignore result here */
+    return result;
+}
+
+BOOL
+LeaveNonRecursiveMutex(PNRMUTEX mutex)
+{
+    BOOL result;
+    if (PyMUTEX_LOCK(&mutex->cs))
+        return FALSE;
+    mutex->locked = 0;
+    /* condvar APIs return 0 on success. We need to return TRUE on success. */
+    result = !PyCOND_SIGNAL(&mutex->cv);
+    PyMUTEX_UNLOCK(&mutex->cs);
+    return result;
+}
+
+typedef struct {
+	void (*func)(void *);
+	void *arg;
+	Signed id;
+	HANDLE done;
+} callobj;
+
+/* win64: _beginthread takes a UINT so we can store this in a long */
+static long _pypythread_stacksize = 0;
+
+static void gil_fatal(const char *msg, DWORD dw) {
+    fprintf(stderr, "Fatal error in the GIL or with locks: %s [%x,%x]\n",
+                    msg, (int)dw, (int)GetLastError());
+    abort();
+}
+
+static void
+bootstrap(void *call)
+{
+	callobj *obj = (callobj*)call;
+	/* copy callobj since other thread might free it before we're done */
+	void (*func)(void *) = obj->func;
+	void *arg = obj->arg;
+
+	obj->id = (Signed)GetCurrentThreadId();
+	if (!ReleaseSemaphore(obj->done, 1, NULL))
+        gil_fatal("bootstrap ReleaseSemaphore", 0);
+	func(arg);
+}
+
+Signed RPyThreadStart(void (*func)(void))
+{
+    /* a kind-of-invalid cast, but the 'func' passed here doesn't expect
+       any argument, so it's unlikely to cause problems */
+    return RPyThreadStartEx((void(*)(void *))func, NULL);
+}
+
+Signed RPyThreadStartEx(void (*func)(void *), void *arg)
+{
+	Unsigned rv;
+	callobj obj;
+
+	obj.id = -1;	/* guilty until proved innocent */
+	obj.func = func;
+	obj.arg = arg;
+	obj.done = CreateSemaphore(NULL, 0, 1, NULL);
+	if (obj.done == NULL)
+		return -1;
+
+	rv = _beginthread(bootstrap, _pypythread_stacksize, &obj);
+	if (rv == (Unsigned)-1) {
+		/* I've seen errno == EAGAIN here, which means "there are
+		 * too many threads".
+		 */
+		obj.id = -1;
+	}
+	else {
+		/* wait for thread to initialize, so we can get its id */
+        DWORD res = WaitForSingleObject(obj.done, INFINITE);
+        if (res != WAIT_OBJECT_0)
+            gil_fatal("WaitForSingleObject(obj.done) failed", res);
+        if (obj.id == -1)
+            gil_fatal("obj.id == -1", 0);
+	}
+	CloseHandle((HANDLE)obj.done);
+	return obj.id;
+}
+
+/************************************************************/
+/* PyPy RPython from here
+ * but RPyThread* calls are strongly adapted on the thread_nt.h code
+ */
+
+
+
+/* minimum/maximum thread stack sizes supported */
+/* win64: _beginthread takes a UINT, so max must be <4GB.
+   It is also stored in a LONG (see above), it must be <2GB.
+   The functions below take Signed to simplify Python code. */
+#define THREAD_MIN_STACKSIZE    0x8000      /* 32kB */
+#define THREAD_MAX_STACKSIZE    0x10000000  /* 256MB */
+
+Signed RPyThreadGetStackSize(void)
+{
+	return _pypythread_stacksize;
+}
+
+Signed RPyThreadSetStackSize(Signed newsize)
+{
+	if (newsize == 0) {    /* set to default */
+		_pypythread_stacksize = 0;
+		return 0;
+	}
+
+	/* check the range */
+	if (newsize >= THREAD_MIN_STACKSIZE && newsize < THREAD_MAX_STACKSIZE) {
+	    /* win64: this cast is safe, see THREAD_MAX_STACKSIZE comment */
+		_pypythread_stacksize = (long) newsize;
+		return 0;
+	}
+	return -1;
+}
+
+unsigned long
+RPyThread_get_thread_native_id(void)
+{
+    DWORD native_id;
+    native_id = GetCurrentThreadId();
+    return (unsigned long) native_id;
+}
+
+/************************************************************/
+
+
+
+void RPyThreadAfterFork(void)
+{
+}
+
+int RPyThreadLockInit(struct RPyOpaque_ThreadLock *lock)
+{
+    /* In upstream this is AllocNonRecursiveMutex */
+    if (!m)
+        return -1;
+    if (PyCOND_INIT(&m->cv))
+        return -1;
+    if (PyMUTEX_INIT(&m->cs)) {
+        PyCOND_FINI(&m->cv);
+        return -1;
+    }
+    m->locked = 0;
+    return 0;
+}
+
+void RPyOpaqueDealloc_ThreadLock(struct RPyOpaque_ThreadLock *mutex)
+{
+	/* FreeNonRecursiveMutex(lock) without the "free" */
+    if (mutex) {
+        PyCOND_FINI(&mutex->cv);
+        PyMUTEX_FINI(&mutex->cs);
+    }
+}
+
+/*
+ * Return 1 on success if the lock was acquired
+ *
+ * and 0 if the lock was not acquired. This means a 0 is returned
+ * if the lock has already been acquired by this thread!
+ */
+RPyLockStatus
+RPyThreadAcquireLockTimed(struct RPyOpaque_ThreadLock *aLock,
+			  RPY_TIMEOUT_T microseconds, int intr_flag)
+{
+    /* Fow now, intr_flag does nothing on Windows, and lock acquires are
+     * uninterruptible.  */
+    PyLockStatus success;
+    RPY_TIMEOUT_T milliseconds;
+
+    if (microseconds >= 0) {
+        milliseconds = microseconds / 1000;
+        if (microseconds % 1000 > 0)
+            ++milliseconds;
+        if (milliseconds > PY_DWORD_MAX) {
+            gil_fatal("Timeout larger than PY_TIMEOUT_MAX");
+        }
+    }
+    else {
+        milliseconds = INFINITE;
+    }
+
+    if (aLock && EnterNonRecursiveMutex((PNRMUTEX)aLock,
+                                        (DWORD)milliseconds) == WAIT_OBJECT_0) {
+        success = RPY_LOCK_ACQUIRED;
+    }
+    else {
+        success = RPY_LOCK_FAILURE;
+    }
+
+    return success;
+}
+
+int RPyThreadAcquireLock(struct RPyOpaque_ThreadLock *lock, int waitflag)
+{
+    return RPyThreadAcquireLockTimed(lock, waitflag ? -1 : 0, /*intr_flag=*/0);
+}
+
+Signed RPyThreadReleaseLock(struct RPyOpaque_ThreadLock *lock)
+{
+    if (LeaveNonRecursiveMutex(lock))
+        return 0;   /* success */
+    else
+        return -1;  /* failure: the lock was not previously acquired */
+}
+
+/************************************************************/
+/* GIL code                                                 */
+/************************************************************/
+
+typedef HANDLE mutex2_t;   /* a semaphore, on Windows */
+
+static INLINE void mutex2_init(mutex2_t *mutex) {
+    *mutex = CreateSemaphore(NULL, 1, 1, NULL);
+    if (*mutex == NULL)
+        gil_fatal("CreateSemaphore failed", 0);
+}
+
+static INLINE void mutex2_lock(mutex2_t *mutex) {
+    DWORD res = WaitForSingleObject(*mutex, INFINITE);
+    if (res != WAIT_OBJECT_0)
+        gil_fatal("mutex2_lock", res);
+}
+
+static INLINE void mutex2_unlock(mutex2_t *mutex) {
+    if (!ReleaseSemaphore(*mutex, 1, NULL))
+        gil_fatal("mutex2_unlock", 0);
+}
+
+static INLINE void mutex2_init_locked(mutex2_t *mutex) {
+    mutex2_init(mutex);
+    mutex2_lock(mutex);
+}
+
+static INLINE void mutex2_loop_start(mutex2_t *mutex) { }
+static INLINE void mutex2_loop_stop(mutex2_t *mutex) { }
+
+static INLINE int mutex2_lock_timeout(mutex2_t *mutex, double delay)
+{
+    DWORD result = WaitForSingleObject(*mutex, (DWORD)(delay * 1000.0 + 0.999));
+    if (result != WAIT_TIMEOUT && result != WAIT_OBJECT_0)
+        gil_fatal("mutex2_lock_timeout", result);
+    return (result != WAIT_TIMEOUT);
+}
+
+typedef CRITICAL_SECTION mutex1_t;
+
+static INLINE void mutex1_init(mutex1_t *mutex) {
+    InitializeCriticalSection(mutex);
+}
+
+static INLINE void mutex1_lock(mutex1_t *mutex) {
+    EnterCriticalSection(mutex);
+}
+
+static INLINE void mutex1_unlock(mutex1_t *mutex) {
+    LeaveCriticalSection(mutex);
+}
+
+//#define pypy_lock_test_and_set(ptr, value)  see thread_nt.h
+#ifdef _WIN64
+#define atomic_increment(ptr)          InterlockedIncrement64(ptr)
+#define atomic_decrement(ptr)          InterlockedDecrement64(ptr)
+#else
+#define atomic_increment(ptr)          InterlockedIncrement(ptr)
+#define atomic_decrement(ptr)          InterlockedDecrement(ptr)
+#endif
+#ifdef YieldProcessor
+#  define RPy_YieldProcessor()         YieldProcessor()
+#else
+#  define RPy_YieldProcessor()         __asm { rep nop }
+#endif
+#define RPy_CompilerMemoryBarrier()    _ReadWriteBarrier()
+
+#include "src/thread_gil.c"

--- a/rpython/translator/c/src/thread_win7.h
+++ b/rpython/translator/c/src/thread_win7.h
@@ -8,7 +8,7 @@
  * Thread support.
  */
 
-typedef struct RPyOpaque_ThreadLock {
+struct RPyOpaque_ThreadLock {
     SRWLOCK cs;
     CONDITION_VARIABLE cv;
     int locked;

--- a/rpython/translator/c/src/thread_win7.h
+++ b/rpython/translator/c/src/thread_win7.h
@@ -1,0 +1,66 @@
+#ifndef _THREAD_NT_H
+#define _THREAD_NT_H
+#define WIN32_LEAN_AND_MEAN
+#include <WinSock2.h>
+#include <windows.h>
+
+/*
+ * Thread support.
+ */
+
+typedef struct RPyOpaque_ThreadLock {
+    SRWLOCK cs;
+    CONDITION_VARIABLE cv;
+    int locked;
+};
+
+/* prototypes */
+RPY_EXTERN
+Signed RPyThreadStart(void (*func)(void));
+RPY_EXTERN
+Signed RPyThreadStartEx(void (*func)(void *), void *arg);
+RPY_EXTERN
+int RPyThreadLockInit(struct RPyOpaque_ThreadLock *lock);
+RPY_EXTERN
+void RPyOpaqueDealloc_ThreadLock(struct RPyOpaque_ThreadLock *lock);
+RPY_EXTERN
+int RPyThreadAcquireLock(struct RPyOpaque_ThreadLock *lock, int waitflag);
+RPY_EXTERN
+RPyLockStatus RPyThreadAcquireLockTimed(struct RPyOpaque_ThreadLock *lock,
+					RPY_TIMEOUT_T timeout, int intr_flag);
+RPY_EXTERN
+Signed RPyThreadReleaseLock(struct RPyOpaque_ThreadLock *lock);
+RPY_EXTERN
+Signed RPyThreadGetStackSize(void);
+RPY_EXTERN
+Signed RPyThreadSetStackSize(Signed);
+#endif
+
+
+#ifdef _M_IA64
+/* On Itanium, use 'acquire' memory ordering semantics */
+
+#define pypy_lock_test_and_set(ptr, value) InterlockedExchangeAcquire64(ptr,value)
+#define pypy_compare_and_swap(ptr, oldval, newval)  \
+    (InterlockedCompareExchangeAcquire64(ptr, newval, oldval) == oldval)
+#define pypy_lock_release(ptr)             (*((volatile __int64 *)ptr) = 0)
+
+#else
+#ifdef _WIN64
+/* 64-bit, not Itanium */
+
+#define pypy_lock_test_and_set(ptr, value) InterlockedExchange64(ptr, value)
+#define pypy_compare_and_swap(ptr, oldval, newval)  \
+    (InterlockedCompareExchange64(ptr, newval, oldval) == oldval)
+#define pypy_lock_release(ptr)             (*((volatile __int64 *)ptr) = 0)
+
+#else
+/* 32-bit */
+
+#define pypy_lock_test_and_set(ptr, value) InterlockedExchange(ptr, value)
+#define pypy_compare_and_swap(ptr, oldval, newval)  \
+    (InterlockedCompareExchange(ptr, newval, oldval) == oldval)
+#define pypy_lock_release(ptr)             (*((volatile long *)ptr) = 0)
+
+#endif
+#endif

--- a/rpython/translator/platform/windows.py
+++ b/rpython/translator/platform/windows.py
@@ -262,7 +262,7 @@ class MsvcPlatform(Platform):
     def check___thread(self):
         # __declspec(thread) does not seem to work when using assembler.
         # Returning False will cause the program to use TlsAlloc functions.
-        # see src/thread_nt.h
+        # see src/thread_nt.h or src/thread_win7.h
         return False
 
     def _link_args_from_eci(self, eci, standalone):


### PR DESCRIPTION
This is the first step in updating windows threading code. It replaces the thread locking mutex with a [`SRWLOCK`](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks), which is faster. Locally, building pypy2.7 with this branch and then translating PyPy with it made translation go from 1700 seconds (with pypy2.7-v7.3.14) to 1500 seconds (this branch).