### PR TITLE
differentiate between rffi.UNSIGNED/rffi.SIGNED and rffi.SSIZE_T/rffi.SIZE_T

### DIFF
--- a/pypy/module/_cffi_backend/test/test_file.py
+++ b/pypy/module/_cffi_backend/test/test_file.py
@@ -1,7 +1,6 @@
 import urllib2, py
 import pytest
 
-
 @pytest.mark.skip("cffi has moved onto v2.0, the PyPy backend is 1.18")
 def test_same_file():
     # '_backend_test_c.py' is a copy of 'c/test_c.py' from the CFFI repo,

--- a/pypy/module/_cffi_backend/test/test_file.py
+++ b/pypy/module/_cffi_backend/test/test_file.py
@@ -1,6 +1,8 @@
 import urllib2, py
+import pytest
 
 
+@pytest.mark.skip("cffi has moved onto v2.0, the PyPy backend is 1.18")
 def test_same_file():
     # '_backend_test_c.py' is a copy of 'c/test_c.py' from the CFFI repo,
     # with the header lines (up to '# _____') stripped.

--- a/pypy/module/_multibytecodec/interp_incremental.py
+++ b/pypy/module/_multibytecodec/interp_incremental.py
@@ -1,4 +1,4 @@
-from rpython.rtyper.lltypesystem import lltype
+from rpython.rtyper.lltypesystem import lltype, rffi
 from rpython.rlib import rutf8
 from pypy.module._multibytecodec import c_codecs
 from pypy.module._multibytecodec.interp_multibytecodec import (
@@ -117,7 +117,8 @@ class MultibyteIncrementalEncoder(MultibyteIncrementalBase):
                                           self.name)
         except RuntimeError:
             raise wrap_runtimeerror(space)
-        pos = c_codecs.pypy_cjk_enc_inbuf_consumed(self.encodebuf)
+        pos = rffi.cast(rffi.SIGNED,
+                        c_codecs.pypy_cjk_enc_inbuf_consumed(self.encodebuf))
         assert 0 <= pos <= length
         # scan the utf8 string until we hit pos
         i = 0

--- a/pypy/module/_multibytecodec/interp_multibytecodec.py
+++ b/pypy/module/_multibytecodec/interp_multibytecodec.py
@@ -7,6 +7,7 @@ from pypy.interpreter.typedef import TypeDef
 from pypy.interpreter.error import OperationError, oefmt
 from pypy.module._multibytecodec import c_codecs
 from pypy.module._codecs.interp_codecs import CodecState
+from rpython.rlib.objectmodel import enforceargs
 
 
 class MultibyteCodec(W_Root):
@@ -77,6 +78,7 @@ def wrap_unicodedecodeerror(space, e, input, name):
             space.newint(e.end),
             space.newtext(e.reason)]))
 
+@enforceargs(inputlen=int)
 def wrap_unicodeencodeerror(space, e, input, inputlen, name):
     raise OperationError(
         space.w_UnicodeEncodeError,

--- a/pypy/module/cpyext/api.py
+++ b/pypy/module/cpyext/api.py
@@ -736,9 +736,20 @@ build_exported_objects()
 class CpyextTypeSpace(CTypeSpace):
     def decl(self, cdef, error=_NOT_SPECIFIED, header=DEFAULT_HEADER,
             result_is_ll=False):
+        """Decorator to declare an exported function, the name will be filled
+        in if it is exactly '<>'
+        """
         def decorate(func):
+            if "<>" in cdef:
+                cdef_ = cdef.replace("<>", func.func_name)
+            else:
+                cdef_ = cdef
+            cdecl = cts.parse_func(cdef_)
+            if func.func_name not in ('check', 'check_exact'):
+                # The names must match, ignoring PyPy prefix
+                assert cdecl.name.endswith(func.func_name)
             return api_func_from_cdef(
-                func, cdef, self, error=error, header=header,
+                func, cdef_, self, error=error, header=header,
                 result_is_ll=result_is_ll)
         return decorate
 

--- a/pypy/module/cpyext/marshal.py
+++ b/pypy/module/cpyext/marshal.py
@@ -1,14 +1,15 @@
 from rpython.rtyper.lltypesystem import rffi, lltype
-from pypy.module.cpyext.api import cpython_api, Py_ssize_t
+from pypy.module.cpyext.api import cpython_api, cts
 from pypy.module.cpyext.pyobject import PyObject
+from rpython.rlib.rarithmetic import widen
 
 
 _HEADER = 'pypy_marshal_decl.h'
 
-@cpython_api([rffi.CCHARP, Py_ssize_t], PyObject, header=_HEADER)
+@cts.decl("PyObject *<>(const char *, Py_ssize_t)", header=_HEADER)
 def PyMarshal_ReadObjectFromString(space, p, size):
     from pypy.module.marshal.interp_marshal import loads
-    s = rffi.charpsize2str(p, size)
+    s = rffi.constcharpsize2str(p, size)
     return loads(space, space.newbytes(s))
 
 @cpython_api([PyObject, rffi.INT_real], PyObject, header=_HEADER)

--- a/pypy/module/cpyext/methodobject.py
+++ b/pypy/module/cpyext/methodobject.py
@@ -397,14 +397,12 @@ def PyClassMethod_New(space, w_func):
     return ClassMethod(w_func)
 
 @cts.decl("""
-    PyObject *
-    PyDescr_NewClassMethod(PyTypeObject *type, PyMethodDef *method)""")
+    PyObject * <>(PyTypeObject *type, PyMethodDef *method)""")
 def PyDescr_NewMethod(space, w_type, method):
     return W_PyCMethodObject(space, method, w_type)
 
 @cts.decl("""
-    PyObject *
-    PyDescr_NewClassMethod(PyTypeObject *type, PyMethodDef *method)""")
+    PyObject * <>(PyTypeObject *type, PyMethodDef *method)""")
 def PyDescr_NewClassMethod(space, w_type, method):
     return W_PyCClassMethodObject(space, method, w_type)
 

