### PR TITLE
VMProf: Resolve names of native functions

### DIFF
--- a/pypy/module/_vmprof/interp_vmprof.py
+++ b/pypy/module/_vmprof/interp_vmprof.py
@@ -93,3 +93,9 @@ def stop_sampling(space):
 def start_sampling(space):
     rvmprof.start_sampling()
     return space.w_None
+
+@unwrap_spec(addr=int)
+def vmprof_resolve_address(space, addr):
+    """ resolve name, lineno and source file for an adress of a native function """
+    funcname, lineno, filename = rvmprof.vmprof_resolve_address(addr)
+    return space.newtuple([space.newtext(funcname), space.newint(lineno), space.newtext(filename)])

--- a/pypy/module/_vmprof/interp_vmprof.py
+++ b/pypy/module/_vmprof/interp_vmprof.py
@@ -94,8 +94,9 @@ def start_sampling(space):
     rvmprof.start_sampling()
     return space.w_None
 
-@unwrap_spec(addr=int)
-def vmprof_resolve_address(space, addr):
-    """ resolve name, lineno and source file for an adress of a native function """
-    funcname, lineno, filename = rvmprof.vmprof_resolve_address(addr)
-    return space.newtuple([space.newtext(funcname), space.newint(lineno), space.newtext(filename)])
+if rvmprof.supports_native_profiling():
+    @unwrap_spec(addr=int)
+    def vmprof_resolve_address(space, addr):
+        """ resolve name, lineno and source file for an adress of a native function """
+        funcname, lineno, filename = rvmprof.vmprof_resolve_address(addr)
+        return space.newtuple([space.newtext(funcname), space.newint(lineno), space.newtext(filename)])

--- a/pypy/module/_vmprof/moduledef.py
+++ b/pypy/module/_vmprof/moduledef.py
@@ -22,7 +22,7 @@ class Module(MixedModule):
         'VMProfError': 'space.fromcache(interp_vmprof.Cache).w_VMProfError',
     }
     if rvmprof.supports_native_profiling():
-        interpleveldefs.update({'resolve_addr': 'interp_vmprof.vmprof_resolve_address'})
+        interpleveldefs['resolve_addr']= 'interp_vmprof.vmprof_resolve_address'
 
 
 # Force the __extend__ hacks and method replacements to occur

--- a/pypy/module/_vmprof/moduledef.py
+++ b/pypy/module/_vmprof/moduledef.py
@@ -17,6 +17,7 @@ class Module(MixedModule):
         'get_profile_path': 'interp_vmprof.get_profile_path',
         'stop_sampling': 'interp_vmprof.stop_sampling',
         'start_sampling': 'interp_vmprof.start_sampling',
+        'resolve_addr': 'interp_vmprof.vmprof_resolve_address',
 
         'VMProfError': 'space.fromcache(interp_vmprof.Cache).w_VMProfError',
     }

--- a/pypy/module/_vmprof/moduledef.py
+++ b/pypy/module/_vmprof/moduledef.py
@@ -1,5 +1,6 @@
 from pypy.interpreter.mixedmodule import MixedModule
 from rpython.rlib.rvmprof import VMProfPlatformUnsupported
+from rpython.rlib import rvmprof
 from rpython.translator.platform import CompilationError
 
 
@@ -17,10 +18,11 @@ class Module(MixedModule):
         'get_profile_path': 'interp_vmprof.get_profile_path',
         'stop_sampling': 'interp_vmprof.stop_sampling',
         'start_sampling': 'interp_vmprof.start_sampling',
-        'resolve_addr': 'interp_vmprof.vmprof_resolve_address',
 
         'VMProfError': 'space.fromcache(interp_vmprof.Cache).w_VMProfError',
     }
+    if rvmprof.supports_native_profiling():
+        interpleveldefs.update({'resolve_addr': 'interp_vmprof.vmprof_resolve_address'})
 
 
 # Force the __extend__ hacks and method replacements to occur

