### PR TITLE
Vmprof manual symbolify

### DIFF
--- a/extra_tests/test_pypy_remote_debug.py
+++ b/extra_tests/test_pypy_remote_debug.py
@@ -134,6 +134,22 @@ def test_symbolify():
     assert name == 'XML_Parse'
     assert 'libexpat.so' in filename
 
+def test_symbolify_all():
+    import ctypes
+    pid = os.getpid()
+    so = ctypes.CDLL('libexpat.so')
+    names = ['XML_Parse', 'XML_GetBase']
+    all = []
+    for name in names:
+        address_of_function = (ctypes.cast(getattr(so, name), ctypes.c_void_p)).value
+        all.append(address_of_function)
+    all.append(1)
+    res = _pypy_remote_debug._symbolify_all(all)
+    for index, name in enumerate(names):
+        addr = all[index]
+        assert res[addr][0] == name
+        assert 'libexpat.so' in res[addr][1]
+
 @pytest.mark.skipif(not hasattr(_vmprof, 'resolve_addr'), reason="not implemented")
 def test_symbolify_vmprof():
     import _vmprof

--- a/extra_tests/test_pypy_remote_debug.py
+++ b/extra_tests/test_pypy_remote_debug.py
@@ -16,7 +16,7 @@ import _vmprof
 
 def test_parse_maps():
     maps = _pypy_remote_debug._parse_maps('self', sys.executable)
-    assert sys.executable == maps[0]['file']
+    assert os.path.realpath(sys.executable) == maps[0]['file']
 
 def test_elf_find_symbol():
     pid = os.getpid()
@@ -25,6 +25,8 @@ def test_elf_find_symbol():
         value = _pypy_remote_debug.elf_find_symbol(f, b'pypysig_counter')
     # compare against output of nm
     out = subprocess.check_output(['nm', file])
+    if not out:
+        pytest.skip("test can't work on stripped binary")
     for line in out.splitlines():
         if 'pypysig_counter' in line:
             addr, _, _ = line.split()
@@ -57,8 +59,8 @@ def test_read_memory():
     pid = os.getpid()
     data = b'hello, world!'
     sourcebuffer = ffi.new('char[]', len(data))
-    for i, char in enumerate(data):
-        sourcebuffer[i] = char
+    for i in range(len(data)):
+        sourcebuffer[i] = data[i:i+1]
     result = _pypy_remote_debug.read_memory(pid, int(ffi.cast('intptr_t', sourcebuffer)), len(data))
     assert result == data
 
@@ -87,7 +89,7 @@ sys.stdin.readline()
     pid = out.pid
     file, base_addr = _pypy_remote_debug._find_file_and_base_addr(pid)
     assert file == sys.executable or 'libpypy' in file
-    out.stdin.write('1\n')
+    out.stdin.write(b'1\n')
     out.stdin.flush()
     out.wait()
 
@@ -131,7 +133,7 @@ def test_symbolify():
     so = ctypes.CDLL('libexpat.so')
     address_of_function = (ctypes.cast(so.XML_Parse, ctypes.c_void_p)).value
     name, filename = _pypy_remote_debug._symbolify(address_of_function)
-    assert name == 'XML_Parse'
+    assert name == b'XML_Parse'
     assert 'libexpat.so' in filename
 
 def test_symbolify_all():
@@ -147,14 +149,32 @@ def test_symbolify_all():
     res = _pypy_remote_debug._symbolify_all(all)
     for index, name in enumerate(names):
         addr = all[index]
-        assert res[addr][0] == name
+        assert res[addr][0] == name.encode('ascii')
         assert 'libexpat.so' in res[addr][1]
+
+def test_symbolify_pypy_function():
+    addr = _pypy_remote_debug.compute_remote_addr()
+    name, filename = _pypy_remote_debug._symbolify(addr)
+    assert name == b'pypysig_counter'
+    addr = _pypy_remote_debug.compute_remote_addr(symbolname=b'pypy_g_DiskFile_read')
+    name, filename = _pypy_remote_debug._symbolify(addr)
+    assert name == b'pypy_g_DiskFile_read'
+
+def test_symbolify_all_pypy_function():
+    names = [b'pypy_g_DiskFile_read', b'pypy_g_DiskFile_write']
+    all = []
+    for name in names:
+        address_of_function = _pypy_remote_debug.compute_remote_addr('self', name)
+        all.append(address_of_function)
+    all.append(1)
+    res = _pypy_remote_debug._symbolify_all(all)
+    for index, name in enumerate(names):
+        addr = all[index]
+        assert res[addr][0] == name
 
 @pytest.mark.skipif(not hasattr(_vmprof, 'resolve_addr'), reason="not implemented")
 def test_symbolify_vmprof():
