### PR TITLE
Make return type of `sendfunc` compatible with CPython

### DIFF
--- a/pypy/module/cpyext/parse/cpyext_object.h
+++ b/pypy/module/cpyext/parse/cpyext_object.h
@@ -156,7 +156,7 @@ typedef enum {
     PYGEN_NEXT = 1,
 } PySendResult;
 
-typedef int (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
+typedef PySendResult (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
 
 typedef struct {
     unaryfunc am_await;


### PR DESCRIPTION
In CPython, the [declaration of `sendfunc`](https://github.com/python/cpython/blob/baf65715fc9002e43cd0e1010b8dba9b4c84d503/Include/cpython/object.h#L127) is
```
typedef PySendResult (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
```

where `PySendResult` is an [`enum`](https://github.com/python/cpython/blob/baf65715fc9002e43cd0e1010b8dba9b4c84d503/Include/object.h#L683). In PyPy we use `int` since
- the `sizeof(enum)` is undefined in C
- more practically, our parser, needed to reflect the C typedef into RPython, does not accept an enum there (maybe to prevent exactly this problem?).

In PR #5169, @da-woods submitted this change. I merged it but then realized there is a problem here so I am recreating the PR. I think the PR should rejected and code that uses the result of `sendfunc` should cast the result instead. @vstinner should this be considered a problem with CPython? Are there other public API functions that use enum return results?