### PR TITLE
Fix segfault in `Parser.diagnose()` called after successful parse

### DIFF
--- a/pypy/interpreter/astcompiler/test/test_compiler.py
+++ b/pypy/interpreter/astcompiler/test/test_compiler.py
@@ -2963,6 +2963,12 @@ class AppTestCompiler:
             assert issubclass(w[-1].category, SyntaxWarning)
             assert "assertion is always true" in w[-1].message.args[0]
 
+    def test_syntax_warnings_invalid_literal_as_error(self):
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', category=SyntaxWarning)
+            raises(SyntaxError, compile, '9and x', '<testcase>', 'exec')
+
     def test_syntax_warnings_false_positives(self):
         import warnings
 

--- a/pypy/interpreter/pyparser/baserpypeg.py
+++ b/pypy/interpreter/pyparser/baserpypeg.py
@@ -397,6 +397,9 @@ class Parser:
         return self._tokens[self._index]
 
     def diagnose(self):
+        # _highwatermark can == len(_tokens) after a successful parse consumes the last token
+        if self._highwatermark >= len(self._tokens):
+            self._highwatermark = len(self._tokens) - 1
         return self._tokens[self._highwatermark]
 
     def get_last_non_whitespace_token(self):


### PR DESCRIPTION
Regression introduced by 051b7bef56, previously `diagnose` was only called on errors.

Currently:
```
>>>> import warnings
>>>> warnings.simplefilter('error', SyntaxWarning)
>>>> compile('9and x', '<test>', 'exec')
Segmentation fault         (core dumped)
```
With fix:
```
>>>> import warnings
>>>> warnings.simplefilter('error', SyntaxWarning)
>>>> compile('9and x', '<test>', 'exec')
Traceback (application-level):
  File "<inline>", line 1 in <module>
    compile('9and x', '<test>', 'exec')
SyntaxError: invalid decimal literal (<test>, line 1)
>>>> 
```

This also fixes `test_grammar`.