### PR TITLE
VMProf: find native symbol names via libunwind & ship libunwind 

### DIFF
--- a/pypy/tool/release/make_portable.py
+++ b/pypy/tool/release/make_portable.py
@@ -122,9 +122,10 @@ def make_portable():
 
     deps = gather_deps(binaries)
 
-    # Add libunwind manually, because its no binarys dependency (we load libunwind at runtime with dlsym)
-    # Must be set to the path where libunwind is installed to in dockerfile
-    deps["libunwind.so"] = "/usr/local/lib/libunwind.so"
+    # Add libunwind manually, because we load it at runtime with dlsym
+    # Must be set to the path where libunwind is installed
+    if os.path.exists("/usr/local/lib/libunwind.so"):
+        deps["libunwind.so"] = "/usr/local/lib/libunwind.so"
 
     copied = copy_deps(deps)
 

--- a/pypy/tool/release/make_portable.py
+++ b/pypy/tool/release/make_portable.py
@@ -122,6 +122,10 @@ def make_portable():
 
     deps = gather_deps(binaries)
 
+    # Add libunwind manually, because its no binarys dependency (we load libunwind at runtime with dlsym)
+    # Must be set to the path where libunwind is installed to in dockerfile
+    deps["libunwind.so"] = "/usr/local/lib/libunwind.so"
+
     copied = copy_deps(deps)
 
     for path, item in copied.items():

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -21,6 +21,7 @@ class VMProfPlatformUnsupported(Exception):
 # vmprof works only on x86 for now
 IS_SUPPORTED = False
 NATIVE_PROFILING_SUPPORTED = False
+IS_DARWIN = 'darwin' in sys.platform
 if sys.platform in ('darwin', 'linux', 'linux2') or sys.platform.startswith('freebsd'):
     try:
         proc = detect_cpu.autodetect()
@@ -161,6 +162,11 @@ def setup():
                                                                     rffi.INT_realP,  rffi.CCHARP, rffi.INT],
                                                 rffi.INT, compilation_info=eci,
                                                 _nowrapper=True)
+        vmprof_load_libunwind_addr_resolve = rffi.llexternal("vmp_load_libunwind", [], rffi.INT, compilation_info=eci,
+                                                _nowrapper=True)
+        vmprof_close_libunwind_addr_resolve = rffi.llexternal("vmp_close_libunwind", [], lltype.Void, compilation_info=eci,
+                                                _nowrapper=True)
+        
 
     return CInterface(locals())
 

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -59,6 +59,8 @@ def make_eci():
            BACKTRACE.join('sort.c'),
         ]
         _libs = ['dl']
+        if NATIVE_PROFILING_SUPPORTED:
+            _libs.extend(['unwind', 'unwind-x86_64'])
         compile_extra += ['-DVMPROF_UNIX']
         compile_extra += ['-DVMPROF_LINUX']
     elif sys.platform == 'win32':

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -60,8 +60,6 @@ def make_eci():
            BACKTRACE.join('sort.c'),
         ]
         _libs = ['dl']
-        if NATIVE_PROFILING_SUPPORTED:
-            _libs.extend(['unwind', 'unwind-x86_64'])
         compile_extra += ['-DVMPROF_UNIX']
         compile_extra += ['-DVMPROF_LINUX']
     elif sys.platform == 'win32':

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -168,7 +168,6 @@ class VMProf(object):
         if self.supports_native_profiling() and not cintf.IS_DARWIN:
             self.cintf.vmprof_close_libunwind_addr_resolve()
 
-        self.cintf.vmprof_close_libunwind_addr_resolve()
         self.is_enabled = False
         res = self.cintf.vmprof_disable()
         if res < 0:

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -164,7 +164,7 @@ class VMProf(object):
         """
         if not self.is_enabled:
             raise VMProfError("vmprof is not enabled")
-        
+
         if self.supports_native_profiling() and not cintf.IS_DARWIN:
             self.cintf.vmprof_close_libunwind_addr_resolve()
 
@@ -194,10 +194,10 @@ class VMProf(object):
         Undo the effect of stop_sampling
         """
         self.cintf.vmprof_start_sampling()
-    
+
     def supports_native_profiling(self):
         return cintf.NATIVE_PROFILING_SUPPORTED
-    
+
     def vmprof_resolve_address(self, addr):
         """
         Resolve name, lineno and source file for an address of a native function
@@ -215,10 +215,10 @@ class VMProf(object):
                     intbuffer[0] = rffi.cast(rffi.INT_real, 0)
                     length = rffi.cast(rffi.INT, 256)
                     res = self.cintf.vmprof_resolve_address(rffi.cast(rffi.VOIDP, addr), namebuffer.raw, length, intbuffer, sourcefilebuffer.raw, length)
-                    
+
                     if rffi.cast(lltype.Signed, res) != 0:
                         return ("", 0, "-")
-                    
+
                     return (rffi.charp2str(namebuffer.raw), rffi.cast(rffi.SIGNED, intbuffer[0]), rffi.charp2str(sourcefilebuffer.raw))
 
 

--- a/rpython/rlib/rvmprof/src/rvmprof.h
+++ b/rpython/rlib/rvmprof/src/rvmprof.h
@@ -29,6 +29,8 @@ typedef intptr_t ssize_t;
 #ifdef VMP_SUPPORTS_NATIVE_PROFILING
 RPY_EXTERN int vmp_resolve_addr(void * addr, char * name, int name_len, int * lineno,
                       char * srcfile, int srcfile_len);
+RPY_EXTERN int vmp_load_libunwind(void);
+RPY_EXTERN void vmp_close_libunwind(void);
 #endif
 
 RPY_EXTERN char *vmprof_init(int fd, double interval, int memory,

--- a/rpython/rlib/rvmprof/src/shared/symboltable.c
+++ b/rpython/rlib/rvmprof/src/shared/symboltable.c
@@ -234,7 +234,6 @@ int vmp_load_libunwind(void) {
 
         // fallback! try to load the system's libunwind.so
         if ((libhandle = dlopen(LIBUNWIND, RTLD_LAZY | RTLD_LOCAL)) == NULL) {
-            printf("couldnt open %s \n", LIBUNWIND);
             goto bail_out;
         }
 loaded_libunwind:

--- a/rpython/rlib/rvmprof/src/shared/symboltable.h
+++ b/rpython/rlib/rvmprof/src/shared/symboltable.h
@@ -2,5 +2,7 @@
 
 #define _GNU_SOURCE 1
 
+int vmp_load_libunwind(void);
+void vmp_close_libunwind(void);
 int vmp_resolve_addr(void * addr, char * name, int name_len, int * lineno,
                       char * srcfile, int srcfile_len);


### PR DESCRIPTION
This will allow VMProf to find native function names via libunwind's function `unw_get_proc_name_by_ip`, which usually finds names, that `dladdr` and `libbacktrace` won't find.

The changes in `make_portable.py` will add `libunwind.so` to the list of dependencies, so that it will be shipped with the PyPy shared object and can be loaded at runtime in `symboltable.c`.

As described by @cfbolz in #5177, a buildbot would need to build a recent version of libunwind for this to work. 