-    import _vmprof
-    import ctypes
-    pid = os.getpid()
+    import _vmprof, ctypes
     so = ctypes.CDLL('libexpat.so')
     address_of_function = (ctypes.cast(so.XML_Parse, ctypes.c_void_p)).value
     name, lineno, filename = _vmprof.resolve_addr(address_of_function)
@@ -162,5 +182,25 @@ def test_symbolify_vmprof():
     assert 'libexpat.so' in filename
 
     result = _vmprof.resolve_addr(1)
-    assert result == ("", 0, "-")
+    assert result is None
 
+@pytest.mark.skipif(not hasattr(_vmprof, 'resolve_many_addrs'), reason="not implemented")
+def test_symbolify_vmprof_many():
+    import _vmprof, ctypes
+    names = [b'pypy_g_DiskFile_read', b'pypy_g_DiskFile_write']
+    all = []
+    for name in names:
+        address_of_function = _pypy_remote_debug.compute_remote_addr('self', name)
+        all.append(address_of_function)
+
+    names2 = ['XML_Parse', 'XML_GetBase']
+    so = ctypes.CDLL('libexpat.so')
+    for name in names2:
+        address_of_function = (ctypes.cast(getattr(so, name), ctypes.c_void_p)).value
+        all.append(address_of_function)
+    all.append(1)
+
+    res = _vmprof.resolve_many_addrs(all)
+    for index, name in enumerate(names + names2):
+        addr = all[index]
+        assert res[addr][0] == name

--- a/extra_tests/test_pypy_remote_debug.py
+++ b/extra_tests/test_pypy_remote_debug.py
@@ -53,6 +53,15 @@ def test_elf_read_first_load_section():
         if name == 'vaddr':
             assert int(value, 16) == phdr.vaddr
 
+def skip_on_oserror(func):
+    def wrapper():
+        try:
+            return func()
+        except OSError as e:
+            if "Operation not permitted" in str(e):
+                pytest.skip('yama ptrace_scope likely forbids read_memory call')
+
+@skip_on_oserror
 def test_read_memory():
     # test using local memory
     ffi = _pypy_remote_debug.ffi
@@ -64,6 +73,7 @@ def test_read_memory():
     result = _pypy_remote_debug.read_memory(pid, int(ffi.cast('intptr_t', sourcebuffer)), len(data))
     assert result == data
 
+@skip_on_oserror
 def test_write_memory():
     # test using local memory
     ffi = _pypy_remote_debug.ffi
@@ -73,6 +83,7 @@ def test_write_memory():
     result = _pypy_remote_debug.write_memory(pid, int(ffi.cast('intptr_t', targetbuffer)), data)
     assert ffi.buffer(targetbuffer)[:] == data
 
+@skip_on_oserror
 def test_cookie():
     pid = os.getpid()
     addr = _pypy_remote_debug.compute_remote_addr(pid)
@@ -93,6 +104,7 @@ sys.stdin.readline()
     out.stdin.flush()
     out.wait()
 
+@skip_on_oserror
 def test_integration():
     import __pypy__
     for func in (_pypy_remote_debug.start_debugger, __pypy__.remote_exec):

--- a/lib_pypy/_pypy_remote_debug.py
+++ b/lib_pypy/_pypy_remote_debug.py
@@ -77,7 +77,11 @@ class ElfProgramHeader(ElfBase):
     PT_LOAD = 1 # loadable segment
 
     def __init__(self, data, is_64bit=False):
-        self.type, self.flags, self.offset, self.vaddr, self.paddr, self.filesz, self.memsz, self.align = self._unpack(data, is_64bit)
+        fields = self._unpack(data, is_64bit)
+        if is_64bit:
+            self.type, self.flags, self.offset, self.vaddr, self.paddr, self.filesz, self.memsz, self.align = fields
+        else:
+            self.type, self.offset, self.vaddr, self.paddr, self.filesz, self.memsz, self.flags, self.align = fields
 
 
 class ElfSectionHeader(ElfBase):
@@ -112,7 +116,11 @@ class ElfSymTabEntry(ElfBase):
     name_as_bytes = None
 
     def __init__(self, data="", is_64bit=False):
-        self.name, self.info, self.other, self.shndx, self.value, self.size = self._unpack(data, is_64bit)
+        fields = self._unpack(data, is_64bit)
+        if is_64bit:
+            self.name, self.info, self.other, self.shndx, self.value, self.size = fields
+        else:
+            self.name, self.value, self.size, self.info, self.other, self.shndx = fields
 
     def __repr__(self):
         if self.name_as_bytes:

