### PR TITLE
Fix object.__format__ to check format spec before string conversion

### DIFF
--- a/pypy/module/__builtin__/test/test_format.py
+++ b/pypy/module/__builtin__/test/test_format.py
@@ -23,3 +23,9 @@ class AppTestFormat(object):
                     raises(TypeError, format, cls(), fmt_str)
                 else:
                     format(cls(), fmt_str)  # does not raise
+
+        class D:
+            def __str__(self):
+                raise ValueError
+
+        raises(TypeError, format, D(), 's')

--- a/pypy/objspace/std/objectobject.py
+++ b/pypy/objspace/std/objectobject.py
@@ -284,15 +284,19 @@ def descr__reduce_ex__(space, w_obj, proto):
 
 def descr___format__(space, w_obj, w_format_spec):
     if space.isinstance_w(w_format_spec, space.w_unicode):
+        if space.len_w(w_format_spec) > 0:
+            raise oefmt(space.w_TypeError,
+                         "unsupported format string passed to %T.__format__",
+                         w_obj)
         w_as_str = space.call_function(space.w_unicode, w_obj)
     elif space.isinstance_w(w_format_spec, space.w_bytes):
+        if space.len_w(w_format_spec) > 0:
+            raise oefmt(space.w_TypeError,
+                         "unsupported format string passed to %T.__format__",
+                         w_obj)
         w_as_str = space.str(w_obj)
     else:
         raise oefmt(space.w_TypeError, "format_spec must be a string")
-    if space.len_w(w_format_spec) > 0:
-        raise oefmt(space.w_TypeError,
-                     "unsupported format string passed to %T.__format__",
-                     w_obj);
     return space.format(w_as_str, w_format_spec)
 
 def descr__eq__(space, w_self, w_other):


### PR DESCRIPTION
## Summary
- Check format spec length before converting object to string in `object.__format__`, matching CPython behavior.

## Details

Fixes #5383

- Moved the `format_spec` non-empty check before the `__str__`/`__repr__` conversion in `descr___format__`. Previously, the conversion happened first, so errors from `__repr__`/`__str__` would propagate instead of the expected `TypeError`.
- Added test case: `format()` with non-empty spec on an object whose `__str__` raises `ValueError` → should raise `TypeError`.
