### PR TITLE
Run `pre-commit autoupdate` and fix new failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 
 repos:
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
         args: ["--toml=pyproject.toml"]

--- a/pypy/doc/release-v7.0.0.rst
+++ b/pypy/doc/release-v7.0.0.rst
@@ -115,7 +115,7 @@ If not specified, the changes are shared across versions
   for the v7.0.0 release.  For more information, see
   https://bitbucket.org/pypy/revdb
 * Support underscores in numerical literals like ``'4_2'`` (Py3.6)
-* Pre-emptively raise MemoryError if the size of dequeue in ``_collections.deque``
+* Preemptively raise MemoryError if the size of dequeue in ``_collections.deque``
   is too large (Py3.5)
 * Fix multithreading issues in calls to ``os.setenv``
 * Add missing defines and typedefs for numpy and pandas on MSVC


### PR DESCRIPTION
Thank you for contributing to PyPy. Please be sure to target one of our active branches:
- `main` for pypy2.7, rpython, and documentation changes
- `py3.10` for the legacy python3.10 branch
- `py3.11` for the current development branch targeting python3.11

Do not target the `branch/*` branches, they are artifacts of our migration from mercurial to git.
