### PR TITLE
gh-5344: Fix `raise` ignoring user modifications to `__traceback__`

### DIFF
--- a/pypy/interpreter/pyopcode.py
+++ b/pypy/interpreter/pyopcode.py
@@ -705,7 +705,7 @@ class __extend__(pyframe.PyFrame):
             w_value = last_operr._w_value
             if w_value is not None and isinstance(w_value, W_BaseException):
                 w_tb = w_value.w_traceback
-                if w_tb is None or space.is_w(w_tb, space.w_None):
+                if space.is_none(w_tb):
                     last_operr.set_traceback(None)
                 else:
                     from pypy.interpreter.pytraceback import PyTraceback

--- a/pypy/interpreter/pyopcode.py
+++ b/pypy/interpreter/pyopcode.py
@@ -699,6 +699,18 @@ class __extend__(pyframe.PyFrame):
             if last_operr is None:
                 raise oefmt(space.w_RuntimeError,
                             "No active exception to reraise")
+            # sync the exceptions __traceback__ back to the
+            # OperationError, in case user code modified it
+            from pypy.module.exceptions.interp_exceptions import W_BaseException
+            w_value = last_operr._w_value
+            if w_value is not None and isinstance(w_value, W_BaseException):
+                w_tb = w_value.w_traceback
+                if w_tb is None or space.is_w(w_tb, space.w_None):
+                    last_operr.set_traceback(None)
+                else:
+                    from pypy.interpreter.pytraceback import PyTraceback
+                    if isinstance(w_tb, PyTraceback):
+                        last_operr.set_traceback(w_tb)
             # re-raise, no new traceback obj will be attached
             raise RaiseWithExplicitTraceback(last_operr)
         if nbargs == 2:

--- a/pypy/interpreter/test/apptest_raise.py
+++ b/pypy/interpreter/test/apptest_raise.py
@@ -655,3 +655,28 @@ def test_invalid_cause_setter():
         assert "exception cause" in str(e)
     else:
         fail("Expected TypeError")
+
+def test_reraise_with_cleared_traceback():
+    try:
+        try:
+            raise ValueError("err")
+        except ValueError as err:
+            err.__traceback__ = None
+            raise
+    except ValueError as err:
+        assert err.__traceback__ is None
+
+def test_reraise_with_replaced_traceback():
+    import sys
+    try:
+        raise KeyError
+    except KeyError:
+        othr = sys.exc_info()[2]
+    try:
+        try:
+            raise ValueError("err")
+        except ValueError as err:
+            err.__traceback__ = othr
+            raise
+    except ValueError as err:
+        assert err.__traceback__ is othr


### PR DESCRIPTION
Now we get:
```pypy
>>>> try:
....     raise ValueError('err')
.... except ValueError as err:
....     err.__traceback__ = None
....     raise
.... 
ValueError: err
```

Closes #5344.
CPython 2.7 also has this bug, so this PR targets py3.11 for consistency.
