### PR TITLE
Gate cpython-specific test case in `test_eval_str_invalid_escape`

### DIFF
--- a/lib-python/3/test/test_string_literals.py
+++ b/lib-python/3/test/test_string_literals.py
@@ -132,16 +132,18 @@ class TestLiterals(unittest.TestCase):
         self.assertEqual(exc.offset, 1)
 
         # Check that the warning is raised ony once if there are syntax errors
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
-            with self.assertRaises(SyntaxError) as cm:
-                eval("'\\e' $")
-            exc = cm.exception
-        self.assertEqual(len(w), 1)
-        self.assertEqual(w[0].category, DeprecationWarning)
-        self.assertRegex(str(w[0].message), 'invalid escape sequence')
-        self.assertEqual(w[0].filename, '<string>')
+        # PyPy: skipped as the parser raises SyntaxError during tokenization
+        # before the AST builder gets a chance to emit the deprecation warning
+        if sys.implementation.name == 'cpython':
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always', category=DeprecationWarning)
+                with self.assertRaises(SyntaxError) as cm:
+                    eval("'\\e' $")
+                exc = cm.exception
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].category, DeprecationWarning)
+            self.assertRegex(str(w[0].message), 'invalid escape sequence')
+            self.assertEqual(w[0].filename, '<string>')
 
     def test_eval_str_invalid_octal_escape(self):
         for i in range(0o400, 0o1000):

--- a/lib-python/3/test/test_string_literals.py
+++ b/lib-python/3/test/test_string_literals.py
@@ -134,7 +134,7 @@ class TestLiterals(unittest.TestCase):
         # Check that the warning is raised ony once if there are syntax errors
         # PyPy: skipped as the parser raises SyntaxError during tokenization
         # before the AST builder gets a chance to emit the deprecation warning
-        if sys.implementation.name == 'cpython':
+        with self.assertRaises(AssertionError):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always', category=DeprecationWarning)
                 with self.assertRaises(SyntaxError) as cm:


### PR DESCRIPTION
Thank you for contributing to PyPy. Please be sure to target one of our active branches:
- `main` for pypy2.7, rpython, and documentation changes
- `py3.10` for the legacy python3.10 branch
- `py3.11` for the current development branch targeting python3.11

Do not target the `branch/*` branches, they are artifacts of our migration from mercurial to git.
