### PR TITLE
Fix `datetime.*.fromisoformat()` to reject spaces in fraction part

### DIFF
--- a/lib-python/3/datetime.py
+++ b/lib-python/3/datetime.py
@@ -398,6 +398,8 @@ def _parse_hh_mm_ss_ff(tstr):
             raise ValueError("Invalid microsecond component")
         else:
             pos += 1
+            if not all(map(_is_ascii_digit, tstr[pos:])):
+                raise ValueError("Non-digit values in fraction")
 
             len_remainder = len_str - pos
 
@@ -409,9 +411,6 @@ def _parse_hh_mm_ss_ff(tstr):
             time_comps[3] = int(tstr[pos:(pos+to_parse)])
             if to_parse < 6:
                 time_comps[3] *= _FRACTION_CORRECTION[to_parse-1]
-            if (len_remainder > to_parse
-                    and not all(map(_is_ascii_digit, tstr[(pos+to_parse):]))):
-                raise ValueError("Non-digit values in unparsed fraction")
 
     return time_comps
 


### PR DESCRIPTION
Fix pure Python implementation of `fromisoformat()` to reject spaces in fractional part of time specifications.  This matches the behavior of the C implementation in CPython, and prevents the method from parsing them incorrectly.

This fixes Django's test suite by enabling a fallback to their own (working) parser.

Backports: https://github.com/python/cpython/pull/130962