### PR TITLE
only use largefile glibc interfaces on 32-bit build (issue 5071)

### DIFF
--- a/rpython/rlib/rposix_stat.py
+++ b/rpython/rlib/rposix_stat.py
@@ -416,9 +416,6 @@ else:
     INCLUDES = ['sys/types.h', 'sys/stat.h', 'sys/statvfs.h', 'unistd.h']
 
 compilation_info = ExternalCompilationInfo(
-    # This must be set to 64 on some systems to enable large file support.
-    #pre_include_bits = ['#define _FILE_OFFSET_BITS 64'],
-    # ^^^ nowadays it's always set in all C files we produce.
     includes=INCLUDES
 )
 

--- a/rpython/translator/c/src/precommondefs.h
+++ b/rpython/translator/c/src/precommondefs.h
@@ -10,12 +10,13 @@
 
 /* Define on Darwin to activate all library features */
 #define _DARWIN_C_SOURCE 1
-/* This must be set to 64 on some systems to enable large file support. */
-#define _FILE_OFFSET_BITS 64
+/* These must be set to 64 to enable large file support on 32-bit systems. */
+#if defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+  #define _FILE_OFFSET_BITS 64
+  #define _LARGEFILE_SOURCE 1
+#endif
 /* Define on Linux to activate all library features */
 #define _GNU_SOURCE 1
-/* This must be defined on some systems to enable large file support. */
-#define _LARGEFILE_SOURCE 1
 /* Define on NetBSD to activate all library features */
 #define _NETBSD_SOURCE 1
 /* Define to activate features from IEEE Stds 1003.1-2008, except on


### PR DESCRIPTION
Fixes #5071. Locally this produces a libpypy without `...64@GLIBC` interfaces.