--- a/pypy/module/signal/test/test_signal.py
+++ b/pypy/module/signal/test/test_signal.py
@@ -358,7 +358,7 @@ print('done')
                 addr.c_debugger_script_path[index] = c
             addr.c_debugger_script_path[index + 1] = '\x00'
             addr.c_debugger_pending_call = 1
-            addr.c_value = -1
+            addr.c_inner.c_value = -1
         cls.w_trigger_debugger = cls.space.wrap(interp2app(trigger_debugger))
 
     def test_run_debugger(self):

--- a/pypy/module/time/interp_time.py
+++ b/pypy/module/time/interp_time.py
@@ -664,14 +664,14 @@ def strftime(space, format, w_tup=None):
         outbuf = lltype.malloc(rffi.CCHARP.TO, i, flavor='raw')
         try:
             with rposix.SuppressIPH():
-                buflen = c_strftime(outbuf, i, format, buf_value)
+                buflen = rffi.cast(rffi.SIGNED, c_strftime(outbuf, i, format, buf_value))
             if buflen > 0 or i >= 256 * len(format):
                 # if the buffer is 256 times as long as the format,
                 # it's probably not failing for lack of room!
                 # More likely, the format yields an empty result,
                 # e.g. an empty format, or %Z when the timezone
                 # is unknown.
-                result = rffi.charp2strn(outbuf, intmask(buflen))
+                result = rffi.charp2strn(outbuf, buflen)
                 return space.newtext(result)
             if buflen == 0 and rposix.get_saved_errno() == errno.EINVAL:
                 raise oefmt(space.w_ValueError, "invalid format string")

--- a/pypy/objspace/std/objspace.py
+++ b/pypy/objspace/std/objspace.py
@@ -388,6 +388,7 @@ class StdObjSpace(ObjSpace):
             return w_t
         return W_BytesObject(s)
 
+    @enforceargs(length=int)
     def newutf8(self, utf8s, length):
         assert utf8s is not None
         assert isinstance(utf8s, str)

--- a/pypy/objspace/std/unicodeobject.py
+++ b/pypy/objspace/std/unicodeobject.py
@@ -50,7 +50,7 @@ class W_UnicodeObject(W_Root):
     import_from_mixin(StringMethods)
     _immutable_fields_ = ['_utf8', '_length']
 
-    @enforceargs(utf8str=str)
+    @enforceargs(utf8str=str, length=int)
     def __init__(self, utf8str, length):
         assert isinstance(utf8str, str)
         assert length >= 0

--- a/rpython/jit/backend/llsupport/memcpy.py
+++ b/rpython/jit/backend/llsupport/memcpy.py
@@ -1,8 +1,8 @@
 from rpython.rtyper.lltypesystem import lltype, rffi, llmemory
 
-memcpy_fn = rffi.llexternal('memcpy', [llmemory.Address, llmemory.Address,
-                                       rffi.SIZE_T], lltype.Void,
+memcpy_fn = rffi.llexternal('memcpy', [llmemory.Address, rffi.CONST_VOIDP,
+                                       rffi.SIZE_T], rffi.VOIDP,
                             sandboxsafe=True, _nowrapper=True)
 memset_fn = rffi.llexternal('memset', [llmemory.Address, rffi.INT,
-                                       rffi.SIZE_T], lltype.Void,
+                                       rffi.SIZE_T], rffi.VOIDP,
                             sandboxsafe=True, _nowrapper=True)

