### PR TITLE
remove extension suffix hack for ppc64le

### DIFF
--- a/pypy/module/imp/interp_imp.py
+++ b/pypy/module/imp/interp_imp.py
@@ -11,12 +11,7 @@ from pypy.interpreter.error import OperationError
 def extension_suffixes(space):
     suffixes_w = []
     so_ext = importing.get_so_extension(space)
-    if "powerpc64le" in so_ext or "ppc_64" in so_ext:
-        # force adding a backward-compatible suffix (issue 3833)
-        suffixes_w.append(space.newtext(".pypy39-pp73-ppc_64-linux-gnu.so"))
-        suffixes_w.append(space.newtext(".pypy39-pp73-powerpc64le-linux-gnu.so"))
-    else:   #if space.config.objspace.usemodules.cpyext:
-        suffixes_w.append(space.newtext(so_ext))
+    suffixes_w.append(space.newtext(so_ext))
     return space.newlist(suffixes_w)
 
 def get_magic(space):


### PR DESCRIPTION
Remove the extension suffix hack for ppc64le to fix using `.pypy39*` suffix for PyPy3.10.  The hack was added
in 8f1f2a55409636a95379da89e29ded62488d1b2b to preserve backwards compatibility with old extension builds.  However, these extensions were never compatible with PyPy3.10, so it should be safe to remove it now.

Fixes #5196