### PR TITLE
Fix duplicate 'const' in C code generation for nested const pointer types

### DIFF
--- a/rpython/translator/c/node.py
+++ b/rpython/translator/c/node.py
@@ -323,10 +323,12 @@ class BareBoneArrayDefNode(NodeWithDependencies):
                                                       deflength(varlength))
         if ARRAY._hints.get("render_as_void"):
             self.fullptrtypename = 'void *@'
+            if ARRAY._hints.get("render_as_const"):
+                self.fullptrtypename = 'const ' + self.fullptrtypename
+        elif ARRAY._hints.get("render_as_const"):
+            self.fullptrtypename = self.itemtypename.replace('@', 'const *@')
         else:
             self.fullptrtypename = self.itemtypename.replace('@', '*@')
-        if ARRAY._hints.get("render_as_const"):
-            self.fullptrtypename = 'const ' + self.fullptrtypename
 
     def setup(self):
         """Array loops are forbidden by ForwardReference.become() because

--- a/rpython/translator/c/test/test_database.py
+++ b/rpython/translator/c/test/test_database.py
@@ -5,7 +5,8 @@ from rpython.translator.c.database import LowLevelDatabase
 from rpython.flowspace.model import Constant, Variable, SpaceOperation
 from rpython.flowspace.model import Block, Link, FunctionGraph
 from rpython.rtyper.lltypesystem.lltype import getfunctionptr
-from rpython.rtyper.lltypesystem.rffi import VOIDP, INT_real, INT, CArrayPtr
+from rpython.rtyper.lltypesystem.rffi import (VOIDP, INT_real, INT, CArrayPtr,
+                                              CONST_CCHARP, CONST_VOIDP)
 
 
 def dump_on_stdout(database):
@@ -256,4 +257,14 @@ def test_typedef():
 
     F = FuncType((A,), A)
     assert db.gettype(F) == "test4 (@)(test4)"
+
+def test_const_types():
+    db = LowLevelDatabase()
+
+    assert db.gettype(CONST_CCHARP) == "char const *@"
+    assert db.gettype(CONST_VOIDP) == "const void *@"
+
+    CONST_CCHARPP = Ptr(Array(CONST_CCHARP, hints={'nolength': True, 'render_as_const': True}))
+    tp = db.gettype(CONST_CCHARPP)
+    assert tp == "char const *const *@"
 


### PR DESCRIPTION
I worry making the pointer read only may break something, but I think the compiler would error if it broke something? This fixes these warnings I see in the OSS Fuzz build log:
```
[893](https://github.com/google/oss-fuzz/actions/runs/24402976663/job/71278410447?pr=15355#step:7:1894)
In file included from data_pypy_module__continuation.c:4:
./singleheader.h:61577:133: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
 61577 | RPY_EXTERN void pypy_g_W_LibObject_make_includes_from(struct pypy_pypy_module__cffi_backend_lib_obj_W_LibObject0 *l_self_824, const const char **l_c_includes_0);
       |                                                                                                                                     ^
1 warning generated.
```




Thank you for contributing to PyPy. Please be sure to target one of our active branches:
- `main` for pypy2.7, rpython, and documentation changes
- `py3.10` for the legacy python3.10 branch
- `py3.11` for the current development branch targeting python3.11

Do not target the `branch/*` branches, they are artifacts of our migration from mercurial to git.
