### PR TITLE
Remove some duplicate code from `_cffi_ssl` module

### DIFF
--- a/lib_pypy/_cffi_ssl/_stdssl/__init__.py
+++ b/lib_pypy/_cffi_ssl/_stdssl/__init__.py
@@ -724,7 +724,7 @@ class _SSLSocket(object):
         return sock
 
     def shutdown(self):
-        sock = self.get_socket_or_None()
+        sock = None
         nonblocking = False
         ssl = self.ssl
 

--- a/lib_pypy/_cffi_ssl/_stdssl/error.py
+++ b/lib_pypy/_cffi_ssl/_stdssl/error.py
@@ -79,8 +79,6 @@ for mnemo, number in _lib_codes:
 
 # the PySSL_SetError equivalent
 def pyssl_error(obj, ret):
-    errcode = lib.ERR_peek_last_error()
-
     errstr = ""
     errval = 0
     errtype = SSLError
@@ -136,7 +134,7 @@ def pyssl_error(obj, ret):
             if e == 0:
                 errstr = "A failure in the SSL library occurred"
             else:
-                errstr = _str_from_buf(lib.ERR_lib_error_string(errcode))
+                errstr = _str_from_buf(lib.ERR_lib_error_string(e))
         else:
             errstr = "Invalid error code"
             errval = SSL_ERROR_INVALID_ERROR_CODE


### PR DESCRIPTION
Remove some duplicate code that I've discovered in `_cffi_ssl` module while debugging https://github.com/python-trio/trio/issues/3253.