### PR TITLE
Add missing audit event for `sys._getframe()`

### DIFF
--- a/pypy/conftest.py
+++ b/pypy/conftest.py
@@ -44,6 +44,13 @@ except AttributeError:
     # no need to dedent on py3.10+
     pass
 
+def get_marker(item, name):
+    try:
+        return item.get_closest_marker(name=name)
+    except AttributeError:
+        # pytest < 3.6
+        return item.get_marker(name=name)
+
 def pytest_report_header():
     return "pytest-%s from %s" % (pytest.__version__, pytest.__file__)
 
@@ -233,7 +240,7 @@ def skip_on_missing_buildoption(**ropts):
 def pytest_runtest_setup(item):
     if isinstance(item, pytest.Function):
         config = item.config
-        if hasattr(item, "get_marker") and item.get_marker(name='pypy_only'):
+        if get_marker(item, name='pypy_only'):
             if config.applevel is not None and not config.applevel.is_pypy:
                 pytest.skip('PyPy-specific test')
         appclass = item.getparent(pytest.Class)

--- a/pypy/module/sys/test/apptest_audit.py
+++ b/pypy/module/sys/test/apptest_audit.py
@@ -94,6 +94,11 @@ def test_exec():
         exec(ret1.__code__)
     assert hook.seen == [("exec", (ret1.__code__, ))]
 
+def test_sys_getframe():
+    with TestHook() as hook:
+        f = sys._getframe()
+    assert hook.seen == [("sys._getframe", (f,))]
+
 def test_donttrace():
     trace_events = []
     audit_events = []

--- a/pypy/module/sys/test/apptest_audit.py
+++ b/pypy/module/sys/test/apptest_audit.py
@@ -1,5 +1,10 @@
 import sys
-import __pypy__
+try:
+    import __pypy__
+except ImportError:
+    __pypy__ = None
+
+import pytest
 
 class TestHook:
     __test__ = False
@@ -70,6 +75,7 @@ def test_id_hook():
         x = id(hook)
         assert hook.seen[0] == ("builtins.id", (x, ))
 
+@pytest.mark.pypy_only
 def test_eval():
     def ret1():
         return 1
@@ -79,6 +85,7 @@ def test_eval():
         assert res == 1
     assert hook.seen == [("exec", (ret1.__code__, ))]
 
+@pytest.mark.pypy_only
 def test_exec():
     def ret1():
         return 1
@@ -106,6 +113,7 @@ def test_donttrace():
     print(trace_events)
     assert len(trace_events) == 0
 
+@pytest.mark.pypy_only
 def test_cantrace():
     trace_events = []
     audit_events = []

--- a/pypy/module/sys/vm.py
+++ b/pypy/module/sys/vm.py
@@ -48,6 +48,7 @@ def getframe(space, depth):
             raise oefmt(space.w_ValueError, "call stack is not deep enough")
         if depth == 0:
             f.mark_as_escaped()
+            audit(space, "sys._getframe", [f])
             return f
         depth -= 1
         f = ec.getnextframe_nohidden(f)


### PR DESCRIPTION
CPython test added in https://github.com/python/cpython/pull/94928

Also, fix `@pytest.mark.pypy_only` to work in `-D` apptests with non-ancient pytest versions.