### PR TITLE
Fix `object.__format__` losing str subclass type

### DIFF
--- a/pypy/module/__builtin__/test/test_format.py
+++ b/pypy/module/__builtin__/test/test_format.py
@@ -29,3 +29,13 @@ class AppTestFormat(object):
                 raise ValueError
 
         raises(TypeError, format, D(), 's')
+
+        class DerivedFromStr(str):
+            pass
+
+        class E:
+            def __repr__(self):
+                return DerivedFromStr('10')
+
+        assert format(0, DerivedFromStr('10')) == '         0'
+        assert type(format(E())) is DerivedFromStr

--- a/pypy/objspace/std/objectobject.py
+++ b/pypy/objspace/std/objectobject.py
@@ -297,7 +297,7 @@ def descr___format__(space, w_obj, w_format_spec):
         w_as_str = space.str(w_obj)
     else:
         raise oefmt(space.w_TypeError, "format_spec must be a string")
-    return space.format(w_as_str, w_format_spec)
+    return w_as_str
 
 def descr__eq__(space, w_self, w_other):
     if space.is_w(w_self, w_other):


### PR DESCRIPTION
## Description

Fixes #5386 

When `object.__format__` is called with an empty format spec on an object whose `__repr__`/`__str__` returns a `str` subclass, PyPy returns a plain `str` instead of preserving the subclass type, diverging from CPython.

#### AS-IS
```
>>> type(format(A()))
<class 'str'>
```

#### TO-BE
```
>>> type(format(A()))
<class '__main__.Substr'>
```
(matching CPython)

## Changes

- Return `w_as_str` directly from `descr___format__` instead of re-processing it through `space.format(w_as_str, w_format_spec)`.
- Add test for str subclass type preservation in `format()`. Also port a missing test case from CPython's [`test_builtin.py`](https://github.com/python/cpython/blob/089cae5158f0fed73f44d7d21ff34bbfb24f1e36/Lib/test/test_builtin.py#L2002-L2003) for str subclass as format spec.