### PR TITLE
Set save_err=rffi.RFFI_SAVE_ERRNO for c_memfd_create().

### DIFF
--- a/pypy/module/posix/test/test_posix2.py
+++ b/pypy/module/posix/test/test_posix2.py
@@ -1717,6 +1717,13 @@ class AppTestPosix:
             finally:
                 os.close(fd)
 
+        def test_memfd_create_error(self):
+            import errno
+            os = self.posix
+            with raises(OSError) as exc_info:
+                fd = os.memfd_create("abc", flags=-1)
+            assert exc_info.value.errno == errno.EINVAL
+
     def test_get_terminal_size(self):
         os = self.posix
         for args in [(), (1,), (0,), (42421,)]:

--- a/rpython/rlib/rposix.py
+++ b/rpython/rlib/rposix.py
@@ -3288,7 +3288,8 @@ if sys.platform.startswith('linux'):
     if cConfig['HAVE_MEMFD_CREATE']:
         c_memfd_create = external('memfd_create',
             [rffi.CCHARP, rffi.UINT], rffi.INT,
-            compilation_info=CConfig._compilation_info_)
+            compilation_info=CConfig._compilation_info_,
+            save_err=rffi.RFFI_SAVE_ERRNO)
         def memfd_create(name, flags):
             return handle_posix_error(
                 'memfd_create', c_memfd_create(name, flags))


### PR DESCRIPTION
Function memfd_create() that wraps c_memfd_create() uses handle_posix_error(), which uses get_saved_errno(), which requires save_err=rffi.RFFI_SAVE_ERRNO.