### PR TITLE
gh-5118: Fix a `SystemError` when `OSError` is raised in `gc.dump_rpy_heap`

### DIFF
--- a/pypy/module/gc/test/test_app_referents.py
+++ b/pypy/module/gc/test/test_app_referents.py
@@ -37,3 +37,16 @@ def test_interface_to_dump_rpy_heap_fd(space):
             gc.dump_rpy_heap(fd)""")
     except NotImplementedError:
         pass
+
+def test_dump_rpy_heap_bad_fd(space):
+    try:
+        space.appexec([], """():
+            import gc
+            try:
+                gc.dump_rpy_heap(-1)
+            except OSError:
+                return
+            raise AssertionError("expected OSError")
+        """)
+    except NotImplementedError:
+        pass

--- a/rpython/rtyper/lltypesystem/lloperation.py
+++ b/rpython/rtyper/lltypesystem/lloperation.py
@@ -513,7 +513,7 @@ LL_OPERATIONS = {
     'gc_get_rpy_memory_usage': LLOp(),
     'gc_get_rpy_type_index': LLOp(),
     'gc_is_rpy_instance'  : LLOp(),
-    'gc_dump_rpy_heap'    : LLOp(),
+    'gc_dump_rpy_heap'    : LLOp(canraise=(OSError,)),
     'gc_typeids_z'        : LLOp(),
     'gc_typeids_list'     : LLOp(),
     'gc_gettypeid'        : LLOp(),


### PR DESCRIPTION
Closes #5118.
