### PR TITLE
allow unterminated string error to propogate

### DIFF
--- a/pypy/interpreter/pyparser/pyparse.py
+++ b/pypy/interpreter/pyparser/pyparse.py
@@ -199,6 +199,7 @@ class PegParser(object):
         except error.TokenError as e:
             if (compile_info.flags & consts.PyCF_ALLOW_INCOMPLETE_INPUT and
                     (pytokenizer.TRIPLE_QUOTE_UNTERMINATED_ERROR in e.msg or
+                     pytokenizer.SINGLE_QUOTE_UNTERMINATED_ERROR in e.msg or
                      'was never closed' in e.msg or
                      pytokenizer.EOF_MULTI_LINE_STATEMENT_ERROR in e.msg)):
                 e.msg = "incomplete input"

--- a/pypy/interpreter/pyparser/pytokenizer.py
+++ b/pypy/interpreter/pyparser/pytokenizer.py
@@ -17,6 +17,7 @@ TYPE_COMMENT_PREFIX = 'type'
 TYPE_IGNORE = 'ignore'
 
 TRIPLE_QUOTE_UNTERMINATED_ERROR = "unterminated triple-quoted string literal"
+SINGLE_QUOTE_UNTERMINATED_ERROR = "unterminated string literal"
 EOF_MULTI_LINE_STATEMENT_ERROR = "unexpected end of file (EOF) in multi-line statement"
 
 def match_encoding_declaration(comment):
@@ -134,9 +135,9 @@ def raise_unterminated_string(is_triple_quoted, line, lineno, column, tokens,
         end_lineno, end_offset=0):
     # same arguments as TokenError, ie 1-based offsets
     if is_triple_quoted:
-        msg = "unterminated triple-quoted string literal (detected at line %s)" % (end_lineno, )
+        msg = TRIPLE_QUOTE_UNTERMINATED_ERROR + " (detected at line %s)" % (end_lineno, )
     else:
-        msg = "unterminated string literal (detected at line %s)" % (end_lineno, )
+        msg = SINGLE_QUOTE_UNTERMINATED_ERROR + " (detected at line %s)" % (end_lineno, )
     raise TokenError(msg, line, lineno, column, tokens, end_lineno, end_offset)
 
 def potential_identifier_char(ch):
@@ -203,7 +204,6 @@ def generate_tokens(lines, flags):
 
         if contstrs:
             if not line:
-                assert strstart[3] # must be triple-quoted
                 raise_unterminated_string(strstart[3], strstart[2], strstart[0],
                                           strstart[1] + 1, token_list,
                                           lnum - 1, len(line))

--- a/pypy/interpreter/pyparser/test/test_pyparse.py
+++ b/pypy/interpreter/pyparser/test/test_pyparse.py
@@ -558,3 +558,4 @@ class TestIncompleteInput(object):
 
     def test_line_continuation(self):
         self.check_incomplete("a = \\")
+        self.check_incomplete("a = '\\")


### PR DESCRIPTION
Fixes #5076, in the spirit of the fix for #4002. I also noticed something else. The SyntaxError in `eval()` does not show the fine-grained error locations where CPython does. Is that easy to fix?

CPython 3.10
```
>>> eval("a =")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1
    a =
      ^
SyntaxError: invalid syntax
>>> eval("a ='\\")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1
    a ='\
       ^
SyntaxError: unterminated string literal (detected at line 1)
```

PyPy 3.10 (with this PR, using pyinteractive)
```
>>>> eval("a =")
Traceback (application-level):
  File "<inline>", line 1 in <module>
    eval("a =")
SyntaxError: invalid syntax (<string>, line 1)
>>>> eval("a ='\\")
Traceback (application-level):
  File "<inline>", line 1 in <module>
    eval("a ='\\")
SyntaxError: unterminated string literal (detected at line 1) (<string>, line 1)
```

cc @gpotter2

Edit: nevermind. The pyinteractive REPL does not show fine grained errors, the translated REPL does.