### PR TITLE
Fix test collection for pytest-A on macos-arm64

### DIFF
--- a/pypy/pytest-A.py
+++ b/pypy/pytest-A.py
@@ -2,13 +2,6 @@
 import platform
 
 DIRS_SPLIT = {
-    'arm': [
-        'interpreter/astcompiler/test',
-        'interpreter/pyparser/test',
-        'interpreter/test',
-        'module/test_lib_pypy',
-        'objspace/std/test',
-    ],
     'amd64': [  # windows
         'module/cpyext/test',
     ]


### PR DESCRIPTION
The existing split was unnecessary and resulted in nonsensical calls to `pytest -A .../apptest_foo.py` which mess up test results, e.g. [here](https://buildbot.pypy.org/summary/longrepr?testname=&builder=pypy-c-jit-macos-arm64&build=1059&mod=pypy.interpreter.astcompiler.test.apptest_exceptiongroup)

IIRC, I tried to make that do the right thing (i.e skip instead of erroring) back in the day but didn't find a reasonable way. Calling `pytest -A` on the parent test directory does the right thing though.