### PR TITLE
Remove `pycparser` dep from `cffi` dist-info

### DIFF
--- a/lib_pypy/cffi-1.18.0.dev0.dist-info/METADATA
+++ b/lib_pypy/cffi-1.18.0.dev0.dist-info/METADATA
@@ -24,7 +24,6 @@ Classifier: Programming Language :: Python :: Implementation :: CPython
 Classifier: Programming Language :: Python :: Implementation :: PyPy
 Classifier: License :: OSI Approved :: MIT License
 License-File: LICENSE
-Requires-Dist: pycparser
 
 
 CFFI


### PR DESCRIPTION
Remove the incorrect `pycparser` dependency from `cffi` dist-info. PyPy is vendoring `pycparser` inside `cffi`, and not as a global package.  Having an explicit dependency meant that `pip check` would fail in environments without `pycparser` manually installed, in particular in a fresh venv.

Fixes #5306