### PR TITLE
Get 32-bit ARM translating on old platforms again

### DIFF
--- a/rpython/translator/c/src/precommondefs.h
+++ b/rpython/translator/c/src/precommondefs.h
@@ -11,7 +11,7 @@
 /* Define on Darwin to activate all library features */
 #define _DARWIN_C_SOURCE 1
 /* These must be set to 64 to enable large file support on 32-bit systems. */
-#if defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+#if defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86) || defined(__arm__)
   #define _FILE_OFFSET_BITS 64
   #define _LARGEFILE_SOURCE 1
 #endif


### PR DESCRIPTION
This applies to the 3.10 and 3.11 branches.

Fixes: #5229