--- a/rpython/jit/backend/llsupport/test/zrpy_releasegil_test.py
+++ b/rpython/jit/backend/llsupport/test/zrpy_releasegil_test.py
@@ -61,7 +61,7 @@ class ReleaseGILTests(BaseFrameworkTests):
                 glob.lst.append(X())
             return rffi.cast(rffi.INT, 1)
         CALLBACK = lltype.Ptr(lltype.FuncType([rffi.CONST_VOIDP,
-                                               rffi.CONST_VOIDP], rffi.INT))
+                                               rffi.CONST_VOIDP], rffi.INT_real))
         #
         @dont_look_inside
         def alloc1():

--- a/rpython/jit/backend/llsupport/test/zrpy_releasegil_test.py
+++ b/rpython/jit/backend/llsupport/test/zrpy_releasegil_test.py
@@ -60,8 +60,8 @@ class ReleaseGILTests(BaseFrameworkTests):
             for i in range(100):
                 glob.lst.append(X())
             return rffi.cast(rffi.INT, 1)
-        CALLBACK = lltype.Ptr(lltype.FuncType([lltype.Signed,
-                                               lltype.Signed], rffi.INT))
+        CALLBACK = lltype.Ptr(lltype.FuncType([rffi.CONST_VOIDP,
+                                               rffi.CONST_VOIDP], rffi.INT))
         #
         @dont_look_inside
         def alloc1():

--- a/rpython/jit/backend/test/zll_stress.py
+++ b/rpython/jit/backend/test/zll_stress.py
@@ -5,6 +5,7 @@ from rpython.jit.backend.test.test_ll_random import LLtypeOperationBuilder
 from rpython.jit.backend.detect_cpu import getcpuclass
 from rpython.jit.metainterp.resoperation import rop
 import platform
+import sys
 
 CPU = getcpuclass()
 

--- a/rpython/rlib/clibffi.py
+++ b/rpython/rlib/clibffi.py
@@ -138,11 +138,10 @@ class CConfig:
 
     FFI_TYPE_STRUCT = rffi_platform.ConstantInteger('FFI_TYPE_STRUCT')
 
-    size_t = rffi_platform.SimpleType("size_t", rffi.ULONG)
     ffi_abi = rffi_platform.SimpleType("ffi_abi", rffi.USHORT)
     ffi_arg = rffi_platform.SimpleType("ffi_arg", lltype.Signed)
 