--- a/lib_pypy/_pypy_remote_debug.py
+++ b/lib_pypy/_pypy_remote_debug.py
@@ -88,12 +88,18 @@ class ElfSectionHeader(ElfBase):
 
     TYPE_SYMTAB = 2
     TYPE_STRTAB = 3
+    TYPE_DYNSYM = 11
 
     name_as_bytes = None
     section_data = None
+    section_index = None
 
     def __init__(self, data, is_64bit=False):
         self.name, self.type, self.flags, self.addr, self.offset, self.size, self.link, self.info, self.addralign, self.entsize = self._unpack(data, is_64bit)
+
+    def __repr__(self):
+        return "<ElfSectionHeader name_as_bytes=%r section_index=%s type=%s>" % (self.name_as_bytes, self.section_index, self.type)
+
 
 
 
@@ -107,6 +113,11 @@ class ElfSymTabEntry(ElfBase):
 
     def __init__(self, data="", is_64bit=False):
         self.name, self.info, self.other, self.shndx, self.value, self.size = self._unpack(data, is_64bit)
+
+    def __repr__(self):
+        if self.name_as_bytes:
+            return "<ElfSymTabEntry name_as_bytes=%r value=%x size=%x info=%s>" % (self.name_as_bytes, self.value, self.size, self.info)
+        return "<ElfSymTabEntry value=%x size=%x info=%s>" % (self.value, self.size, self.info)
 
 
 def read_header(file_obj):
@@ -132,6 +143,7 @@ def _elf_section_headers(file_obj):
     for section_idx in range(ehdr.shnum):
         section_header = ElfSectionHeader.from_file(file_obj, ehdr.is_64bit,
                                                     ehdr.shoff + section_idx * ehdr.shentsize)
+        section_header.section_index = section_idx
         file_obj.seek(section_header.offset)
         data = file_obj.read(section_header.size)
         section_header.section_data = data
@@ -140,35 +152,36 @@ def _elf_section_headers(file_obj):
             continue
 
         if section_header.type == ElfSectionHeader.TYPE_STRTAB:
-            if section_idx != ehdr.shstrndx:
-                strtab_data = data
-            else:
+            if section_idx == ehdr.shstrndx:
                 shstr_data = data
-        elif section_header.type == ElfSectionHeader.TYPE_SYMTAB:
-            symtab_data = data
     for section_header in sections:
         start = section_header.name
         end = shstr_data.find(b'\0', start)
         assert end >= 0
         section_header.name_as_bytes = shstr_data[start: end]
-    return sections, symtab_data, strtab_data
+    return sections, ehdr #, symtab_data, strtab_data
 
+def _find_section(sections, what):
+    res = []
+    for section in sections:
+        if section.type == what or section.name_as_bytes == what:
+            res.append(section)
+    return res
 
 def _iter_symbol_and_dynsym(file_obj):
-    sections, symtab_data, strtab_data = _elf_section_headers(file_obj)
-    assert strtab_data is not None
-    file_obj.seek(0)
-    ehdr = read_header(file_obj)
-    # yield entries from the symbol table if we have it
-    if symtab_data is not None:
-        for sym in _elf_iter_symbols(ehdr, symtab_data, strtab_data):
-            yield sym
-    # yield entries from the dynamic symbol table if we have it
-    for section in sections:
-        if section.name_as_bytes != b'.dynsym':
+    sections, ehdr = _elf_section_headers(file_obj)
+    symtabs = _find_section(sections, ElfSectionHeader.TYPE_SYMTAB) + _find_section(sections, ElfSectionHeader.TYPE_DYNSYM)
+    for symtab in symtabs:
+        strtab_index = symtab.link
+        if not 0 <= strtab_index < len(sections):
             continue
-        for sym in _elf_iter_symbols(ehdr, section.section_data, strtab_data):
+        strtab = sections[strtab_index]
+        if strtab.type != ElfSectionHeader.TYPE_STRTAB:
+            continue
+        for sym in _elf_iter_symbols(ehdr, symtab.section_data, strtab.section_data):
+            sym.source = symtab
             yield sym
+    return
 
 
 def elf_find_symbol(file_obj, symbol):
@@ -188,14 +201,14 @@ def _elf_iter_symbols(ehdr, symtab_data, strtab_data):
         start = sym_idx * symtabentry_nbytes
         sym_data = symtab_data[start: start + symtabentry_nbytes]
         if sym_idx == 0:
