### PR TITLE
on windows, use wchar_t for main(..., argv) in C

### DIFF
--- a/rpython/translator/c/src/entrypoint.h
+++ b/rpython/translator/c/src/entrypoint.h
@@ -4,10 +4,16 @@
 #  define STANDALONE_ENTRY_POINT   PYPY_STANDALONE
 #endif
 
-#ifndef PYPY_MAIN_FUNCTION
-#define PYPY_MAIN_FUNCTION main
-#endif
-
 RPY_EXTERN void RPython_StartupCode(void);
-RPY_EXPORTED int PYPY_MAIN_FUNCTION(int argc, char *argv[]);
+#if defined(MS_WINDOWS)
+  #ifndef PYPY_MAIN_FUNCTION
+  #define PYPY_MAIN_FUNCTION wmain
+  #endif
+  RPY_EXPORTED int PYPY_MAIN_FUNCTION(int argc, wchar_t *argv[]);
+#else
+  #ifndef PYPY_MAIN_FUNCTION
+  #define PYPY_MAIN_FUNCTION main
+  #endif
+  RPY_EXPORTED int PYPY_MAIN_FUNCTION(int argc, char *argv[]);
+#endif
 #endif  /* PYPY_STANDALONE */

--- a/rpython/translator/platform/test/test_makefile.py
+++ b/rpython/translator/platform/test/test_makefile.py
@@ -86,7 +86,7 @@ class TestMakefile(object):
         for i in range(ncfiles):
             txt += "int func%03d();\n" % i
         txt += "\n__declspec(dllexport) int\n"
-        txt += "pypy_main_startup(int argc, char * argv[])\n"
+        txt += "pypy_main_startup(int argc, wchar_t * argv[])\n"
         txt += "{\n   int i=0;\n"
         for i in range(ncfiles):
             txt += "   i += func%03d();\n" % i

--- a/rpython/translator/platform/test/test_windows.py
+++ b/rpython/translator/platform/test/test_windows.py
@@ -84,7 +84,7 @@ class TestMakefile(object):
         cfile = tmpdir.join('pypy_main.c')
         cfile.write('''
         #include <stdio.h>
-        __declspec(dllexport) int pypy_main_startup(int argc, char* argv[])
+        __declspec(dllexport) int pypy_main_startup(int argc, wchar_t* argv[])
         {
             int x = 10;
             int y = x * 2;

--- a/rpython/translator/platform/windows.py
+++ b/rpython/translator/platform/windows.py
@@ -248,6 +248,7 @@ class MsvcPlatform(Platform):
             if lib.endswith('.dll'):
                 lib = lib[:-4]
             libs.append('%s.lib' % (lib,))
+        libs.append("kernel32.lib")
         return libs
 
     def _libdirs(self, library_dirs):
@@ -505,22 +506,29 @@ class MsvcPlatform(Platform):
             m.definition('PYPY_MAIN_FUNCTION', "pypy_main_startup")
             m.rule('main.c', '',
                    'echo '
-                   'int $(PYPY_MAIN_FUNCTION)(int, char*[]); '
-                   'int main(int argc, char* argv[]) '
+                   'typedef unsigned short ARGV_T; '
+                   'int $(PYPY_MAIN_FUNCTION)(int, ARGV_T*[]); '
+                   'int wmain(int argc, ARGV_T* argv[]) '
                    '{ return $(PYPY_MAIN_FUNCTION)(argc, argv); } > $@')
             deps = ['main.obj']
             m.rule('wmain.c', '',
                    ['echo #define WIN32_LEAN_AND_MEAN > $@.tmp',
                    'echo #include "stdlib.h" >> $@.tmp',
                    'echo #include "windows.h" >> $@.tmp',
-                   'echo int $(PYPY_MAIN_FUNCTION)(int, char*[]); >> $@.tmp',
+                   'echo #include "shellapi.h" >> $@.tmp',
+                   'echo int $(PYPY_MAIN_FUNCTION)(int, wchar_t*[]); >> $@.tmp',
                    'echo int WINAPI WinMain( >> $@.tmp',
                    'echo     HINSTANCE hInstance,      /* handle to current instance */ >> $@.tmp',
                    'echo     HINSTANCE hPrevInstance,  /* handle to previous instance */ >> $@.tmp',
                    'echo     LPSTR lpCmdLine,          /* pointer to command line */ >> $@.tmp',
                    'echo     int nCmdShow              /* show state of window */ >> $@.tmp',
                    'echo ) >> $@.tmp',
-                   'echo    { return $(PYPY_MAIN_FUNCTION)(__argc, __argv); } >> $@.tmp',
+                   'echo { >> $@.tmp',
+                   'echo    LPWSTR* szArgList; int argCount; >> $@.tmp',
+                   'echo    szArgList = CommandLineToArgvW(GetCommandLineW(), ^&argCount); >> $@.tmp',
+                   'echo    if (!szArgList) {return 10;} >> $@.tmp',
+                   'echo    return $(PYPY_MAIN_FUNCTION)(argCount, szArgList); >> $@.tmp',
+                   'echo } >> $@.tmp',
                    'move $@.tmp $@',
                    ])
             wdeps = ['wmain.obj']
@@ -539,7 +547,7 @@ class MsvcPlatform(Platform):
                    ['$(CC_LINK) /DEBUG /LARGEADDRESSAWARE /STACK:3145728 ' +
                     '/SUBSYSTEM:WINDOWS '  +
                     ' '.join(wdeps) + ' $(SHARED_IMPORT_LIB) ' +
-                    manifest_args + ' /out:$@ '
+                    manifest_args + ' /out:$@ Shell32.lib'
                     ])
             m.rule('debugmode_$(DEFAULT_TARGET)', ['debugmode_$(TARGET)']+deps,
                    ['$(CC_LINK) /DEBUG /LARGEADDRESSAWARE /STACK:3145728 ' +


### PR DESCRIPTION
This solves #5138 by accepting `wchar_t` for `argv` in `main` and cnverting each argument to utf8 using `WideCharToMultiByte`. found in `kernel32.lib`. For the `WinMain` console-less pypy-w.exe implementation, I additionally used `CommandLineToArgvW(GetCommandLineW(), &argCount)`, which requires linking with `Shell32.lib`. There might be a better way to add the link libraries, but this one works.