### PR TITLE
Add PyThread_acquire_lock_timed

### DIFF
--- a/pypy/module/cpyext/api.py
+++ b/pypy/module/cpyext/api.py
@@ -633,7 +633,7 @@ SYMBOLS_C = [
     'PyOS_getsig', 'PyOS_setsig', 'PyType_GetName', 'PyType_GetQualName',
     '_Py_RestoreSignals',
     'PyThread_get_thread_ident', 'PyThread_allocate_lock', 'PyThread_free_lock',
-    'PyThread_acquire_lock', 'PyThread_release_lock',
+    'PyThread_acquire_lock', 'PyThread_acquire_lock_timed', 'PyThread_release_lock',
     'PyThread_create_key', 'PyThread_delete_key', 'PyThread_set_key_value',
     'PyThread_get_key_value', 'PyThread_delete_key_value',
     'PyThread_ReInitTLS', 'PyThread_init_thread',

--- a/pypy/module/cpyext/include/pythread.h
+++ b/pypy/module/cpyext/include/pythread.h
@@ -9,6 +9,12 @@ typedef void *PyThread_type_lock;
 extern "C" {
 #endif
 
+typedef enum PyLockStatus {
+    PY_LOCK_FAILURE = 0,
+    PY_LOCK_ACQUIRED = 1,
+    PY_LOCK_INTR
+} PyLockStatus;
+
 PyAPI_FUNC(long) PyThread_get_thread_ident(void);
 
 PyAPI_FUNC(PyThread_type_lock) PyThread_allocate_lock(void);
@@ -16,6 +22,12 @@ PyAPI_FUNC(void) PyThread_free_lock(PyThread_type_lock);
 PyAPI_FUNC(int) PyThread_acquire_lock(PyThread_type_lock, int);
 #define WAIT_LOCK	1
 #define NOWAIT_LOCK	0
+
+
+#define PY_TIMEOUT_T long long
+PyAPI_FUNC(PyLockStatus) PyThread_acquire_lock_timed(PyThread_type_lock,
+                                                     PY_TIMEOUT_T microseconds,
+                                                     int intr_flag);
 PyAPI_FUNC(void) PyThread_release_lock(PyThread_type_lock);
 
 PyAPI_FUNC(void) PyThread_init_thread(void);

--- a/pypy/module/cpyext/include/pythread.h
+++ b/pypy/module/cpyext/include/pythread.h
@@ -25,7 +25,7 @@ PyAPI_FUNC(int) PyThread_acquire_lock(PyThread_type_lock, int);
 
 
 #define PY_TIMEOUT_T long long
-PyAPI_FUNC(PyLockStatus) PyThread_acquire_lock_timed(PyThread_type_lock,
+PyAPI_FUNC(PyLockStatus) PyThread_acquire_lock_timed(PyThread_type_lock lock,
                                                      PY_TIMEOUT_T microseconds,
                                                      int intr_flag);
 PyAPI_FUNC(void) PyThread_release_lock(PyThread_type_lock);

--- a/pypy/module/cpyext/src/pythread.c
+++ b/pypy/module/cpyext/src/pythread.c
@@ -60,7 +60,7 @@ PyThread_acquire_lock(PyThread_type_lock lock, int waitflag)
 }
 
 PyLockStatus
-PyThread_acquire_lock_timed(PyThread_type_lock,
+PyThread_acquire_lock_timed(PyThread_type_lock lock,
                             PY_TIMEOUT_T microseconds,
                             int intr_flag)
 {

--- a/pypy/module/cpyext/src/pythread.c
+++ b/pypy/module/cpyext/src/pythread.c
@@ -59,6 +59,14 @@ PyThread_acquire_lock(PyThread_type_lock lock, int waitflag)
     return RPyThreadAcquireLock((struct RPyOpaque_ThreadLock*)lock, waitflag);
 }
 
+PyLockStatus
+PyThread_acquire_lock_timed(PyThread_type_lock,
+                            PY_TIMEOUT_T microseconds,
+                            int intr_flag)
+{
+    return RPyThreadAcquireLockTimed((struct RPyOpaque_ThreadLock*)lock, microseconds, intr_flag);
+}
+
 void
 PyThread_release_lock(PyThread_type_lock lock)
 {

--- a/pypy/module/cpyext/test/test_thread.py
+++ b/pypy/module/cpyext/test/test_thread.py
@@ -82,6 +82,78 @@ class AppTestThread(AppTestCpythonExtensionBase):
         module.test_release_lock()
 
     @pytest.mark.skipif(only_pypy, reason='pypy only test')
+    def test_timed_lock(self):
+        module = self.import_extension('foo', [
+            ("timed_acquire_lock", "METH_O",
+             """
+#ifndef PyThread_acquire_lock_timed
+#error "seems we are not accessing PyPy's functions"
+#endif
+                PyLockStatus acquire_result;
+                int microseconds = PyLong_AsLong(args);
+                Py_BEGIN_ALLOW_THREADS
+                acquire_result = PyThread_acquire_lock_timed(global_lock, microseconds, 0);
+                Py_END_ALLOW_THREADS
+                if (acquire_result == PY_LOCK_ACQUIRED) {
+                    Py_RETURN_TRUE;
+                } else {
+                    Py_RETURN_FALSE;
+                }
+             """),
+            ("release_lock", "METH_NOARGS",
+              """
+              PyThread_release_lock(global_lock);
+              Py_RETURN_NONE;
+              """),
+            ("cleanup_lock", "METH_NOARGS",
+              """
+              // cleanup isn't part of the test, but I'd feel guilty otherwise
+              PyThread_free_lock(global_lock); global_lock=NULL;
+              Py_RETURN_NONE;
+              """
+             )
+            ],
+            prologue="static PyThread_type_lock global_lock;",
+            more_init="global_lock = PyThread_allocate_lock();"
+        )
+        try:
+            import threading
+            import time
+            failure = []
+            assert module.timed_acquire_lock(-1)
+            main_thread_should_release_the_lock_barrier = threading.Barrier(2)
+
+            def thread_func():
+                try:
+                    if module.timed_acquire_lock(0):
+                        failure.append("Lock should be held elsewhere")
+                        return
+                    if module.timed_acquire_lock(1):
+                        failure.append("Lock should be held elsewhere")
+                        return
+                finally:
+                    main_thread_should_release_the_lock_barrier.wait()
+                if not module.timed_acquire_lock(1000000):
+                    failure.append("Lock should have become available")
+                    return
+                print("CCCC")
+                module.release_lock()
+            thread = threading.Thread(target=thread_func)
+            thread.start()
+            main_thread_should_release_the_lock_barrier.wait()
+            # At this point, thread_func should be waiting 1s for the lock,
+            # so sleep a short amount of time then let it have the lock.
+            time.sleep(0.01)
+            module.release_lock()
+
+            thread.join()
+            assert not failure, failure
+        finally:
+            module.cleanup_lock()
+
+        # The intr_flag isn't tested here though
+
+    @pytest.mark.skipif(only_pypy, reason='pypy only test')
     @pytest.mark.xfail(reason='segfaults', run=False)
     def test_tls(self):
         module = self.import_extension('foo', [

--- a/pypy/module/cpyext/test/test_thread.py
+++ b/pypy/module/cpyext/test/test_thread.py
@@ -136,7 +136,6 @@ class AppTestThread(AppTestCpythonExtensionBase):
                 if not module.timed_acquire_lock(1000000):
                     failure.append("Lock should have become available")
                     return
-                print("CCCC")
                 module.release_lock()
             thread = threading.Thread(target=thread_func)
             thread.start()


### PR DESCRIPTION
It looks to map fairly directly onto RPyThreadAcquireLockTimed anyway so no new functionality is needed.