### PR TITLE
gh-5362: fix `function.__get__(None)` to raise `TypeError` like CPython

### DIFF
--- a/pypy/interpreter/gateway.py
+++ b/pypy/interpreter/gateway.py
@@ -1498,7 +1498,9 @@ def descr_function_get(space, w_function, w_instance, w_owner=None):
     """functionobject.__get__(instance, owner=None, /) -> method"""
     # this is not defined as a method on Function because it's generally
     # useful logic: w_function can be any callable.  It is used by Method too.
-    if w_instance is None or space.is_w(w_instance, space.w_None):
+    if space.is_none(w_instance):
+        if space.is_none(w_owner):
+            raise oefmt(space.w_TypeError, "__get__(None, None) is invalid")
         return w_function
     else:
         return Method(space, w_function, w_instance)

--- a/pypy/interpreter/test/apptest_function.py
+++ b/pypy/interpreter/test/apptest_function.py
@@ -406,6 +406,15 @@ def test_get():
     meth = func.__get__(obj, object)
     assert meth() == obj
 
+def test_get_none_none_invalid():
+    def func(): ...
+
+    with pytest.raises(TypeError):
+        func.__get__(None, None)
+    with pytest.raises(TypeError):
+        func.__get__(None)
+    assert func.__get__(None, type(func)) is func
+
 @pytest.mark.skipif(IS_PYPY, reason="XXX issue #2083")
 def test_none_get_interaction():
     assert type(None).__repr__(None) == 'None'


### PR DESCRIPTION
Closes #5362.

Pyton3.11:
```pycon
>>> def f(): pass
... 
>>> result = f.__get__(None, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __get__(None, None) is invalid
>>> result = f.__get__(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __get__(None, None) is invalid
>>> result = f.__get__(None, type(f))
>>>
```
And, with the fix, pypy 3.11:
```
>>>> def f(): pass
>>>> result = f.__get__(None, None)
Traceback (application-level):
  File "<inline>", line 1 in <module>
    result = f.__get__(None, None)
TypeError: __get__(None, None) is invalid
>>>> result = f.__get__(None)
Traceback (application-level):
  File "<inline>", line 1 in <module>
    result = f.__get__(None)
TypeError: __get__(None, None) is invalid
>>>> result = f.__get__(None, type(f))
>>>> 
```
