### PR TITLE
Adjust sqlite_*int64 types to match upstream

### DIFF
--- a/lib_pypy/_sqlite3_build.py
+++ b/lib_pypy/_sqlite3_build.py
@@ -168,8 +168,8 @@ typedef ... sqlite3;
 typedef ... sqlite3_stmt;
 typedef ... sqlite3_context;
 typedef ... sqlite3_value;
-typedef int64_t sqlite3_int64;
-typedef uint64_t sqlite3_uint64;
+typedef long long int sqlite3_int64;
+typedef unsigned long long int sqlite3_uint64;
 
 int sqlite3_open(
     const char *filename,   /* Database filename (UTF-8) */


### PR DESCRIPTION
The sqlite3 int64 types are defined as:

```
  typedef long long int sqlite_int64;
  typedef unsigned long long int sqlite_uint64;
```

This technically is distinct from `int64_t` and `uint64_t` (that are defined as plain `[unsigned] long int` on 64-bit architectures). Adjust the definitions in `_sqlite3_build.py` to match.