### PR TITLE
Improve the performance of `str.splitlines()`

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,5 @@
 * find a better way to run "find" without creating the index storage, if one
   if one is not already readily available (understand cost now, improve after merge)
-* improve performance of splitlines (CF)
 * think about cost of utf8 list strategy (CF)
 * revisit why runicode import str_decode_utf_8_impl needed instead of runicode
   import str_decode_utf_8

--- a/pypy/objspace/std/unicodeobject.py
+++ b/pypy/objspace/std/unicodeobject.py
@@ -935,7 +935,7 @@ class W_UnicodeObject(W_Root):
         while pos < length:
             sol = pos
             lgt = 0
-            while pos < length and not self._islinebreak(rutf8.codepoint_at_pos(value, pos)):
+            while pos < length and not rutf8.islinebreak(value, pos):
                 pos = rutf8.next_codepoint_pos(value, pos)
                 lgt += 1
             eol = pos


### PR DESCRIPTION
<details>

<summary>Benchmark script</summary>

```py
import pyperf

CASES = {
    "long_lf":     ("hello\nworld\n" * 10000, False),
    "no_newline":  ("x" * 100000, False),
    "crlf":        ("line\r\n" * 10000, False),
    "keepends":    ("hello\nworld\n" * 10000, True),
    "u_no_break":  ("☃" * 100000, False),
    "u_long_lf":   ("h\xe9llo\nw\xf6rld\n" * 10000, False),
    "u_nel":       ("h\xe9llo\x85w\xf6rld\x85" * 10000, False),
}

runner = pyperf.Runner()
for name, (text, keepends) in CASES.items():
    runner.bench_func(name, str.splitlines, text, keepends)
```

</details>

Comparing HEAD vs. with the patch applied:

```
long_lf: Mean +- std dev: [pypy] 1.24 ms +- 0.04 ms -> [pypyopt] 912 us +- 46 us: 1.36x faster
no_newline: Mean +- std dev: [pypy] 285 us +- 14 us -> [pypyopt] 41.8 us +- 1.5 us: 6.82x faster
crlf: Mean +- std dev: [pypy] 438 us +- 16 us -> [pypyopt] 287 us +- 17 us: 1.53x faster
keepends: Mean +- std dev: [pypy] 1.21 ms +- 0.04 ms -> [pypyopt] 905 us +- 42 us: 1.34x faster
u_no_break: Mean +- std dev: [pypy] 317 us +- 13 us -> [pypyopt] 307 us +- 10 us: 1.03x faster
u_long_lf: Mean +- std dev: [pypy] 1.23 ms +- 0.06 ms -> [pypyopt] 1.13 ms +- 0.06 ms: 1.09x faster
u_nel: Mean +- std dev: [pypy] 1.26 ms +- 0.07 ms -> [pypyopt] 1.12 ms +- 0.06 ms: 1.13x faster

Geometric mean: 1.57x faster
```

Also, "Geometric mean: 2.66x slower" than Python 3.11 with patch, compared to without it "Geometric mean: 4.19x slower," a nice ~37% improvement.

The functions are identical, it matches `STRINGLIB_ISLINEBREAK` in CPython, and there is also a test to ensure they are identical:

https://github.com/pypy/pypy/blob/4caabe039eab43de374b99861634e58096a2bb6d/rpython/rlib/test/test_rutf8.py#L86-L91

Going through `PyUnicode_Splitlines`, I don't see any more tricks we could apply here.