--- a/pypy/module/_vmprof/test/test__vmprof.py
+++ b/pypy/module/_vmprof/test/test__vmprof.py
@@ -1,5 +1,6 @@
-import py
+import pytest
 import sys
+from rpython.rlib import rvmprof
 from rpython.tool.udir import udir
 
 class AppTestVMProf(object):
@@ -107,7 +108,7 @@ class AppTestVMProf(object):
         _vmprof.disable()
         assert _vmprof.is_enabled() is False
 
-    @py.test.mark.xfail(sys.platform.startswith('freebsd'), reason = "not implemented")
+    @pytest.mark.xfail(sys.platform.startswith('freebsd'), reason = "not implemented")
     def test_get_profile_path(self):
         import _vmprof
         with open(self.tmpfilename, "wb") as tmpfile:
@@ -152,6 +153,7 @@ class AppTestVMProf(object):
         assert pos3 > pos
         _vmprof.disable()
 
+    @pytest.mark.skipif(not rvmprof.supports_native_profiling(), reason="not implemented")
     def test_resolve(self):
         import _vmprof
         

--- a/pypy/module/_vmprof/test/test__vmprof.py
+++ b/pypy/module/_vmprof/test/test__vmprof.py
@@ -152,3 +152,9 @@ class AppTestVMProf(object):
         assert pos3 > pos
         _vmprof.disable()
 
+    def test_resolve(self):
+        import _vmprof
+        
+        result = _vmprof.resolve_addr(1)
+
+        assert result == ("", -1, "-")

--- a/pypy/module/_vmprof/test/test__vmprof.py
+++ b/pypy/module/_vmprof/test/test__vmprof.py
@@ -157,4 +157,4 @@ class AppTestVMProf(object):
         
         result = _vmprof.resolve_addr(1)
 
-        assert result == ("", -1, "-")
+        assert result == ("", 0, "-")

