### PR TITLE
Fix the type of sendfunc

### DIFF
--- a/pypy/module/cpyext/parse/cpyext_object.h
+++ b/pypy/module/cpyext/parse/cpyext_object.h
@@ -156,7 +156,7 @@ typedef enum {
     PYGEN_NEXT = 1,
 } PySendResult;
 
-typedef int (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
+typedef PySendResult (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
 
 typedef struct {
     unaryfunc am_await;


### PR DESCRIPTION
This fails to compile on C++ because it's more strict than C about matching exact function types..