### PR TITLE
py3.11: raise `SyntaxError` on null bytes, to match CPython 3.11

### DIFF
--- a/lib-python/3/test/test_ast.py
+++ b/lib-python/3/test/test_ast.py
@@ -864,8 +864,7 @@ class AST_Tests(unittest.TestCase):
         check_limit("a", "*a")
 
     def test_null_bytes(self):
-        # PyPy raises a ValueError
-        with self.assertRaises((SyntaxError, ValueError),
+        with self.assertRaises(SyntaxError,
             msg="source code string cannot contain null bytes"):
             ast.parse("a\0b")
 

--- a/pypy/interpreter/pyopcode.py
+++ b/pypy/interpreter/pyopcode.py
@@ -1988,7 +1988,7 @@ def source_as_str(space, w_source, funcname, what, flags):
 
     if not (flags & consts.PyCF_ACCEPT_NULL_BYTES):
         if '\x00' in source:
-            raise oefmt(space.w_ValueError,
+            raise oefmt(space.w_SyntaxError,
                         "source code string cannot contain null bytes")
         source = rstring.assert_str0(source)
     return source, flags

--- a/pypy/module/__builtin__/test/apptest_compile.py
+++ b/pypy/module/__builtin__/test/apptest_compile.py
@@ -6,7 +6,7 @@ def test_simple():
     assert eval(co) == 3
     co = compile(memoryview(b'1+2'), '?', 'eval')
     assert eval(co) == 3
-    exc = raises(ValueError, compile, chr(0), '?', 'eval')
+    exc = raises(SyntaxError, compile, chr(0), '?', 'eval')
     assert str(exc.value) == "source code string cannot contain null bytes"
     compile("from __future__ import with_statement", "<test>", "exec")
     raises(SyntaxError, compile, '-', '?', 'eval')


### PR DESCRIPTION
Raise `SyntaxError` rather than `ValueError` on null bytes in source code, to match the behavior of Python 3.11.4+.

Fixes #5234