### PR TITLE
revert rvmprof resolve_address via libunwind

### DIFF
--- a/pypy/tool/release/make_portable.py
+++ b/pypy/tool/release/make_portable.py
@@ -122,11 +122,6 @@ def make_portable():
 
     deps = gather_deps(binaries)
 
-    # Add libunwind manually, because we load it at runtime with dlsym
-    # Must be set to the path where libunwind is installed
-    if os.path.exists("/usr/local/lib/libunwind.so"):
-        deps["libunwind.so"] = "/usr/local/lib/libunwind.so"
-
     copied = copy_deps(deps)
 
     for path, item in copied.items():

--- a/rpython/rlib/rvmprof/__init__.py
+++ b/rpython/rlib/rvmprof/__init__.py
@@ -48,18 +48,12 @@ def get_profile_path(space):
         return None
 
     with rffi.scoped_alloc_buffer(4096) as buf:
-        length = vmp.cintf.vmprof_get_profile_path(buf.raw, buf.size) 
+        length = vmp.cintf.vmprof_get_profile_path(buf.raw, buf.size)
         if length == -1:
             return ""
         return buf.str(length)
 
     return None
-
-def vmprof_resolve_address(addr):
-    return _get_vmprof().vmprof_resolve_address(addr)
-
-def supports_native_profiling():
-    return _get_vmprof().supports_native_profiling()
 
 def stop_sampling():
     return _get_vmprof().stop_sampling()

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -110,7 +110,7 @@ def configure_libbacktrace_linux():
 def setup():
     if not IS_SUPPORTED:
         raise VMProfPlatformUnsupported
-    
+
     if sys.platform.startswith('linux'):
         configure_libbacktrace_linux()
 
@@ -154,12 +154,6 @@ def setup():
     vmprof_start_sampling = rffi.llexternal("vmprof_start_sampling", [],
                                             lltype.Void, compilation_info=eci,
                                             _nowrapper=True)
-    if NATIVE_PROFILING_SUPPORTED:
-        vmprof_resolve_address = rffi.llexternal("vmp_resolve_addr", [rffi.VOIDP, rffi.CCHARP, rffi.INT,
-                                                                    rffi.INT_realP,  rffi.CCHARP, rffi.INT],
-                                                rffi.INT, compilation_info=eci,
-                                                _nowrapper=True)
-
     return CInterface(locals())
 
 

--- a/rpython/rlib/rvmprof/dummy.py
+++ b/rpython/rlib/rvmprof/dummy.py
@@ -25,6 +25,3 @@ class DummyVMProf(object):
 
     def stop_sampling(self):
         return -1
-    
-    def vmprof_resolve_address(addr):
-        return ("", 0, "-")

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -187,34 +187,6 @@ class VMProf(object):
         """
         self.cintf.vmprof_start_sampling()
     
-    def supports_native_profiling(self):
-        return cintf.NATIVE_PROFILING_SUPPORTED
-
-    def vmprof_resolve_address(self, addr):
-        """
-        Resolve name, lineno and source file for an address of a native function
-        """
-        if not self.supports_native_profiling():
-            return ("", 0, "-")
-
-        with rffi.scoped_alloc_buffer(256) as namebuffer, \
-                rffi.scoped_alloc_buffer(256) as sourcefilebuffer, \
-                rffi.scoped_alloc_buffer(rffi.sizeof(rffi.INT_real)) as intbuffer:
-                    namebuffer.raw[0] = '\x00'
-                    sourcefilebuffer.raw[0] = '-'
-                    sourcefilebuffer.raw[1] = '\x00'
-                    intbuffer = rffi.cast(rffi.INT_realP, intbuffer.raw)
-                    intbuffer[0] = rffi.cast(rffi.INT_real, 0)
-                    length = rffi.cast(rffi.INT, 256)
-                    res = self.cintf.vmprof_resolve_address(rffi.cast(rffi.VOIDP, addr), namebuffer.raw, length, intbuffer, sourcefilebuffer.raw, length)
-                    
-                    if rffi.cast(lltype.Signed, res) != 0:
-                        return ("", 0, "-")
-                    
-                    return (rffi.charp2str(namebuffer.raw), rffi.cast(rffi.SIGNED, intbuffer[0]), rffi.charp2str(sourcefilebuffer.raw))
-
-
-
 
 def vmprof_execute_code(name, get_code_fn, result_class=None,
                         _hack_update_stack_untranslated=False):

--- a/rpython/rlib/rvmprof/src/rvmprof.h
+++ b/rpython/rlib/rvmprof/src/rvmprof.h
@@ -26,11 +26,6 @@ typedef intptr_t ssize_t;
 #define RPY_EXPORTED  extern __attribute__((visibility("default")))
 #endif
 
-#ifdef VMP_SUPPORTS_NATIVE_PROFILING
-RPY_EXTERN int vmp_resolve_addr(void * addr, char * name, int name_len, int * lineno,
-                      char * srcfile, int srcfile_len);
-#endif
-
 RPY_EXTERN char *vmprof_init(int fd, double interval, int memory,
                      int lines, const char *interp_name, int native, int real_time);
 RPY_EXTERN void vmprof_ignore_signals(int);

--- a/rpython/rlib/rvmprof/test/test_rvmprof.py
+++ b/rpython/rlib/rvmprof/test/test_rvmprof.py
@@ -67,7 +67,7 @@ class TestResultClass(RVMProfTest):
 
 
 class TestRegisterCode(RVMProfTest):
-    
+
     @rvmprof.vmprof_execute_code("xcode1", lambda self, code, num: code)
     def main(self, code, num):
         print num
@@ -207,24 +207,3 @@ class TestNative(RVMProfSamplingTest):
                     del not_found[i]
                     break
         assert not_found == []
-
-def test_symboltable():
-    """" Test if vmprof can resolve the name of a function """
-    eci = ExternalCompilationInfo(compile_extra=['-g','-O0', '-Werror'],
-        post_include_bits = ['int native_func(int);'],
-        separate_module_sources=["""
-        RPY_EXTERN int native_func(int d) {
-           return 7;
-        }
-        RPY_EXTERN long get_addr() {
-            return (long) native_func;
-        }                                
-        """])
-    native_func = rffi.llexternal("get_addr", [], rffi.SIGNED,
-                                    compilation_info=eci)
-    
-    addr = native_func()
-
-    result = rvmprof.vmprof_resolve_address(addr)
-
-    assert result[0] == 'native_func'


### PR DESCRIPTION
Revert rvmprof changes in #5180 to create a rvmprof `resolve_address` function that uses `libunwind`. Related to #5186