-            assert sym_data == b"\x00" * len(sym_data)
             continue
 
         sym = ElfSymTabEntry(sym_data, ehdr.is_64bit)
         start = sym.name
         assert start >= 0
         end = strtab_data.find(b'\0', start)
-        assert end >= 0
+        if end < 0:
+            continue
         name = strtab_data[start: end]
         sym.name_as_bytes = name
         yield sym
@@ -286,7 +299,7 @@ def _parse_maps(pid='self', filter=None):
             parsed_maps.append(dict(file=mapping[-1], from_=from_, to_=to_, full_line=entry))
         return parsed_maps
 
-def _find_file_and_base_addr(pid):
+def _find_file_and_base_addr(pid='self'):
     maps = _parse_maps(pid, 'libpypy')
     if not maps:
         executable = os.path.realpath('/proc/%s/exe' % pid)
@@ -297,12 +310,12 @@ def _find_file_and_base_addr(pid):
 
 def _check_elf_debuglink(file):
     with open(file, 'rb') as f:
-        sections, _, _ = _elf_section_headers(f)
+        sections, ehdr = _elf_section_headers(f)
         debuglinks = [section for section in sections if section.name_as_bytes == b'.gnu_debuglink']
         if debuglinks:
             debuglink = debuglinks[0]
             end = debuglink.section_data.find(b'\x00')
-            fn = debuglink.section_data[:end]
+            fn = debuglink.section_data[:end].decode('utf-8')
             res = os.path.join(os.path.dirname(os.path.realpath(file)), fn)
             try:
                 os.stat(res)
@@ -313,7 +326,8 @@ def _check_elf_debuglink(file):
     return file
 
 # __________________________________________________________
-# symbolication support, used by _vmprof.vmprof_resolve_address
+# symbolication support, used by _vmprof.resolve_address and
+# _vmprof.resolve_many_addrs
 
 def _proc_maps_find_map(value):
     maps = _parse_maps()
@@ -339,6 +353,8 @@ def _symbolify(value):
     with open(filename, 'rb') as f:
         phdr = elf_read_first_load_section(f)
         assert phdr.vaddr % phdr.align == 0
+    filename = _check_elf_debuglink(filename)
+    with open(filename, 'rb') as f:
         symbol_value = value - base_addr + phdr.vaddr
         f.seek(0)
         for sym in _iter_symbol_and_dynsym(f):
@@ -363,16 +379,16 @@ def _symbolify_all(values):
             with open(filename, 'rb') as f:
                 phdr = elf_read_first_load_section(f)
                 assert phdr.vaddr % phdr.align == 0
-                f.seek(0)
-                syms = list(_iter_symbol_and_dynsym(f))
+            filename = _check_elf_debuglink(filename)
+            with open(filename, 'rb') as f:
+                syms = [sym for sym in _iter_symbol_and_dynsym(f) if sym.name_as_bytes]
                 syms.sort(key=lambda sym: sym.value)
                 symindex = 0
         symbol_value = value - base_addr + phdr.vaddr
         for symindex in range(symindex, len(syms)):
             sym = syms[symindex]
             if sym.value <= symbol_value < sym.value + sym.size:
-                res[value] = sym.name_as_bytes, filename
-                break
+                res[value] = (sym.name_as_bytes, filename)
             if sym.value > symbol_value:
                 break
         else:
@@ -389,14 +405,21 @@ SCRIPT_OFFSET = PENDING_CALL_OFFSET + struct.calcsize('l')
 SCRIPT_MAX = 4096
 
 
-def compute_remote_addr(pid):
+def compute_remote_addr(pid='self', symbolname=b'pypysig_counter'):
     file, base_addr = _find_file_and_base_addr(pid)
     origfile = file
-    file = _check_elf_debuglink(file)
     with open(file, 'rb') as f:
-        symbol_value = elf_find_symbol(f, b'pypysig_counter')
-        f.seek(0)
         phdr = elf_read_first_load_section(f)
+
+    try:
+        with open(file, 'rb') as f:
+            symbol_value = elf_find_symbol(f, symbolname)
+    except ValueError:
+        file = _check_elf_debuglink(file)
+        if file == origfile:
+            raise ValueError('symbol not found')
+        with open(file, 'rb') as f:
+            symbol_value = elf_find_symbol(f, symbolname)
     # compute address in target process
     # XXX I don't understand how alignment works, assert that it is aligned
     assert phdr.vaddr % phdr.align == 0

