### PR TITLE
Translate variant with --revdb in “Translate PyPy” GitHub workflow.

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   build:
 
+    name: build on ${{ matrix.os }}${{ matrix.revdb && ' (with RevDB)' || '' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Before this change, translating RevDB was not tested in CI, leading to occasional breaks. Also, having the translated RevDB-enabled PyPy variant available as an Artifact makes it easier for people to try it.