--- a/pypy/module/_vmprof/test/test_direct.py
+++ b/pypy/module/_vmprof/test/test_direct.py
@@ -11,7 +11,7 @@ shareddir = srcdir.join('shared')
 
 ffi = cffi.FFI()
 ffi.cdef("""
-long vmprof_write_header_for_jit_addr(void **, long, void*, int);
+long vmprof_write_header_for_jit_addr(void **, long, intptr_t , int);
 void *pypy_find_codemap_at_addr(long addr, long *start_addr);
 long pypy_yield_codemap_at_addr(void *codemap_raw, long addr,
                                 long *current_pos_addr);
@@ -68,6 +68,6 @@ class TestDirect(object):
         lib.buffer[4] = 0
         buf = ffi.new("long[10]", [0] * 10)
         result = ffi.cast("void**", buf)
-        res = lib.vmprof_write_header_for_jit_addr(result, 0, ffi.NULL, 100)
+        res = lib.vmprof_write_header_for_jit_addr(result, 0, 0, 100)
         assert res == 10
         assert [x for x in buf] == [6, 0, 3, 16, 3, 12, 3, 8, 3, 4]

--- a/rpython/rlib/rvmprof/__init__.py
+++ b/rpython/rlib/rvmprof/__init__.py
@@ -55,6 +55,9 @@ def get_profile_path(space):
 
     return None
 
+def vmprof_resolve_address(addr):
+    return _get_vmprof().vmprof_resolve_address(addr)
+
 def stop_sampling():
     return _get_vmprof().stop_sampling()
 

--- a/rpython/rlib/rvmprof/__init__.py
+++ b/rpython/rlib/rvmprof/__init__.py
@@ -58,6 +58,9 @@ def get_profile_path(space):
 def vmprof_resolve_address(addr):
     return _get_vmprof().vmprof_resolve_address(addr)
 
+def supports_native_profiling():
+    return _get_vmprof().supports_native_profiling()
+
 def stop_sampling():
     return _get_vmprof().stop_sampling()
 

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -20,6 +20,7 @@ class VMProfPlatformUnsupported(Exception):
 
 # vmprof works only on x86 for now
 IS_SUPPORTED = False
+NATIVE_PROFILING_SUPPORTED = False
 if sys.platform in ('darwin', 'linux', 'linux2') or sys.platform.startswith('freebsd'):
     try:
         proc = detect_cpu.autodetect()

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -152,6 +152,10 @@ def setup():
     vmprof_start_sampling = rffi.llexternal("vmprof_start_sampling", [],
                                             lltype.Void, compilation_info=eci,
                                             _nowrapper=True)
+    vmprof_resolve_address = rffi.llexternal("vmp_resolve_addr", [rffi.VOIDP, rffi.CCHARP, rffi.INT,
+                                                                  rffi.INT_realP,  rffi.CCHARP, rffi.INT],
+                                            rffi.INT, compilation_info=eci,
+                                            _nowrapper=True)
 
     return CInterface(locals())
 

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -27,7 +27,7 @@ if sys.platform in ('darwin', 'linux', 'linux2') or sys.platform.startswith('fre
         IS_SUPPORTED = (proc.startswith('x86')
                         or proc == 'aarch64'
                         or proc == 'riscv64')
-        NATIVE_PROFILING_SUPPORTED = proc.startswith('x86')# or proc.startswith('ppc-64')
+        NATIVE_PROFILING_SUPPORTED = proc.startswith('x86')
     except detect_cpu.ProcessorAutodetectError:
         print("PROCESSOR NOT DETECTED, SKIPPING VMPROF")
 

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -26,6 +26,7 @@ if sys.platform in ('darwin', 'linux', 'linux2') or sys.platform.startswith('fre
         IS_SUPPORTED = (proc.startswith('x86')
                         or proc == 'aarch64'
                         or proc == 'riscv64')
+        NATIVE_PROFILING_SUPPORTED = proc.startswith('x86')# or proc.startswith('ppc-64')
     except detect_cpu.ProcessorAutodetectError:
         print("PROCESSOR NOT DETECTED, SKIPPING VMPROF")
 
@@ -152,10 +153,11 @@ def setup():
     vmprof_start_sampling = rffi.llexternal("vmprof_start_sampling", [],
                                             lltype.Void, compilation_info=eci,
                                             _nowrapper=True)
-    vmprof_resolve_address = rffi.llexternal("vmp_resolve_addr", [rffi.VOIDP, rffi.CCHARP, rffi.INT,
-                                                                  rffi.INT_realP,  rffi.CCHARP, rffi.INT],
-                                            rffi.INT, compilation_info=eci,
-                                            _nowrapper=True)
+    if NATIVE_PROFILING_SUPPORTED:
+        vmprof_resolve_address = rffi.llexternal("vmp_resolve_addr", [rffi.VOIDP, rffi.CCHARP, rffi.INT,
+                                                                    rffi.INT_realP,  rffi.CCHARP, rffi.INT],
+                                                rffi.INT, compilation_info=eci,
+                                                _nowrapper=True)
 
     return CInterface(locals())
 

--- a/rpython/rlib/rvmprof/dummy.py
+++ b/rpython/rlib/rvmprof/dummy.py
@@ -25,3 +25,6 @@ class DummyVMProf(object):
 
     def stop_sampling(self):
         return -1
+    
+    def vmprof_resolve_address(addr):
+        return ("", -1, "-")

--- a/rpython/rlib/rvmprof/dummy.py
+++ b/rpython/rlib/rvmprof/dummy.py
@@ -27,4 +27,4 @@ class DummyVMProf(object):
         return -1
     
     def vmprof_resolve_address(addr):
-        return ("", -1, "-")
+        return ("", 0, "-")

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -204,7 +204,7 @@ class VMProf(object):
                     sourcefilebuffer.raw[0] = '-'
                     sourcefilebuffer.raw[1] = '\x00'
                     intbuffer = rffi.cast(rffi.INT_realP, intbuffer.raw)
-                    intbuffer[0] = rffi.cast(rffi.INT_real, -1)
+                    intbuffer[0] = rffi.cast(rffi.INT_real, 0)
                     length = rffi.cast(rffi.INT, 256)
                     res = self.cintf.vmprof_resolve_address(rffi.cast(rffi.VOIDP, addr), namebuffer.raw, length, intbuffer, sourcefilebuffer.raw, length)
         

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -200,8 +200,10 @@ class VMProf(object):
                     intbuffer = rffi.cast(rffi.INT_realP, intbuffer.raw)
                     intbuffer[0] = rffi.cast(rffi.INT_real, -1)
                     length = rffi.cast(rffi.INT, 256)
-                    if self.cintf.vmprof_resolve_address(rffi.cast(rffi.VOIDP, addr), namebuffer.raw, length, intbuffer, sourcefilebuffer.raw, length) != 0:
-                        return (None, -1, None)
+                    res = self.cintf.vmprof_resolve_address(rffi.cast(rffi.VOIDP, addr), namebuffer.raw, length, intbuffer, sourcefilebuffer.raw, length)
+        
+                    #if res != 0:
+                    #    return (None, rffi.cast(rffi.SIGNED, -1), None)
                     
                     return (rffi.charp2str(namebuffer.raw), rffi.cast(rffi.SIGNED, intbuffer[0]), rffi.charp2str(sourcefilebuffer.raw))
 

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -186,11 +186,17 @@ class VMProf(object):
         Undo the effect of stop_sampling
         """
         self.cintf.vmprof_start_sampling()
+    
+    def supports_native_profiling(self):
+        return cintf.NATIVE_PROFILING_SUPPORTED
 
     def vmprof_resolve_address(self, addr):
         """
         Resolve name, lineno and source file for an address of a native function
         """
+        if not self.supports_native_profiling():
+            return ("", -1, "-")
+
         with rffi.scoped_alloc_buffer(256) as namebuffer, \
                 rffi.scoped_alloc_buffer(256) as sourcefilebuffer, \
                 rffi.scoped_alloc_buffer(rffi.sizeof(rffi.INT_real)) as intbuffer:

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -195,7 +195,7 @@ class VMProf(object):
         Resolve name, lineno and source file for an address of a native function
         """
         if not self.supports_native_profiling():
-            return ("", -1, "-")
+            return ("", 0, "-")
 
         with rffi.scoped_alloc_buffer(256) as namebuffer, \
                 rffi.scoped_alloc_buffer(256) as sourcefilebuffer, \
@@ -207,9 +207,9 @@ class VMProf(object):
                     intbuffer[0] = rffi.cast(rffi.INT_real, 0)
                     length = rffi.cast(rffi.INT, 256)
                     res = self.cintf.vmprof_resolve_address(rffi.cast(rffi.VOIDP, addr), namebuffer.raw, length, intbuffer, sourcefilebuffer.raw, length)
-        
-                    #if res != 0:
-                    #    return (None, rffi.cast(rffi.SIGNED, -1), None)
+                    
+                    if rffi.cast(lltype.Signed, res) != 0:
+                        return ("", 0, "-")
                     
                     return (rffi.charp2str(namebuffer.raw), rffi.cast(rffi.SIGNED, intbuffer[0]), rffi.charp2str(sourcefilebuffer.raw))
 

--- a/rpython/rlib/rvmprof/src/rvmprof.h
+++ b/rpython/rlib/rvmprof/src/rvmprof.h
@@ -26,6 +26,11 @@ typedef intptr_t ssize_t;
 #define RPY_EXPORTED  extern __attribute__((visibility("default")))
 #endif
 
+#ifdef VMP_SUPPORTS_NATIVE_PROFILING
+RPY_EXTERN int vmp_resolve_addr(void * addr, char * name, int name_len, int * lineno,
+                      char * srcfile, int srcfile_len);
+#endif
+
 RPY_EXTERN char *vmprof_init(int fd, double interval, int memory,
                      int lines, const char *interp_name, int native, int real_time);
 RPY_EXTERN void vmprof_ignore_signals(int);


### PR DESCRIPTION
use vmp_resolve_addr function to get name, file and line number of native functions after profiling with vmprof on pypy.