### PR TITLE
Ordereddict move to first bug

### DIFF
--- a/rpython/rtyper/test/test_rdict.py
+++ b/rpython/rtyper/test/test_rdict.py
@@ -14,9 +14,10 @@ from rpython.rlib.objectmodel import r_dict
 from rpython.rlib.rarithmetic import r_int, r_uint, r_longlong, r_ulonglong
 
 import py
-from hypothesis import settings
+from hypothesis import settings, assume
 from hypothesis.strategies import (
-    builds, sampled_from, binary, just, integers, text, characters, tuples)
+    builds, sampled_from, binary, just, integers, text, characters, tuples,
+    lists, sets, composite)
 from hypothesis.stateful import GenericStateMachine, run_state_machine_as_test
 
 def ann2strategy(s_value):
@@ -1255,6 +1256,14 @@ class MappingSpace(object):
     def move_to_first(self, key):
         self.move_to_end(key, last=False)
 
+    def many_move_to_first(self, keys):
+        for key in keys:
+            self.move_to_first(key)
+
+    def many_move_to_end(self, keys):
+        for key in keys:
+            self.move_to_end(key)
+
     def copydict(self):
         self.l_dict = self.ll_copy(self.l_dict)
         assert self.ll_len(self.l_dict) == len(self.reference)
@@ -1300,6 +1309,29 @@ class MappingSpace(object):
                 else:
                     raise AssertionError("removed key still shows up")
 
+    def init_many(self, l):
+        for key, value in l:
+            self.setitem(key, value)
+
+@composite
+def st_many_elements(draw, st_keys, st_values):
+    keys = draw(sets(st_keys, min_size=50))
+    res = [(key, draw(st_values)) for key in keys]
+    return (res, )
+
+@composite
+def st_many_moves(draw, reference):
+    assume(len(reference) > 3)
+    number = draw(integers(3, len(reference) - 1))
+    remaining = set(reference)
+    keys = []
+    for i in range(number):
+        key = draw(sampled_from(list(remaining)))
+        keys.append(key)
+        remaining.remove(key)
+    print("st_many_elements", len(keys), len(reference))
+    return (keys, )
+
 class MappingSM(GenericStateMachine):
     def __init__(self):
         self.space = None
@@ -1307,6 +1339,10 @@ class MappingSM(GenericStateMachine):
     def st_setitem(self):
         return builds(Action,
             just('setitem'), tuples(self.st_keys, self.st_values))
+
+    def st_init_many(self):
+        return builds(Action,
+            just('init_many'), st_many_elements(self.st_keys, self.st_values))
 
     def st_updateitem(self):
         return builds(Action,
@@ -1326,18 +1362,29 @@ class MappingSM(GenericStateMachine):
             just('move_to_first'),
                 tuples(sampled_from(self.space.reference)))
 
+    def st_many_move_to_end(self):
+        return builds(Action,
+            just('many_move_to_end'), st_many_moves(self.space.reference))
+
+    def st_many_move_to_first(self):
+        return builds(Action,
+            just('many_move_to_first'), st_many_moves(self.space.reference))
+
     def steps(self):
         if not self.space:
             return builds(Action, just('setup'), tuples(st_keys, st_values))
         global_actions = [Action('copydict', ()), Action('cleardict', ()),
                           Action('popitem', ()), Action('removeindex', ())]
         if self.space.reference:
-            return (
+            res = (
                 self.st_setitem() | sampled_from(global_actions) |
-                self.st_updateitem() | self.st_delitem() |
-                self.st_move_to_end() | self.st_move_to_first())
+                self.st_updateitem() | self.st_delitem())
+            if self.HAVE_MOVE_TO_FIRST_END:
+                res |= (self.st_move_to_end() | self.st_move_to_first() |
+                    self.st_many_move_to_end() | self.st_many_move_to_first())
+            return res
         else:
-            return (self.st_setitem() | sampled_from(global_actions))
+            return (self.st_setitem() | sampled_from(global_actions) | self.st_init_many())
 
     def execute_step(self, action):
         if action.method == 'setup':
@@ -1345,8 +1392,11 @@ class MappingSM(GenericStateMachine):
             self.st_keys = ann2strategy(self.space.s_key)
             self.st_values = ann2strategy(self.space.s_value)
             return
-        with signal_timeout(10):  # catches infinite loops
+        try:
             action.execute(self.space)
+        except Exception as e:
+            import pdb;pdb.xpm()
+            raise
 
     def teardown(self):
         if self.space:
@@ -1368,6 +1418,8 @@ class DictSpace(MappingSpace):
         return rdict.ll_newdict(repr.DICT)
 
 class DictSM(MappingSM):
+    HAVE_MOVE_TO_FIRST_END = False
+
     Space = DictSpace
 
 def test_hypothesis():

--- a/rpython/rtyper/test/test_rdict.py
+++ b/rpython/rtyper/test/test_rdict.py
@@ -1392,11 +1392,8 @@ class MappingSM(GenericStateMachine):
             self.st_keys = ann2strategy(self.space.s_key)
             self.st_values = ann2strategy(self.space.s_value)
             return
-        try:
+        with signal_timeout(10):
             action.execute(self.space)
-        except Exception as e:
-            import pdb;pdb.xpm()
-            raise
 
     def teardown(self):
         if self.space:

--- a/rpython/rtyper/test/test_rordereddict.py
+++ b/rpython/rtyper/test/test_rordereddict.py
@@ -376,6 +376,7 @@ class TestRDictDirect(object):
         for i in range(5, 150):
             rordereddict.ll_dict_move_to_first(ll_d, i)
 
+
 class TestRDictDirectDummyKey(TestRDictDirect):
     class dummykeyobj:
         ll_dummy_value = llstr("dupa")
@@ -533,6 +534,8 @@ class ODictSpace(MappingSpace):
 
 
 class ODictSM(MappingSM):
+    HAVE_MOVE_TO_FIRST_END = True
+
     Space = ODictSpace
 
 def test_hypothesis():

--- a/rpython/rtyper/test/test_rordereddict.py
+++ b/rpython/rtyper/test/test_rordereddict.py
@@ -367,6 +367,14 @@ class TestRDictDirect(object):
                 rordereddict.ll_dict_move_to_end(ll_d, 1, False)
                 assert content() == [(1, 11), (2, 22)]
 
+    def test_direct_move_to_start_bug(self):
+        DICT = self._get_int_dict()
+        ll_d = rordereddict.ll_newdict(DICT)
+        for i in range(150):
+            rordereddict.ll_dict_setitem(ll_d, i, i)
+        assert ll_d.lookup_function_no == 0
+        for i in range(5, 150):
+            rordereddict.ll_dict_move_to_first(ll_d, i)
 
 class TestRDictDirectDummyKey(TestRDictDirect):
     class dummykeyobj:


### PR DESCRIPTION
#5257 fix a subtle invariant violation of PyPy's ordered dictionaries in the `move_to_first` logic