### PR TITLE
Fix LTO issue with pypysig_counter

### DIFF
--- a/rpython/translator/c/src/signals.h
+++ b/rpython/translator/c/src/signals.h
@@ -24,10 +24,6 @@ int pypysig_poll(void);   /* => signum or -1 */
 RPY_EXTERN
 void pypysig_pushback(int signum);
 
-#ifndef PATH_MAX
- #define PATH_MAX 1024
-#endif
-
 /* When a signal is received, pypysig_counter is set to -1. */
 struct pypysig_long_struct_inner {
     Signed value;

--- a/rpython/translator/c/src/signals.h
+++ b/rpython/translator/c/src/signals.h
@@ -3,6 +3,7 @@
 
 #include "src/precommondefs.h"
 
+#include <limits.h>
 
 /* utilities to set a signal handler */
 RPY_EXTERN


### PR DESCRIPTION
If `limits.h` isn't included, we get two values in use for `PATH_MAX` -
one is the fallback defined by `signals.h`, and the other is the one
that `signals.c` sees when it includes `limits.h`. This is a problem
with LTO if another object included limits.h and picked up a different
definition of `pypysig_counter`, showing up as -Wlto-type-mismatch.

Fix that by including `limits.h` unconditionally. signals.c already
does that so it should be fine.

Closes: #5199