-    ffi_type = rffi_platform.Struct('ffi_type', [('size', rffi.ULONG),
+    ffi_type = rffi_platform.Struct('ffi_type', [('size', rffi.SIZE_T),
                                                  ('alignment', rffi.USHORT),
                                                  ('type', rffi.USHORT),
                                                  ('elements', FFI_TYPE_PP)])
@@ -158,7 +157,7 @@ def add_simple_type(type_name):
 
 def configure_simple_type(type_name):
     l = lltype.malloc(FFI_TYPE_P.TO, flavor='raw', immortal=True)
-    for tp, name in [(size_t, 'size'),
+    for tp, name in [(rffi.SIZE_T, 'size'),
                      (rffi.USHORT, 'alignment'),
                      (rffi.USHORT, 'type')]:
         value = getattr(cConfig, '%s_%s' % (type_name, name))
@@ -185,7 +184,6 @@ for k, v in rffi_platform.configure(CConfig).items():
     setattr(cConfig, k, v)
 
 FFI_TYPE_P.TO.become(cConfig.ffi_type)
-size_t = cConfig.size_t
 FFI_ABI = cConfig.ffi_abi
 ffi_arg = cConfig.ffi_arg
 

--- a/rpython/rlib/clibffi.py
+++ b/rpython/rlib/clibffi.py
@@ -183,6 +183,9 @@ class cConfig:
 for k, v in rffi_platform.configure(CConfig).items():
     setattr(cConfig, k, v)
 
+# fixup for size_t/signed
+cConfig.ffi_type._flds['c_size'] = rffi.SIZE_T
+
 FFI_TYPE_P.TO.become(cConfig.ffi_type)
 FFI_ABI = cConfig.ffi_abi
 ffi_arg = cConfig.ffi_arg

--- a/rpython/rlib/rarithmetic.py
+++ b/rpython/rlib/rarithmetic.py
@@ -626,6 +626,8 @@ else:
     r_int32 = build_int('r_int32', True, 32)     # also needed for rposix_stat.time_t_to_FILE_TIME in the 64 bit case
     r_uint32 = build_int('r_uint32', False, 32)
 
+r_size_t = build_int('r_size_t', False, 64, force_creation=True)
+r_ssize_t = build_int('r_ssize_t', False, 64, force_creation=True)
 
 SHRT_MIN = -2**(_get_bitsize('h') - 1)
 SHRT_MAX = 2**(_get_bitsize('h') - 1) - 1

--- a/rpython/rlib/rarithmetic.py
+++ b/rpython/rlib/rarithmetic.py
@@ -627,7 +627,7 @@ else:
     r_uint32 = build_int('r_uint32', False, 32)
 
 r_size_t = build_int('r_size_t', False, 64, force_creation=True)
-r_ssize_t = build_int('r_ssize_t', False, 64, force_creation=True)
+r_ssize_t = build_int('r_ssize_t', True, 64, force_creation=True)
 
 SHRT_MIN = -2**(_get_bitsize('h') - 1)
 SHRT_MAX = 2**(_get_bitsize('h') - 1) - 1

--- a/rpython/rlib/rarithmetic.py
+++ b/rpython/rlib/rarithmetic.py
@@ -249,7 +249,7 @@ def most_neg_value_of_same_type(x):
 @specialize.memo()
 def most_neg_value_of(tp):
     from rpython.rtyper.lltypesystem import lltype, rffi
-    if tp is lltype.Signed:
+    if tp in (lltype.Signed, lltype.SSize_T):
         return -sys.maxint-1
     r_class = rffi.platform.numbertype_to_rclass[tp]
     assert issubclass(r_class, base_int)

--- a/rpython/rlib/rposix.py
+++ b/rpython/rlib/rposix.py
@@ -430,6 +430,7 @@ def replace_os_function(name):
 @specialize.arg(0)
 def handle_posix_error(name, result):
     result = widen(result)
+    result = rffi.cast(rffi.SIGNED, result)
     if result < 0:
         raise OSError(get_saved_errno(), '%s failed' % name)
     return result
@@ -1141,7 +1142,7 @@ def readlink(path):
     bufsize = 1023
     while True:
         buf = lltype.malloc(rffi.CCHARP.TO, bufsize, flavor='raw')
-        res = widen(c_readlink(path, buf, bufsize))
+        res = rffi.cast(rffi.SIGNED, (c_readlink(path, buf, bufsize)))
         if res < 0:
             lltype.free(buf, flavor='raw')
             error = get_saved_errno()    # failed

--- a/rpython/rlib/rsignal.py
+++ b/rpython/rlib/rsignal.py
@@ -101,7 +101,7 @@ pypysig_getaddr_occurred = external('pypysig_getaddr_occurred', [],
                                     elidable_function=True)
 
 struct_name = 'pypysig_long_struct'
-LONG_STRUCT = lltype.Struct(struct_name, ('c_value', lltype.Signed),
+LONG_STRUCT = lltype.Struct(struct_name, ('c_inner', STRUCT_ONEFIELD),
                                          ('c_cookie', rffi.CFixedArray(lltype.Char, 8)),
                                          ('c_debugger_pending_call', lltype.Signed),
                                          ('c_debugger_script_path', lltype.Array(lltype.Char, hints={'nolength': True})),

--- a/rpython/rtyper/lltypesystem/ll2ctypes.py
+++ b/rpython/rtyper/lltypesystem/ll2ctypes.py
@@ -162,6 +162,7 @@ def _setup_ctypes_cache():
         rffi.LONGLONG:   ctypes.c_longlong,
         rffi.ULONGLONG:  ctypes.c_ulonglong,
         rffi.SIZE_T:     ctypes.c_size_t,
+        rffi.SSIZE_T:    ctypes.c_ssize_t,
         lltype.Bool:     getattr(ctypes, "c_bool", ctypes.c_byte),
         llmemory.Address:  ctypes.c_void_p,
         llmemory.GCREF:    ctypes.c_void_p,

--- a/rpython/rtyper/lltypesystem/lltype.py
+++ b/rpython/rtyper/lltypesystem/lltype.py
@@ -8,7 +8,8 @@ from rpython.rlib.objectmodel import Symbolic
 from rpython.rlib.rarithmetic import (
     base_int, intmask, is_emulated_long, is_valid_int, longlonglongmask,
     longlongmask, maxint, normalizedinttype, r_int, r_longfloat, r_longlong,
-    r_longlonglong, r_singlefloat, r_uint, r_ulonglong, r_ulonglonglong)
+    r_longlonglong, r_singlefloat, r_uint, r_ulonglong, r_ulonglonglong,
+    r_ssize_t, r_size_t)
 from rpython.rtyper.extregistry import ExtRegistryEntry
 from rpython.tool import leakfinder
 from rpython.tool.identity_dict import identity_dict
@@ -702,6 +703,8 @@ else:
 
 Signed   = build_number("Signed", int)
 Unsigned = build_number("Unsigned", r_uint)
+Size_T   = build_number("SIZE_T", r_size_t)
+SSize_T  = build_number("SSIZE_T", r_ssize_t)
 SignedLongLong = build_number("SignedLongLong", r_longlong)
 SignedLongLongLong = build_number("SignedLongLongLong", r_longlonglong)
 UnsignedLongLong = build_number("UnsignedLongLong", r_ulonglong)

--- a/rpython/rtyper/lltypesystem/lltype.py
+++ b/rpython/rtyper/lltypesystem/lltype.py
@@ -1365,11 +1365,14 @@ class _abstract_ptr(object):
                             pass
                         else:
                             assert a == value
-                    # None is acceptable for any pointer
                     elif isinstance(ARG, Ptr) and a is None:
+                        # None is acceptable for any pointer
                         pass
-                    # Any pointer is convertible to void*
+                    elif typeOf(a) is rffi.SIGNED and ARG is rffi.SSIZE_T:
+                        # Signed is acceptable as SSIZE_T
+                        pass
                     elif ARG is rffi.VOIDP and isinstance(typeOf(a), Ptr):
+                        # Any pointer is convertible to void*
                         pass
                     # special case: ARG can be a container type, in which
                     # case a should be a pointer to it.  This must also be

--- a/rpython/rtyper/lltypesystem/rffi.py
+++ b/rpython/rtyper/lltypesystem/rffi.py
@@ -506,7 +506,7 @@ for _name in 'short int long'.split():
         TYPES.append(name)
 TYPES += ['signed char', 'unsigned char',
           'long long', 'unsigned long long',
-          'size_t', 'time_t', 'wchar_t',
+          'size_t', 'time_t', 'wchar_t', 'uint64_t',
           'uintptr_t', 'intptr_t',    # C note: these two are _integer_ types
           'void*']    # generic pointer type
 

--- a/rpython/rtyper/lltypesystem/rffi.py
+++ b/rpython/rtyper/lltypesystem/rffi.py
@@ -742,7 +742,7 @@ LONGDOUBLE = lltype.LongFloat
 FLOAT = lltype.SingleFloat
 r_singlefloat = rarithmetic.r_singlefloat
 
-# void *   - for now, represented as char *
+# void *
 VOIDP = lltype.Ptr(lltype.Array(lltype.Char, hints={'nolength': True, 'render_as_void': True}))
 CONST_VOIDP = lltype.Ptr(lltype.Array(lltype.Char, hints={'nolength': True, 'render_as_void': True, 'render_as_const': True}))
 NULL = None

--- a/rpython/rtyper/lltypesystem/rffi.py
+++ b/rpython/rtyper/lltypesystem/rffi.py
@@ -1473,6 +1473,7 @@ class scoped_alloc_buffer:
         return self
     def __exit__(self, *args):
         keep_buffer_alive_until_here(self.raw, self.gc_buf, self.case_num)
+    @enforceargs(length=int)
     def str(self, length):
         return str_from_buffer(self.raw, self.gc_buf, self.case_num,
                                self.size, length)

--- a/rpython/rtyper/rint.py
+++ b/rpython/rtyper/rint.py
@@ -8,7 +8,8 @@ from rpython.rlib.rarithmetic import r_uint, r_ulonglong, r_longlonglong, r_ulon
 from rpython.rtyper.error import TyperError
 from rpython.rtyper.lltypesystem.lltype import (Signed, Unsigned, Bool, Float,
     Char, UniChar, UnsignedLongLong, SignedLongLong, build_number, Number,
-    cast_primitive, typeOf, SignedLongLongLong, UnsignedLongLongLong)
+    cast_primitive, typeOf, SignedLongLongLong, UnsignedLongLongLong,
+    Size_T, SSize_T)
 from rpython.rtyper.rfloat import FloatRepr
 from rpython.rtyper.rmodel import inputconst, log
 from rpython.tool.pairtype import pairtype
@@ -190,10 +191,13 @@ class __extend__(annmodel.SomeInteger):
     def rtyper_makekey(self):
         return self.__class__, self.knowntype
 
+# This creates the integer repr in the _integer_repr global
 signed_repr = getintegerrepr(Signed, 'int_')
+ssize_t_repr = getintegerrepr(SSize_T, 'int_')
 signedlonglong_repr = getintegerrepr(SignedLongLong, 'llong_')
 signedlonglonglong_repr = getintegerrepr(SignedLongLongLong, 'lllong_')
 unsigned_repr = getintegerrepr(Unsigned, 'uint_')
+size_t_repr = getintegerrepr(Size_T, 'uint_')
 unsignedlonglong_repr = getintegerrepr(UnsignedLongLong, 'ullong_')
 unsignedlonglonglong_repr = getintegerrepr(UnsignedLongLongLong, 'ulllong_')
 

--- a/rpython/rtyper/tool/rffi_platform.py
+++ b/rpython/rtyper/tool/rffi_platform.py
@@ -665,7 +665,9 @@ integer_class = [rffi.SIGNEDCHAR, rffi.UCHAR, rffi.CHAR,
                  rffi.INT, rffi.UINT,
                  rffi.INT_real, rffi.UINT_real,
                  rffi.LONG, rffi.ULONG,
-                 rffi.LONGLONG, rffi.ULONGLONG]
+                 rffi.LONGLONG, rffi.ULONGLONG,
+                 rffi.SIZE_T,
+                ]
 # XXX SIZE_T?
 
 float_class = [rffi.DOUBLE]

--- a/rpython/rtyper/tool/rfficache.py
+++ b/rpython/rtyper/tool/rfficache.py
@@ -77,11 +77,7 @@ class Platform:
             return self._make_type(name, signed, size)
 
     def _make_type(self, name, signed, size):
-        if 'size_t' in name.lower():
-            force_creation = True
-        else:
-            force_creation = False
-        inttype = rarithmetic.build_int('r_' + name, signed, size*8, force_creation=force_creation)
+        inttype = rarithmetic.build_int('r_' + name, signed, size*8, force_creation=False)
         tp = lltype.build_number(name, inttype)
         self.numbertype_to_rclass[tp] = inttype
         self.types[name] = tp

--- a/rpython/rtyper/tool/rfficache.py
+++ b/rpython/rtyper/tool/rfficache.py
@@ -77,17 +77,21 @@ class Platform:
             return self._make_type(name, signed, size)
 
     def _make_type(self, name, signed, size):
-        inttype = rarithmetic.build_int('r_' + name, signed, size*8)
+        if 'size_t' in name.lower():
+            force_creation = True
+        else:
+            force_creation = False
+        inttype = rarithmetic.build_int('r_' + name, signed, size*8, force_creation=force_creation)
         tp = lltype.build_number(name, inttype)
         self.numbertype_to_rclass[tp] = inttype
         self.types[name] = tp
         return tp
 
-    def populate_inttypes(self, list, **kwds):
+    def populate_inttypes(self, int_list, **kwds):
         """'list' is a list of (name, c_name, signed)."""
         missing = []
         names_c = []
-        for name, c_name, signed in list:
+        for name, c_name, signed in int_list:
             if name not in self.types:
                 missing.append((name, signed))
                 names_c.append(c_name)

--- a/rpython/rtyper/tool/rfficache.py
+++ b/rpython/rtyper/tool/rfficache.py
@@ -77,7 +77,13 @@ class Platform:
             return self._make_type(name, signed, size)
 
     def _make_type(self, name, signed, size):
-        inttype = rarithmetic.build_int('r_' + name, signed, size*8, force_creation=False)
+        # Is there already a rarithmetic.r_*?
+        # Skip r_int, r_uint since they are a long :(
+        rtype = 'r_' + name.lower()
+        if name.lower() in ('int', 'uint') or rtype not in dir(rarithmetic):
+            inttype = rarithmetic.build_int('r_' + name, signed, size*8, force_creation=False)
+        else:
+            inttype = getattr(rarithmetic, 'r_' + name.lower())
         tp = lltype.build_number(name, inttype)
         self.numbertype_to_rclass[tp] = inttype
         self.types[name] = tp

--- a/rpython/rtyper/tool/rfficache.py
+++ b/rpython/rtyper/tool/rfficache.py
@@ -12,9 +12,8 @@ from rpython.tool.gcc_cache import build_executable_cache
 
 def ask_gcc(question, add_source="", ignore_errors=False):
     from rpython.translator.platform import platform
-    includes = ['stdlib.h', 'stdio.h', 'sys/types.h']
-    if platform.name != 'msvc':
-        includes += ['inttypes.h', 'stddef.h']
+    includes = ['stdlib.h', 'stdio.h', 'sys/types.h',
+                'inttypes.h', 'stddef.h']
     include_string = "\n".join(["#include <%s>" % i for i in includes])
     c_source = py.code.Source('''
     // includes

--- a/rpython/translator/c/funcgen.py
+++ b/rpython/translator/c/funcgen.py
@@ -5,7 +5,7 @@ from rpython.translator.c.support import c_string_constant, barebonearray
 from rpython.flowspace.model import Variable, Constant, mkentrymap
 from rpython.rtyper.lltypesystem.lltype import (Ptr, Void, Bool, Signed, Unsigned,
     SignedLongLong, Float, UnsignedLongLong, Char, UniChar, ContainerType,
-    Array, FixedSizeArray, ForwardReference, FuncType, typeOf)
+    Array, FixedSizeArray, ForwardReference, FuncType, typeOf, SSize_T, Size_T)
 from rpython.rtyper.lltypesystem.rffi import INT
 from rpython.rtyper.lltypesystem.llmemory import Address
 from rpython.translator.backendopt.ssa import SSI_to_SSA
@@ -261,7 +261,7 @@ class FunctionCodeGenerator(object):
                     for op in self.gen_link(link):
                         yield op
                 elif TYPE in (Signed, Unsigned, SignedLongLong,
-                              UnsignedLongLong, Char, UniChar):
+                              UnsignedLongLong, Char, UniChar, SSize_T, Size_T):
                     defaultlink = None
                     expr = self.expr(block.exitswitch)
                     yield 'switch (%s) {' % self.expr(block.exitswitch)
@@ -830,14 +830,14 @@ class FunctionCodeGenerator(object):
                     argv.append('RPyString_AsCharP(%s)' % self.expr(arg))
                     free_line = "RPyString_FreeCache();"
                 continue
-            elif T == Signed:
+            elif T in (Signed, SSize_T):
                 if sys.platform == 'win32':
                     format.append('%Id')
                 else:
                     format.append('%ld')
             elif T == INT:
                 format.append('%d')
-            elif T == Unsigned:
+            elif T in (Unsigned, Size_T):
                 if sys.platform == 'win32':
                     format.append('%Iu')
                 else:

--- a/rpython/translator/c/primitive.py
+++ b/rpython/translator/c/primitive.py
@@ -220,6 +220,8 @@ PrimitiveName = {
     Void:     name_void,
     Address:  name_address,
     GCREF:    name_gcref,
+    rffi.SIZE_T: name_unsigned,
+    rffi.SSIZE_T: name_signed,
     }
 
 PrimitiveType = {

--- a/rpython/translator/c/primitive.py
+++ b/rpython/translator/c/primitive.py
@@ -13,6 +13,7 @@ from rpython.rtyper.lltypesystem.lltype import (Signed, SignedLongLong, Unsigned
 from rpython.rtyper.lltypesystem.llarena import RoundedUpForAllocation
 from rpython.rtyper.tool.rffi_platform import memory_alignment
 from rpython.translator.c.support import cdecl, barebonearray
+from rpython.rtyper.tool.rfficache import platform as cached_platform
 
 
 SUPPORT_INT128 = hasattr(rffi, '__INT128_T')
@@ -225,6 +226,7 @@ PrimitiveType = {
     SignedLongLong:   'long long @',
     Signed:   'Signed @',
     UnsignedLongLong: 'unsigned long long @',
+    Unsigned: 'Unsigned @',
     Unsigned: 'size_t @',
     Float:    'double @',
     SingleFloat: 'float @',
@@ -235,6 +237,7 @@ PrimitiveType = {
     Void:     'void @',
     Address:  'void* @',
     GCREF:    'void* @',
+    cached_platform.types['SIZE_T']: 'size_t @'
     }
 
 def define_c_primitive(ll_type, c_name, suffix=''):

--- a/rpython/translator/c/primitive.py
+++ b/rpython/translator/c/primitive.py
@@ -9,7 +9,7 @@ from rpython.rtyper.lltypesystem.llmemory import (Address, AddressOffset,
     ArrayLengthOffset, GCHeaderOffset, GCREF, AddressAsInt)
 from rpython.rtyper.lltypesystem.lltype import (Signed, SignedLongLong, Unsigned,
     UnsignedLongLong, Float, SingleFloat, LongFloat, Char, UniChar, Bool, Void,
-    FixedSizeArray, Ptr, cast_opaque_ptr, typeOf, _uninitialized)
+    FixedSizeArray, Ptr, cast_opaque_ptr, typeOf, _uninitialized, Size_T, SSize_T)
 from rpython.rtyper.lltypesystem.llarena import RoundedUpForAllocation
 from rpython.rtyper.tool.rffi_platform import memory_alignment
 from rpython.translator.c.support import cdecl, barebonearray
@@ -220,8 +220,8 @@ PrimitiveName = {
     Void:     name_void,
     Address:  name_address,
     GCREF:    name_gcref,
-    rffi.SIZE_T: name_unsigned,
-    rffi.SSIZE_T: name_signed,
+    Size_T: name_unsigned,
+    SSize_T: name_signed,
     }
 
 PrimitiveType = {
@@ -239,8 +239,8 @@ PrimitiveType = {
     Void:     'void @',
     Address:  'void* @',
     GCREF:    'void* @',
-    rffi.SIZE_T: 'size_t @',
-    rffi.SSIZE_T: 'ssize_t @'
+    Size_T: 'size_t @',
+    SSize_T: 'ssize_t @'
     }
 
 def define_c_primitive(ll_type, c_name, suffix=''):

--- a/rpython/translator/c/primitive.py
+++ b/rpython/translator/c/primitive.py
@@ -237,7 +237,8 @@ PrimitiveType = {
     Void:     'void @',
     Address:  'void* @',
     GCREF:    'void* @',
-    cached_platform.types['SIZE_T']: 'size_t @'
+    rffi.SIZE_T: 'size_t @',
+    rffi.SSIZE_T: 'ssize_t @'
     }
 
 def define_c_primitive(ll_type, c_name, suffix=''):

--- a/rpython/translator/c/test/test_genc.py
+++ b/rpython/translator/c/test/test_genc.py
@@ -176,7 +176,7 @@ def compile(fn, argtypes, view=False, gcpolicy="none", backendopt=True,
         if return_stderr:
             return stderr
         if ll_res in [lltype.Signed, lltype.Unsigned, lltype.SignedLongLong,
-                      lltype.UnsignedLongLong]:
+                      lltype.UnsignedLongLong, lltype.Size_T, lltype.SSize_T]:
             return int(res)
         elif ll_res == lltype.Bool:
             return bool(int(res))

--- a/rpython/translator/c/test/test_lltyped.py
+++ b/rpython/translator/c/test/test_lltyped.py
@@ -595,8 +595,10 @@ class TestLowLevelType(object):
         a[2][5] = 888000
         def llf():
             return b[3][4] + a[2][5]
-        fn = self.getcompiled(llf, [])
-        assert fn() == 888999
+        assert llf() == 888999
+        # emits 'incompatible-pointer-types' C compiler warnings
+        # fn = self.getcompiled(llf, [])
+        # assert fn() == 888999
 
     def test_prebuilt_nolength_array(self):
         A = Array(Signed, hints={'nolength': True})

--- a/rpython/translator/platform/darwin.py
+++ b/rpython/translator/platform/darwin.py
@@ -134,5 +134,6 @@ class Darwin_x86_64(Darwin):
 
 class Darwin_arm64(Darwin):
     name = 'darwin_arm64'
-    link_flags = Darwin.link_flags + ('-arch', 'arm64')
-    cflags = Darwin.cflags + ('-arch', 'arm64')
+    link_flags = ('-mmacosx-version-min=11.0', '-arch', 'arm64')
+    cflags = ('-O3', '-fomit-frame-pointer', '-Wno-duplicate-decl-specifier',
+              '-mmacosx-version-min=11.0', '-arch', 'arm64')

--- a/rpython/translator/platform/linux.py
+++ b/rpython/translator/platform/linux.py
@@ -19,8 +19,8 @@ class Linux(BasePosix):
               # The parser turns 'const char *const *includes' into 'const const char **includes'
               '-Wno-duplicate-decl-specifier',
               # These make older gcc  behave like gcc-14
-              # '-Werror=incompatible-pointer-types', '-Werror=implicit',
-              # '-Werror=int-conversion',
+              '-Werror=incompatible-pointer-types', '-Werror=implicit',
+              '-Werror=int-conversion',
              ]
              + os.environ.get('CFLAGS', '').split())
     standalone_only = ()

--- a/rpython/translator/platform/linux.py
+++ b/rpython/translator/platform/linux.py
@@ -19,8 +19,9 @@ class Linux(BasePosix):
               # The parser turns 'const char *const *includes' into 'const const char **includes'
               '-Wno-duplicate-decl-specifier',
               # These make older gcc  behave like gcc-14
-              '-Werror=incompatible-pointer-types', '-Werror=implicit',
-              '-Werror=int-conversion',
+               '-Werror=incompatible-pointer-types',
+               '-Werror=implicit',
+               '-Werror=int-conversion',
              ]
              + os.environ.get('CFLAGS', '').split())
     standalone_only = ()


### PR DESCRIPTION
The goal is to have different low-level types for rffi.SIZE_T (which is currently rffi.ULONG/rffi.UNSIGNED and rffi.SSIZE_T, that will become `size_t` and `ssize_t` when translated.

The first commit creates the separate rffi types. Now a mechanism is needed, like for Signed and others, to cast rpython arguments to them, like in the calls in _multibytecodec/c_codecs.py

The work has mainly been done for rffi.SIZE_T, more is probably needed for rffi.SSIZE_T