### PR TITLE
Raise `SyntaxError` for unterminated single-quoted strings ending in newline

### DIFF
--- a/pypy/interpreter/pyparser/pyparse.py
+++ b/pypy/interpreter/pyparser/pyparse.py
@@ -218,12 +218,19 @@ class PegParser(object):
             tokens = pytokenizer.generate_tokens(source_lines, flags,
                                                   compile_info.filename)
         except error.TokenError as e:
-            if (compile_info.flags & consts.PyCF_ALLOW_INCOMPLETE_INPUT and
-                    (pytokenizer.TRIPLE_QUOTE_UNTERMINATED_ERROR in e.msg or
-                     pytokenizer.SINGLE_QUOTE_UNTERMINATED_ERROR in e.msg or
-                     'was never closed' in e.msg or
-                     pytokenizer.EOF_MULTI_LINE_STATEMENT_ERROR in e.msg)):
-                e.msg = "incomplete input"
+            if compile_info.flags & consts.PyCF_ALLOW_INCOMPLETE_INPUT:
+                single_quote_finalized = (
+                    pytokenizer.SINGLE_QUOTE_UNTERMINATED_ERROR in e.msg and
+                    (textsrc.endswith('\n') or textsrc.endswith('\r')) and
+                    not textsrc.endswith('\\\n') and
+                    not textsrc.endswith('\\\r') and
+                    not textsrc.endswith('\\\r\n'))
+                if not single_quote_finalized and (
+                        pytokenizer.TRIPLE_QUOTE_UNTERMINATED_ERROR in e.msg or
+                        pytokenizer.SINGLE_QUOTE_UNTERMINATED_ERROR in e.msg or
+                        'was never closed' in e.msg or
+                        pytokenizer.EOF_MULTI_LINE_STATEMENT_ERROR in e.msg):
+                    e.msg = "incomplete input"
             e.filename = compile_info.filename
             raise
         except error.TokenIndentationError as e:

--- a/pypy/interpreter/pyparser/test/test_pyparse.py
+++ b/pypy/interpreter/pyparser/test/test_pyparse.py
@@ -618,6 +618,16 @@ class TestIncompleteInput(object):
         self.check_incomplete("a = \\")
         self.check_incomplete("a = '\\")
 
+    def test_unterminated_single_quote_with_newline_is_invalid(self):
+        self.check_incomplete("a = 'a\\\n")
+        self.check_incomplete("a = 'a\\\r")
+        self.check_incomplete("a = 'a\\\r\n")
+        for eol in ("\n", "\r", "\r\n"):
+            msg = self.check_error("a = 'sta" + eol)
+            assert "unterminated string literal" in msg
+            msg = self.check_error("a = 'a\\ " + eol)
+            assert "unterminated string literal" in msg
+
     def test_invalid_with_explicit_newline(self):
         # An expression that is genuinely invalid (not just incomplete) should
         # raise "invalid syntax" when it ends with an explicit newline.


### PR DESCRIPTION
Previously:
```
>>>> import codeop
>>>> codeop.compile_command("a = 'a\ ")
>>>> 
```
Whereas Python 3.11:
```
>>> import codeop
>>> codeop.compile_command("a = 'a\ ")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.11/codeop.py", line 110, in compile_command
    return _maybe_compile(_compile, source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 73, in _maybe_compile
    return compiler(source, filename, symbol, incomplete_input=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 89, in _compile
    return compile(source, filename, symbol, flags)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<input>", line 1
    a = 'a\ 
        ^
SyntaxError: unterminated string literal (detected at line 1)
```

And finally, PyPy with this patch:
```
>>>> import codeop
>>>> codeop.compile_command("a = 'a\ ")
Traceback (application-level):
  File "<inline>", line 1 in <module>
    codeop.compile_command("a = 'a\ ")
  File "/home/stan/dev/pypy/lib-python/3/codeop.py", line 110 in compile_command
    return _maybe_compile(_compile, source, filename, symbol)
  File "/home/stan/dev/pypy/lib-python/3/codeop.py", line 73 in _maybe_compile
    return compiler(source, filename, symbol, incomplete_input=False)
  File "/home/stan/dev/pypy/lib-python/3/codeop.py", line 89 in _compile
    return compile(source, filename, symbol, flags)
SyntaxError: unterminated string literal (detected at line 1) (<input>, line 1)
```

This fixes this failure seen in the buildbots on [`test_codeop`](https://buildbot.pypy.org/summary/longrepr?testname=unmodified&builder=pypy-c-jit-linux-x86-64&build=11695&mod=lib-python.3.test.test_codeop).
