### PR TITLE
Fix EINTR handling in time.sleep() on Mac

### DIFF
--- a/pypy/module/time/interp_time.py
+++ b/pypy/module/time/interp_time.py
@@ -210,8 +210,7 @@ if rtime.HAVE_NANOSLEEP:
             int ret = nanosleep(rqtp, rmtp);
             if (ret == 0)
                 return 0;
-            errno = ret;
-            return ret;
+            return errno;
         }
     """)
 


### PR DESCRIPTION
nanosleep() is documented as returning -1 on error and setting errno.