### PR TITLE
Statically link in libffi if possible

### DIFF
--- a/rpython/rlib/clibffi.py
+++ b/rpython/rlib/clibffi.py
@@ -74,8 +74,14 @@ if not _WIN32:
     else:
         pre_include_bits = []
 
+    library_dirs = platform.library_dirs_for_libffi()
     libraries = ['ffi']
     link_files = []
+    for libdir in library_dirs:
+        candidate = os.path.join(libdir, "libffi.a")
+        if os.path.exists(candidate):
+            link_files.append(candidate)
+            libraries = []
 
     eci = ExternalCompilationInfo(
         pre_include_bits = pre_include_bits,
@@ -84,7 +90,7 @@ if not _WIN32:
         separate_module_sources = separate_module_sources,
         post_include_bits = post_include_bits,
         include_dirs = platform.include_dirs_for_libffi(),
-        library_dirs = platform.library_dirs_for_libffi(),
+        library_dirs = library_dirs,
         link_files = link_files,
         testonly_libraries = ['ffi'],
     )


### PR DESCRIPTION
Since libffi is such an integral part of PyPy, search for a libffi.a static library and link to it instead of dynamically linking to it. I think this is preferable?

This fixes an edge case when testing a freshly built pypy in the docker images used on linux, libffi is in `/usr/local/lib`, that directory is not in the ldconfig cache, and `subprocess.Popen` is called with `env={}`.