### PR TITLE
Update all docs links after `/en/latest/` prefix was removed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Building PyPy is not the recommended way to obtain the PyPy alternative python
 interpreter. It is time-consuming and requires significant computing resources.
 More information can be found here:
 
-    https://doc.pypy.org/en/latest/build.html
+    https://doc.pypy.org/build.html
 
 Enjoy and send us feedback!
 

--- a/pypy/doc/conf.py
+++ b/pypy/doc/conf.py
@@ -62,7 +62,7 @@ extensions = ['sphinx.ext.autodoc',
 
 # Canonical URL (including the '/') so searching from rpython docs finds these
 affiliate_options = {
-    'canonical_url': "https://doc.pypy.org/en/latest/"
+    'canonical_url': "https://doc.pypy.org/"
 }
 
 # Other sites to add to the search of this site

--- a/pypy/doc/release-1.8.0.rst
+++ b/pypy/doc/release-1.8.0.rst
@@ -90,7 +90,7 @@ the release or is not ready yet. Highlights include:
 Cheers,
 The PyPy Team
 
-.. _`brief overview`: https://doc.pypy.org/en/latest/jit-hooks.html
+.. _`brief overview`: https://doc.pypy.org/jit-hooks.html
 .. _`numpy status page`: https://buildbot.pypy.org/numpy-status/latest.html
 .. _`numpy status update blog report`: https://morepypy.blogspot.com/2012/01/numpypy-status-update.html
 .. _`numpypy`: https://pypy.org/numpydonate.html

--- a/pypy/doc/release-1.9.0.rst
+++ b/pypy/doc/release-1.9.0.rst
@@ -97,7 +97,7 @@ Highlights
 * List comprehension has been improved.
 
 .. _`numpy-status`: https://buildbot.pypy.org/numpy-status/latest.html
-.. _`JIT hooks documentation`: https://doc.pypy.org/en/latest/jit-hooks.html
+.. _`JIT hooks documentation`: https://doc.pypy.org/jit-hooks.html
 
 JitViewer
 =========

--- a/pypy/doc/release-2.0.0-beta1.rst
+++ b/pypy/doc/release-2.0.0-beta1.rst
@@ -37,10 +37,10 @@ We suggest using PyPy from a `virtualenv`_. Once you have a virtualenv
 installed, you can follow instructions from `pypy documentation`_ on how
 to proceed. This document also covers other `installation schemes`_.
 
-.. _`pypy documentation`: https://doc.pypy.org/en/latest/getting-started.html#installing-using-virtualenv
+.. _`pypy documentation`: https://doc.pypy.org/getting-started.html#installing-using-virtualenv
 .. _`virtualenv`: https://www.virtualenv.org/en/latest/
-.. _`installation schemes`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
-.. _`PyPy and pip`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
+.. _`installation schemes`: https://doc.pypy.org/getting-started.html#installing-pypy
+.. _`PyPy and pip`: https://doc.pypy.org/getting-started.html#installing-pypy
 
 Regressions
 ===========
@@ -102,7 +102,7 @@ Highlights
   and more compact.
 
 .. _`cpython issue tracker`: https://bugs.python.org/issue14621
-.. _`jit hooks`: https://doc.pypy.org/en/latest/jit-hooks.html
+.. _`jit hooks`: https://doc.pypy.org/jit-hooks.html
 
 Things we're working on
 =======================

--- a/pypy/doc/release-2.0.0-beta2.rst
+++ b/pypy/doc/release-2.0.0-beta2.rst
@@ -47,9 +47,9 @@ We suggest using PyPy from a `virtualenv`_. Once you have a virtualenv
 installed, you can follow instructions from `pypy documentation`_ on how
 to proceed. This document also covers other `installation schemes`_.
 
-.. _`pypy documentation`: https://doc.pypy.org/en/latest/getting-started.html#installing-using-virtualenv
+.. _`pypy documentation`: https://doc.pypy.org/getting-started.html#installing-using-virtualenv
 .. _`virtualenv`: https://www.virtualenv.org/en/latest/
-.. _`installation schemes`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
+.. _`installation schemes`: https://doc.pypy.org/getting-started.html#installing-pypy
 
 Highlights
 ==========
@@ -86,7 +86,7 @@ Improvements since 1.9
 .. _`eventlet`: https://eventlet.net/
 .. _`gevent`: https://www.gevent.org/
 .. _`cffi`: https://cffi.readthedocs.org/en/release-0.6/
-.. _`JIT hooks`: https://doc.pypy.org/en/latest/jit-hooks.html
+.. _`JIT hooks`: https://doc.pypy.org/jit-hooks.html
 .. _`pypycore`: https://github.com/gevent-on-pypy/pypycore
 .. _`pypy-hacks`: https://github.com/schmir/gevent/tree/pypy-hacks
 .. _`_curses.py`: https://bitbucket.org/pypy/pypy/src/aefddd47f224e3c12e2ea74f5c796d76f4355bdb/lib_pypy/_curses.py?at=default

--- a/pypy/doc/release-2.1.0-beta1.rst
+++ b/pypy/doc/release-2.1.0-beta1.rst
@@ -62,10 +62,10 @@ We suggest using PyPy from a `virtualenv`_. Once you have a virtualenv
 installed, you can follow instructions from `pypy documentation`_ on how
 to proceed. This document also covers other `installation schemes`_.
 
-.. _`pypy documentation`: https://doc.pypy.org/en/latest/getting-started.html#installing-using-virtualenv
+.. _`pypy documentation`: https://doc.pypy.org/getting-started.html#installing-using-virtualenv
 .. _`virtualenv`: https://www.virtualenv.org/en/latest/
-.. _`installation schemes`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
-.. _`PyPy and pip`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
+.. _`installation schemes`: https://doc.pypy.org/getting-started.html#installing-pypy
+.. _`PyPy and pip`: https://doc.pypy.org/getting-started.html#installing-pypy
 
 
 Cheers,

--- a/pypy/doc/release-2.1.0-beta2.rst
+++ b/pypy/doc/release-2.1.0-beta2.rst
@@ -56,10 +56,10 @@ We suggest using PyPy from a `virtualenv`_. Once you have a virtualenv
 installed, you can follow instructions from `pypy documentation`_ on how
 to proceed. This document also covers other `installation schemes`_.
 
-.. _`pypy documentation`: https://doc.pypy.org/en/latest/getting-started.html#installing-using-virtualenv
+.. _`pypy documentation`: https://doc.pypy.org/getting-started.html#installing-using-virtualenv
 .. _`virtualenv`: https://www.virtualenv.org/en/latest/
-.. _`installation schemes`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
-.. _`PyPy and pip`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
+.. _`installation schemes`: https://doc.pypy.org/getting-started.html#installing-pypy
+.. _`PyPy and pip`: https://doc.pypy.org/getting-started.html#installing-pypy
 
 
 Cheers,

--- a/pypy/doc/release-2.3.0.rst
+++ b/pypy/doc/release-2.3.0.rst
@@ -34,7 +34,7 @@ so we can finish those projects!  The three sub-projects are:
 .. _`Py3k`: https://pypy.org/py3donate.html
 .. _`STM`: https://pypy.org/tmdonate2.html
 .. _ `NumPy`: https://pypy.org/numpydonate.html
-.. _`TDD`: https://doc.pypy.org/en/latest/how-to-contribute.html
+.. _`TDD`: https://doc.pypy.org/how-to-contribute.html
 .. _`CFFI`: https://cffi.readthedocs.org
 .. _`cryptography`: https://cryptography.io
 .. _`Pillow`: https://pypi.python.org/pypi/Pillow/2.4.0
@@ -58,7 +58,7 @@ bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
 .. _`pypy 2.3 and cpython 2.7.x`: https://speed.pypy.org
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 Highlights
 ==========
@@ -93,7 +93,7 @@ for more information see `whats-new`_:
 * Fix handling of tp_name for type objects
 
 .. _`HippyVM`: https://www.hippyvm.com
-.. _`whats-new`: https://doc.pypy.org/en/latest/whatsnew-2.3.0.html
+.. _`whats-new`: https://doc.pypy.org/whatsnew-2.3.0.html
 
 
 New Platforms and Features

--- a/pypy/doc/release-2.3.1.rst
+++ b/pypy/doc/release-2.3.1.rst
@@ -44,7 +44,7 @@ bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
 .. _`pypy 2.3 and cpython 2.7.x`: https://speed.pypy.org
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 Highlights
 ==========
@@ -67,7 +67,7 @@ for more information see `whats-new`_:
 
 * Many issues were resolved_ since the 2.3 release on May 8
 
-.. _`whats-new`: https://doc.pypy.org/en/latest/whatsnew-2.3.1.html
+.. _`whats-new`: https://doc.pypy.org/whatsnew-2.3.1.html
 .. _resolved: https://bitbucket.org/pypy/pypy/issues?status=resolved
 
 Please try it out and let us know what you think. We especially welcome

--- a/pypy/doc/release-2.4.0.rst
+++ b/pypy/doc/release-2.4.0.rst
@@ -49,7 +49,7 @@ bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
 .. _`pypy 2.4 and cpython 2.7.x`: https://speed.pypy.org
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 Highlights
 ==========
@@ -105,9 +105,9 @@ for more information see `whats-new`_:
   
 * Many issues were resolved_ since the 2.3.1 release on June 8
 
-.. _`whats-new`: https://doc.pypy.org/en/latest/whatsnew-2.4.0.html
+.. _`whats-new`: https://doc.pypy.org/whatsnew-2.4.0.html
 .. _resolved: https://bitbucket.org/pypy/pypy/issues?status=resolved
-.. _sandbox: https://doc.pypy.org/en/latest/sandbox.html   
+.. _sandbox: https://doc.pypy.org/sandbox.html   
 
 We have further improvements on the way: rpython file handling,
 numpy linalg compatibility, as well

--- a/pypy/doc/release-2.5.0.rst
+++ b/pypy/doc/release-2.5.0.rst
@@ -47,7 +47,7 @@ bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
 .. _`pypy and cpython 2.7.x`: https://speed.pypy.org
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 Highlights
 ==========
@@ -90,7 +90,7 @@ Highlights
 .. _`PyPy documentation`: https://doc.pypy.org
 .. _`RPython documentation`: https://rpython.readthedocs.org
 .. _`blog post`: https://morepypy.blogspot.com/2015/01/faster-more-memory-efficient-and-more.html
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-2.5.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-2.5.0.html
 
 We have further improvements on the way: rpython file handling,
 finishing numpy linalg compatibility, numpy object dtypes, a better profiler,

--- a/pypy/doc/release-2.5.1.rst
+++ b/pypy/doc/release-2.5.1.rst
@@ -37,8 +37,8 @@ Rpython's JIT even better.
 
 .. _`PyPy`: https://doc.pypy.org 
 .. _`Rpython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 
 What is PyPy?
 =============
@@ -56,7 +56,7 @@ bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
 .. _`pypy and cpython 2.7.x`: https://speed.pypy.org
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 Highlights 
 ==========
@@ -102,7 +102,7 @@ Highlights
 .. _`PEP 477`: https://www.python.org/dev/peps/pep-0477
 .. _`POODLE attack`: https://www.imperialviolet.org/2014/10/14/poodle.html
 .. _`ensurepip module`: https://docs.python.org/2/library/ensurepip.html
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-2.5.1.html
+.. _resolved: https://doc.pypy.org/whatsnew-2.5.1.html
 
 Please try it out and let us know what you think. We welcome
 success stories, `experiments`_,  or `benchmarks`_, we know you are using PyPy, please tell us about it!

--- a/pypy/doc/release-2.6.0.rst
+++ b/pypy/doc/release-2.6.0.rst
@@ -45,8 +45,8 @@ you too could be one of them.
 
 .. _`PyPy`: https://doc.pypy.org 
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 
 What is PyPy?
 =============
@@ -67,7 +67,7 @@ to `handle that`_. We also welcome developers with other operating systems or
 .. _`pypy and cpython 2.7.x`: https://speed.pypy.org
 .. _OpenBSD: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/pypy
 .. _freebsd: https://svnweb.freebsd.org/ports/head/lang/pypy/
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 .. _`dynamic languages`: https://pypyjs.org
 
 Highlights 
@@ -115,7 +115,7 @@ Highlights
     over 7 times faster than cpython
 
 .. _`vmprof`: https://vmprof.readthedocs.org
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-2.6.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-2.6.0.html
 
 Please try it out and let us know what you think. We welcome
 success stories, `experiments`_,  or `benchmarks`_, we know you are using PyPy, please tell us about it!

--- a/pypy/doc/release-2.6.1.rst
+++ b/pypy/doc/release-2.6.1.rst
@@ -23,8 +23,8 @@ RPython's JIT even better.
 
 .. _`PyPy`: https://doc.pypy.org 
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 
 What is PyPy?
 =============
@@ -116,7 +116,7 @@ Highlights
     one sequence argument
 
 .. _`vmprof`: https://vmprof.readthedocs.org
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-2.6.1.html
+.. _resolved: https://doc.pypy.org/whatsnew-2.6.1.html
 
 Please try it out and let us know what you think. We welcome
 success stories, `experiments`_,  or `benchmarks`_, we know you are using PyPy, please tell us about it!

--- a/pypy/doc/release-4.0.0.rst
+++ b/pypy/doc/release-4.0.0.rst
@@ -85,8 +85,8 @@ lifetimes, __stdcall on Win32, ffi.memmove(), and percolate ``const``,
 .. _`RPython`: https://rpython.readthedocs.org
 .. _`cffi`: https://cffi.readthedocs.org
 .. _`cffi-1.3`: https://cffi.readthedocs.org/en/latest/whatsnew.html#v1-3-0
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _`numpy`: https://bitbucket.org/pypy/numpy
 
 What is PyPy?
@@ -204,7 +204,7 @@ Other Highlights (since 2.6.1 release two months ago)
     and locals2fast only if truly necessary
 
 .. _`vmprof`: https://vmprof.readthedocs.org
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-15.11.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-15.11.0.html
 
 Please try it out and let us know what you think. We welcome feedback,
 we know you are using PyPy, please tell us about it!

--- a/pypy/doc/release-4.0.1.rst
+++ b/pypy/doc/release-4.0.1.rst
@@ -31,8 +31,8 @@ contribution to the python ecosystem. PyPy 4.0.1 ships with
 .. _`RPython`: https://rpython.readthedocs.org
 .. _`cffi`: https://cffi.readthedocs.org
 .. _`cffi-1.3.1`: https://cffi.readthedocs.org/en/latest/whatsnew.html#v1-3-1
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _`numpy`: https://bitbucket.org/pypy/numpy
 
 What is PyPy?
@@ -96,7 +96,7 @@ Other Highlights (since 4.0.0 released three weeks ago)
 
   * Silence some warnings while translating
 
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-4.0.1.html
+.. _resolved: https://doc.pypy.org/whatsnew-4.0.1.html
 
 Please update, and continue to help us make PyPy better.
 

--- a/pypy/doc/release-5.0.0.rst
+++ b/pypy/doc/release-5.0.0.rst
@@ -42,8 +42,8 @@ contribution to the python ecosystem. PyPy 5.0 ships with
 .. _`RPython`: https://rpython.readthedocs.org
 .. _`cffi`: https://cffi.readthedocs.org
 .. _`cffi-1.5.2`: https://cffi.readthedocs.org/en/latest/whatsnew.html#v1-5-2
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _`numpy`: https://bitbucket.org/pypy/numpy
 .. _vmprof: https://vmprof.readthedocs.org
 
@@ -217,7 +217,7 @@ Other Highlights (since 4.0.1 released in November 2015)
 
   * Fix tokenizer to enforce universal newlines, needed for Python 3 support
 
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-5.0.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-5.0.0.html
 .. _`hypothesis`: https://hypothesis.readthedocs.org
 .. _`blog post`: https://morepypy.blogspot.com/2016/02/c-api-support-update.html
 

--- a/pypy/doc/release-5.1.0.rst
+++ b/pypy/doc/release-5.1.0.rst
@@ -30,8 +30,8 @@ with making RPython's JIT even better.
 
 .. _`PyPy`: https://doc.pypy.org
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _`numpy`: https://bitbucket.org/pypy/numpy
 .. _cffi: https://cffi.readthedocs.org
 .. _`fully support for the IBM s390x`: https://morepypy.blogspot.com/2016/04/pypy-enterprise-edition.html
@@ -149,7 +149,7 @@ Other Highlights (since 5.0 released in March 2015)
 
   * Update rpython functions with ones needed for py3k
 
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-5.0.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-5.0.0.html
 .. _Numpy: https://bitbucket.org/pypy/numpy
 
 Please update, and continue to help us make PyPy better.

--- a/pypy/doc/release-pypy2.7-v5.3.0.rst
+++ b/pypy/doc/release-pypy2.7-v5.3.0.rst
@@ -30,8 +30,8 @@ with making RPython's JIT even better.
 
 .. _`PyPy`: https://doc.pypy.org
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 
 What is PyPy?
 =============
@@ -181,7 +181,7 @@ Other Highlights (since 5.1 released in April 2016)
 
   * Compile c snippets with -Werror, and fix warnings it exposed
 
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-5.3.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-5.3.0.html
 .. _Numpy: https://bitbucket.org/pypy/numpy
 .. _`the repo`: https://bitbucket.org/pypy/numpy
 

--- a/pypy/doc/release-pypy2.7-v5.3.1.rst
+++ b/pypy/doc/release-pypy2.7-v5.3.1.rst
@@ -7,7 +7,7 @@ due to issues_ reported by users.
 
 Thanks to those who reported the issues.
 
-.. _issues: https://doc.pypy.org/en/latest/whatsnew-pypy2-5.3.1.html
+.. _issues: https://doc.pypy.org/whatsnew-pypy2-5.3.1.html
 
 What is PyPy?
 =============

--- a/pypy/doc/release-pypy2.7-v5.4.0.rst
+++ b/pypy/doc/release-pypy2.7-v5.4.0.rst
@@ -32,8 +32,8 @@ with making RPython's JIT even better.
 .. _JIT: https://morepypy.blogspot.com.au/2016/08/pypy-tooling-upgrade-jitviewer-and.html
 .. _`PyPy`: https://doc.pypy.org
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 
 What is PyPy?
 =============
@@ -210,7 +210,7 @@ Other Highlights (since 5.3 released in June 2016)
     `interp_posix.py`, based on the clean-up of CPython 2.7.x 
 
 .. _`JIT logging`: https://morepypy.blogspot.com/2016/08/pypy-tooling-upgrade-jitviewer-and.html
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-5.4.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-5.4.0.html
 
 Please update, and continue to help us make PyPy better.
 

--- a/pypy/doc/release-pypy2.7-v5.6.0.rst
+++ b/pypy/doc/release-pypy2.7-v5.6.0.rst
@@ -45,8 +45,8 @@ with making RPython's JIT even better.
 .. _grant: https://morepypy.blogspot.com/2016/08/pypy-gets-funding-from-mozilla-for.html
 .. _`PyPy`: https://doc.pypy.org
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`modules`: https://doc.pypy.org/en/latest/project-ideas.html#make-more-python-modules-pypy-friendly
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`modules`: https://doc.pypy.org/project-ideas.html#make-more-python-modules-pypy-friendly
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _`enhanced`: https://morepypy.blogspot.co.at/2016/11/vectorization-extended-powerpc-and-s390x.html
 
 What is PyPy?
@@ -147,7 +147,7 @@ Other Highlights (since 5.4 released Aug 31, 2016)
   * Refactor and remove dead code from ``optimizeopt``, ``resume``
   
 
-.. _resolved: https://doc.pypy.org/en/latest/whatsnew-5.6.0.html
+.. _resolved: https://doc.pypy.org/whatsnew-5.6.0.html
 
 Please update, and continue to help us make PyPy better.
 

--- a/pypy/doc/release-pypy3-2.1.0-beta1.rst
+++ b/pypy/doc/release-pypy3-2.1.0-beta1.rst
@@ -47,9 +47,9 @@ to proceed. This document also covers other `installation schemes`_.
 .. _`known issues`: https://bugs.pypy.org/issue?%40search_text=&title=py3k&%40columns=title&keyword=&id=&%40columns=id&creation=&creator=&release=&activity=&%40columns=activity&%40sort=activity&actor=&priority=&%40group=priority&status=-1%2C1%2C2%2C3%2C4%2C5%2C6&%40columns=status&assignedto=&%40columns=assignedto&%40pagesize=50&%40startwith=0&%40queryname=&%40old-queryname=&%40action=search
 .. _`#1540`: https://bugs.pypy.org/issue1540
 .. _`#1541`: https://bugs.pypy.org/issue1541
-.. _`pypy documentation`: https://doc.pypy.org/en/latest/getting-started.html#installing-using-virtualenv
+.. _`pypy documentation`: https://doc.pypy.org/getting-started.html#installing-using-virtualenv
 .. _`virtualenv`: https://www.virtualenv.org/en/latest/
-.. _`installation schemes`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
+.. _`installation schemes`: https://doc.pypy.org/getting-started.html#installing-pypy
 
 
 Cheers,

--- a/pypy/doc/release-pypy3-2.3.1.rst
+++ b/pypy/doc/release-pypy3-2.3.1.rst
@@ -49,7 +49,7 @@ While we support 32 bit python on Windows, work on the native Windows 64
 bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 How to use PyPy?
 =================
@@ -60,9 +60,9 @@ to proceed. This document also covers other `installation schemes`_.
 
 .. _donated: https://morepypy.blogspot.com/2012/01/py3k-and-numpy-first-stage-thanks-to.html
 .. _`py3k proposal`: https://pypy.org/py3donate.html
-.. _`pypy documentation`: https://doc.pypy.org/en/latest/getting-started.html#installing-using-virtualenv
+.. _`pypy documentation`: https://doc.pypy.org/getting-started.html#installing-using-virtualenv
 .. _`virtualenv`: https://www.virtualenv.org/en/latest/
-.. _`installation schemes`: https://doc.pypy.org/en/latest/getting-started.html#installing-pypy
+.. _`installation schemes`: https://doc.pypy.org/getting-started.html#installing-pypy
 
 
 Cheers,

--- a/pypy/doc/release-pypy3-2.4.0.rst
+++ b/pypy/doc/release-pypy3-2.4.0.rst
@@ -46,7 +46,7 @@ bit python is still stalling, we would welcome a volunteer
 to `handle that`_.
 
 .. _`pypy 2.4 and cpython 2.7.x`: https://speed.pypy.org
-.. _`handle that`: https://doc.pypy.org/en/latest/windows.html#what-is-missing-for-a-full-64-bit-translation
+.. _`handle that`: https://doc.pypy.org/windows.html#what-is-missing-for-a-full-64-bit-translation
 
 PyPy3 Highlights
 ================
@@ -109,9 +109,9 @@ directly related to Summer of Code.
 
 * Many issues were resolved_ since the 2.3.1 release in June
 
-.. _`whats-new`: https://doc.pypy.org/en/latest/whatsnew-2.4.0.html
+.. _`whats-new`: https://doc.pypy.org/whatsnew-2.4.0.html
 .. _resolved: https://bitbucket.org/pypy/pypy/issues?status=resolved
-.. _sandbox: https://doc.pypy.org/en/latest/sandbox.html
+.. _sandbox: https://doc.pypy.org/sandbox.html
 
 We have further improvements on the way: rpython file handling,
 numpy linalg compatibility, as well

--- a/pypy/doc/release-v7.0.0.rst
+++ b/pypy/doc/release-v7.0.0.rst
@@ -24,7 +24,7 @@ performance, has been improved and it is now possible to manually manage the
 GC by using a combination of ``gc.disable`` and ``gc.collect_step``. See the
 `GC blog post`_.
 
-.. _`GC hooks`: https://doc.pypy.org/en/latest/gc_info.html#semi-manual-gc-management
+.. _`GC hooks`: https://doc.pypy.org/gc_info.html#semi-manual-gc-management
 
 We updated the `cffi`_ module included in PyPy to version 1.12, and the
 `cppyy`_ backend to 1.4. Please use these to wrap your C and C++ code,
@@ -149,4 +149,4 @@ We also refactored many parts of the JIT bridge optimizations, as well as cpyext
 internals, and together with new contributors fixed issues, added new
 documentation, and cleaned up the codebase.
 
-.. _contributing: https://doc.pypy.org/en/latest/contributing.html
+.. _contributing: https://doc.pypy.org/contributing.html

--- a/pypy/doc/release-v7.3.19.rst
+++ b/pypy/doc/release-v7.3.19.rst
@@ -50,7 +50,7 @@ building wheels for PyPy.
 
 .. _`PyPy`: https://doc.pypy.org/
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _CFFI: https://cffi.readthedocs.io
 .. _cppyy: https://cppyy.readthedocs.io
 .. _`multibuild system`: https://github.com/matthew-brett/multibuild

--- a/pypy/doc/release-v7.3.20.rst
+++ b/pypy/doc/release-v7.3.20.rst
@@ -44,7 +44,7 @@ on PyPy. In any case, `cibuildwheel`_ supports building wheels for PyPy.
 
 .. _`PyPy`: https://doc.pypy.org/
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _CFFI: https://cffi.readthedocs.io
 .. _cppyy: https://cppyy.readthedocs.io
 .. _`cibuildwheel`: https://github.com/joerick/cibuildwheel

--- a/pypy/doc/release-v7.3.21.rst
+++ b/pypy/doc/release-v7.3.21.rst
@@ -44,7 +44,7 @@ on PyPy. In any case, `cibuildwheel`_ supports building wheels for PyPy.
 
 .. _`PyPy`: https://doc.pypy.org/
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _CFFI: https://cffi.readthedocs.io
 .. _cppyy: https://cppyy.readthedocs.io
 .. _`cibuildwheel`: https://github.com/joerick/cibuildwheel

--- a/pypy/doc/release-v7.3.22.rst
+++ b/pypy/doc/release-v7.3.22.rst
@@ -69,7 +69,7 @@ on PyPy. In any case, `cibuildwheel`_ supports building wheels for PyPy.
 
 .. _`PyPy`: https://doc.pypy.org/
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
+.. _`help`: https://doc.pypy.org/project-ideas.html
 .. _CFFI: https://cffi.readthedocs.io
 .. _cppyy: https://cppyy.readthedocs.io
 .. _`cibuildwheel`: https://github.com/joerick/cibuildwheel

--- a/pypy/doc/whatsnew-pypy2-5.4.0.rst
+++ b/pypy/doc/whatsnew-pypy2-5.4.0.rst
@@ -8,7 +8,7 @@ What's new in PyPy2.7 5.4
 .. 418b05f95db5
 
 Improve CPython compatibility for ``is``. Now code like ``if x is ():``
-works the same way as it does on CPython.  See https://pypy.readthedocs.io/en/latest/cpython_differences.html#object-identity-of-primitive-values-is-and-id .
+works the same way as it does on CPython.  See https://doc.pypy.org/cpython_differences.html#object-identity-of-primitive-values-is-and-id .
 
 .. pull request #455
 

--- a/pypy/module/README.txt
+++ b/pypy/module/README.txt
@@ -1,9 +1,8 @@
-
-this directory contains PyPy's builtin module implementation
-that require access to interpreter level.  See here
+This directory contains PyPy's builtin module implementation
+that requires access to the interpreter level.  See here
 for more information: 
 
-    http://doc.pypy.org/en/latest/coding-guide.html#modules-in-pypy
+    https://doc.pypy.org/coding-guide.html#modules-in-pypy
 
 ATTENTION: don't put any '.py' files directly into pypy/module 
 because you can easily get import mixups on e.g. "import sys" 

--- a/pypy/tool/option.py
+++ b/pypy/tool/option.py
@@ -5,7 +5,7 @@ from rpython.config.config import to_optparse
 import optparse
 
 extra_useage = """For detailed descriptions of all the options see
-http://doc.pypy.org/en/latest/config/commandline.html"""
+https://doc.pypy.org/config/commandline.html"""
 
 def get_standard_options():
     config = get_pypy_config()

--- a/rpython/doc/conf.py
+++ b/rpython/doc/conf.py
@@ -56,7 +56,7 @@ affiliate_options = {
 
 # Other sites to add to the search of this site
 sphinx_affiliates = [
-    'https://doc.pypy.org/en/latest/affiliate_searchindex.js',
+    'https://doc.pypy.org/affiliate_searchindex.js',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/rpython/doc/riscv.rst
+++ b/rpython/doc/riscv.rst
@@ -190,7 +190,7 @@ Using the RPython Toolchain
 First, install `the dependencies`_ for PyPy development:
 
 .. _`the dependencies`:
-   https://doc.pypy.org/en/latest/build.html#install-build-time-dependencies
+   https://doc.pypy.org/build.html#install-build-time-dependencies
 
 ::
 

--- a/rpython/translator/goal/bpnn.py
+++ b/rpython/translator/goal/bpnn.py
@@ -10,7 +10,7 @@
 
     Insert '--help' before 'bpnn.py' for a list of translation options,
     or see the Overview of Command Line Options for translation at
-    https://doc.pypy.org/en/latest/config/index.html
+    https://doc.pypy.org/config/index.html
 """
 # Back-Propagation Neural Networks
 # 


### PR DESCRIPTION
I also slightly rewrote `pypy/module/README.txt` a long the way since it was a tad messy.