--- a/pypy/module/_vmprof/app_vmprof.py
+++ b/pypy/module/_vmprof/app_vmprof.py
@@ -1,0 +1,8 @@
+
+def resolve_addr(addr):
+    import sys
+    if not sys.platform.startswith('linux'):
+        return None
+    from _pypy_remote_debug import _symbolify
+    name, filename = _symbolify(addr)
+    return name, 0, filename

--- a/pypy/module/_vmprof/app_vmprof.py
+++ b/pypy/module/_vmprof/app_vmprof.py
@@ -4,5 +4,16 @@ def resolve_addr(addr):
     if not sys.platform.startswith('linux'):
         return None
     from _pypy_remote_debug import _symbolify
-    name, filename = _symbolify(addr)
+    res = _symbolify(addr)
+    if res is None:
+        return None
+    name, filename = res
     return name, 0, filename
+
+def resolve_many_addrs(addrs):
+    import sys
+    if not sys.platform.startswith('linux'):
+        return {}
+    from _pypy_remote_debug import _symbolify_all
+    res = _symbolify_all(addrs)
+    return {addr: (name, 0, filename) for addr, (name, filename) in res.items()}

--- a/pypy/module/_vmprof/interp_vmprof.py
+++ b/pypy/module/_vmprof/interp_vmprof.py
@@ -93,10 +93,3 @@ def stop_sampling(space):
 def start_sampling(space):
     rvmprof.start_sampling()
     return space.w_None
-
-if rvmprof.supports_native_profiling():
-    @unwrap_spec(addr=int)
-    def vmprof_resolve_address(space, addr):
-        """ resolve name, lineno and source file for an adress of a native function """
-        funcname, lineno, filename = rvmprof.vmprof_resolve_address(addr)
-        return space.newtuple([space.newtext(funcname), space.newint(lineno), space.newtext(filename)])

--- a/pypy/module/_vmprof/moduledef.py
+++ b/pypy/module/_vmprof/moduledef.py
@@ -13,6 +13,7 @@ class Module(MixedModule):
     }
     if sys.implementation.startswith('linux'):
         appleveldefs['resolve_addr'] = 'app_vmprof.resolve_addr'
+        appleveldefs['resolve_many_addrs'] = 'app_vmprof.resolve_many_addrs'
 
     interpleveldefs = {
         'enable': 'interp_vmprof.enable',

--- a/pypy/module/_vmprof/moduledef.py
+++ b/pypy/module/_vmprof/moduledef.py
@@ -1,3 +1,4 @@
+import sys
 from pypy.interpreter.mixedmodule import MixedModule
 from rpython.rlib.rvmprof import VMProfPlatformUnsupported
 from rpython.rlib import rvmprof
@@ -10,6 +11,8 @@ class Module(MixedModule):
     """
     appleveldefs = {
     }
+    if sys.implementation.startswith('linux'):
+        appleveldefs['resolve_addr'] = 'app_vmprof.resolve_addr'
 
     interpleveldefs = {
         'enable': 'interp_vmprof.enable',
@@ -21,8 +24,6 @@ class Module(MixedModule):
 
         'VMProfError': 'space.fromcache(interp_vmprof.Cache).w_VMProfError',
     }
-    if rvmprof.supports_native_profiling():
-        interpleveldefs['resolve_addr']= 'interp_vmprof.vmprof_resolve_address'
 
 
 # Force the __extend__ hacks and method replacements to occur

--- a/pypy/module/_vmprof/moduledef.py
+++ b/pypy/module/_vmprof/moduledef.py
@@ -11,7 +11,7 @@ class Module(MixedModule):
     """
     appleveldefs = {
     }
-    if sys.implementation.startswith('linux'):
+    if sys.platform.startswith('linux'):
         appleveldefs['resolve_addr'] = 'app_vmprof.resolve_addr'
         appleveldefs['resolve_many_addrs'] = 'app_vmprof.resolve_many_addrs'
 

--- a/pypy/module/_vmprof/test/test__vmprof.py
+++ b/pypy/module/_vmprof/test/test__vmprof.py
@@ -152,11 +152,3 @@ class AppTestVMProf(object):
         pos3 = os.lseek(fileno, 0, os.SEEK_CUR)
         assert pos3 > pos
         _vmprof.disable()
-
-    @pytest.mark.skipif(not rvmprof.supports_native_profiling(), reason="not implemented")
-    def test_resolve(self):
-        import _vmprof
-        
-        result = _vmprof.resolve_addr(1)
-
-        assert result == ("", 0, "-")


### PR DESCRIPTION
#5186: instead of using libunwind to symbolify (which crashes), parse the elf files ourselves (which we do for the remote debugger already anyway). This probably has some not implemented corner cases, but at least it can't segfault.