### PR TITLE
feat: add missing constants in zlib

### DIFF
--- a/pypy/module/zlib/moduledef.py
+++ b/pypy/module/zlib/moduledef.py
@@ -39,10 +39,27 @@ objects support decompress() and flush()."""
 
 
 for _name in """
-    MAX_WBITS  DEFLATED  DEF_MEM_LEVEL
-    Z_BEST_SPEED  Z_BEST_COMPRESSION  Z_DEFAULT_COMPRESSION
-    Z_FILTERED  Z_HUFFMAN_ONLY  Z_DEFAULT_STRATEGY
-    Z_FINISH  Z_NO_FLUSH  Z_SYNC_FLUSH  Z_FULL_FLUSH
+    MAX_WBITS
+    DEFLATED
+    DEF_MEM_LEVEL
+    DEF_BUF_SIZE
+    Z_NO_COMPRESSION
+    Z_BEST_SPEED
+    Z_BEST_COMPRESSION
+    Z_DEFAULT_COMPRESSION
+    Z_FILTERED
+    Z_HUFFMAN_ONLY
+    Z_RLE
+    Z_FIXED
+    Z_DEFAULT_STRATEGY
+    Z_NO_FLUSH
+    Z_PARTIAL_FLUSH
+    Z_SYNC_FLUSH
+    Z_FULL_FLUSH
+    Z_FINISH
+    Z_FINISH
+    Z_BLOCK
     ZLIB_VERSION
+    ZLIB_RUNTIME_VERSION
     """.split():
     Module.interpleveldefs[_name] = 'space.wrap(%r)' % (getattr(rzlib, _name),)

--- a/rpython/rlib/rzlib.py
+++ b/rpython/rlib/rzlib.py
@@ -29,12 +29,38 @@ eci = rffi_platform.configure_external_library(
 
 
 constantnames = '''
-    Z_OK  Z_STREAM_ERROR  Z_BUF_ERROR  Z_MEM_ERROR  Z_STREAM_END Z_DATA_ERROR
-    Z_DEFLATED  Z_DEFAULT_STRATEGY  Z_DEFAULT_COMPRESSION
-    Z_NO_FLUSH  Z_FINISH  Z_SYNC_FLUSH  Z_FULL_FLUSH
-    MAX_WBITS  MAX_MEM_LEVEL
-    Z_BEST_SPEED  Z_BEST_COMPRESSION  Z_DEFAULT_COMPRESSION
-    Z_FILTERED  Z_HUFFMAN_ONLY  Z_DEFAULT_STRATEGY Z_NEED_DICT
+    MAX_WBITS
+    MAX_MEM_LEVEL
+    Z_NO_FLUSH
+    Z_PARTIAL_FLUSH
+    Z_SYNC_FLUSH
+    Z_FULL_FLUSH
+    Z_FINISH
+    Z_BLOCK
+    Z_TREES
+    Z_OK
+    Z_STREAM_END
+    Z_NEED_DICT
+    Z_ERRNO
+    Z_STREAM_ERROR
+    Z_DATA_ERROR
+    Z_MEM_ERROR
+    Z_BUF_ERROR
+    Z_VERSION_ERROR
+    Z_NO_COMPRESSION
+    Z_BEST_SPEED
+    Z_BEST_COMPRESSION
+    Z_DEFAULT_COMPRESSION
+    Z_FILTERED
+    Z_HUFFMAN_ONLY
+    Z_RLE
+    Z_FIXED
+    Z_DEFAULT_STRATEGY
+    Z_BINARY
+    Z_TEXT
+    Z_ASCII
+    Z_UNKNOWN
+    Z_DEFLATED
     Z_NULL
     '''.split()
 
@@ -77,6 +103,8 @@ if MAX_MEM_LEVEL >= 8:
     DEF_MEM_LEVEL = 8
 else:
     DEF_MEM_LEVEL = MAX_MEM_LEVEL
+
+DEF_BUF_SIZE = 16*1024
 
 OUTPUT_BUFFER_SIZE = 32*1024
 INPUT_BUFFER_MAX = 2047*1024*1024
@@ -225,6 +253,8 @@ def inflateSetDictionary(stream, string):
 def zlibVersion():
     """Return the runtime version of zlib library"""
     return rffi.charp2str(_zlibVersion())
+
+ZLIB_RUNTIME_VERSION = zlibVersion()
 
 # ____________________________________________________________
 


### PR DESCRIPTION
I have added some missing constants for the `zlib` module that are present in the CPython module. See [CPython commit](https://github.com/python/cpython/commit/bc3f2289b9007396bfb7f986bee477b6176c1822).

I am not sure what branch to target, this applies to `main`, `py3.10`, and `py3.11`; if so I can open other PRs for the other branches or what it is needed.