### PR TITLE
small optimizations

### DIFF
--- a/pypy/interpreter/function.py
+++ b/pypy/interpreter/function.py
@@ -45,6 +45,8 @@ class Function(W_Root):
     w_objclass = None
     w_text_signature = None
     _empty_defs = []
+    _w_name = None
+    _w_qualname = None
 
     def __init__(self, space, code, w_globals=None, defs_w=[], kw_defs_w=None,
                  closure=None, w_ann=None, forcename=None, qualname=None):
@@ -362,7 +364,9 @@ class Function(W_Root):
 
         self.space = space
         self.name = space.text_w(w_name)
+        self._w_name = w_name
         self.qualname = space.utf8_w(w_qualname)
+        self._w_qualname = w_qualname
         self.code = space.interp_w(Code, w_code)
         if not space.is_w(w_closure, space.w_None):
             from pypy.interpreter.nestedscope import Cell
@@ -457,21 +461,31 @@ class Function(W_Root):
         self.w_doc = space.w_None
 
     def fget_func_name(self, space):
-        return space.newtext(self.name)
+        w_name = self._w_name
+        if w_name is None:
+            w_name = space.newtext(self.name)
+            self._w_name = w_name
+        return w_name
 
     def fset_func_name(self, space, w_name):
         self._check_code_mutable("__name__")
         if space.isinstance_w(w_name, space.w_text):
             self.name = space.text_w(w_name)
+            self._w_name = w_name
         else:
             raise oefmt(space.w_TypeError,
                         "__name__ must be set to a string object")
 
     def fget_func_qualname(self, space):
-        return space.newtext(self.qualname)
+        w_qualname = self._w_qualname
+        if w_qualname is None:
+            w_qualname = space.newtext(self.qualname)
+            self._w_qualname = w_qualname
+        return w_qualname
 
     def set_qualname(self, qualname):
         self.qualname = qualname
+        self._w_qualname = None
 
     def fset_func_qualname(self, space, w_name):
         self._check_code_mutable("__qualname__")
@@ -482,7 +496,8 @@ class Function(W_Root):
                 raise oefmt(space.w_TypeError,
                             "__qualname__ must be set to a string object")
             raise
-        self.set_qualname(qualname)
+        self.qualname = qualname
+        self._w_qualname = w_name
 
     def fget_func_text_signature(self, space):
         if self.w_text_signature is None:

--- a/pypy/objspace/std/formatting.py
+++ b/pypy/objspace/std/formatting.py
@@ -373,7 +373,6 @@ def make_formatter_subclass(do_unicode):
         @specialize.arg(2)
         def std_wp(self, r, is_string=False):
             # r is utf8-encoded unicode
-            length = rutf8.codepoints_in_utf8(r)
             if do_unicode and is_string:
                 # convert string to unicode using the default encoding
                 r = self.space.utf8_w(self.space.newbytes(r))
@@ -382,6 +381,7 @@ def make_formatter_subclass(do_unicode):
                 # fast path
                 self.result.append(r)
                 return
+            length = rutf8.codepoints_in_utf8(r)
             if prec >= 0 and prec < length:
                 length = prec   # ignore the end of the string if too long
             padding = self.width - length

--- a/pypy/objspace/std/mapdict.py
+++ b/pypy/objspace/std/mapdict.py
@@ -420,6 +420,9 @@ class DevolvedDictTerminator(Terminator):
 class PlainAttribute(AbstractAttribute):
     _immutable_fields_ = ['name', 'attrkind', 'storageindex', '_num_attributes', 'back', 'ever_mutated?', 'order']
 
+    # cached W_UnicodeObject for the attribute name, used by dict iterators
+    _w_name = None
+
     def __init__(self, name, attrkind, back, order):
         AbstractAttribute.__init__(self, back.space, back.terminator)
         self.name = name
@@ -1331,7 +1334,7 @@ class IteratorMixin(object):
             curr_map = curr_map.search(DICT)
             if curr_map is None:
                 break
-            attrs.append(curr_map.name)
+            attrs.append(curr_map)
             curr_map = curr_map.back
         self.attrs = attrs
 
@@ -1347,8 +1350,11 @@ class MapDictIteratorKeys(BaseKeyIterator):
         assert isinstance(self.w_dict.get_strategy(), MapDictStrategy)
         attrs = self.attrs
         if len(attrs) > 0:
-            attr = attrs.pop()
-            w_attr = self.space.newtext(attr)
+            map_attr = attrs.pop()
+            w_attr = map_attr._w_name
+            if w_attr is None:
+                w_attr = self.space.newtext(map_attr.name)
+                map_attr._w_name = w_attr
             return w_attr
         return None
 
@@ -1364,8 +1370,8 @@ class MapDictIteratorValues(BaseValueIterator):
         assert isinstance(self.w_dict.get_strategy(), MapDictStrategy)
         attrs = self.attrs
         if len(attrs) > 0:
-            attr = attrs.pop()
-            return self.w_obj.getdictvalue(self.space, attr)
+            map_attr = attrs.pop()
+            return self.w_obj.getdictvalue(self.space, map_attr.name)
         return None
 
 
@@ -1380,9 +1386,12 @@ class MapDictIteratorItems(BaseItemIterator):
         assert isinstance(self.w_dict.get_strategy(), MapDictStrategy)
         attrs = self.attrs
         if len(attrs) > 0:
-            attr = attrs.pop()
-            w_attr = self.space.newtext(attr)
-            return w_attr, self.w_obj.getdictvalue(self.space, attr)
+            map_attr = attrs.pop()
+            w_attr = map_attr._w_name
+            if w_attr is None:
+                w_attr = self.space.newtext(map_attr.name)
+                map_attr._w_name = w_attr
+            return w_attr, self.w_obj.getdictvalue(self.space, map_attr.name)
         return None, None
 
 class MapDictKeyIteratorReversed(BaseKeyIterator):
@@ -1396,7 +1405,7 @@ class MapDictKeyIteratorReversed(BaseKeyIterator):
             curr_map = curr_map.search(DICT)
             if curr_map is None:
                 break
-            attrs.append(curr_map.name)
+            attrs.append(curr_map)
             curr_map = curr_map.back
         attrs.reverse()
         self.attrs = attrs
@@ -1405,8 +1414,11 @@ class MapDictKeyIteratorReversed(BaseKeyIterator):
         assert isinstance(self.w_dict.get_strategy(), MapDictStrategy)
         attrs = self.attrs
         if len(attrs) > 0:
-            attr = attrs.pop()
-            w_attr = self.space.newtext(attr)
+            map_attr = attrs.pop()
+            w_attr = map_attr._w_name
+            if w_attr is None:
+                w_attr = self.space.newtext(map_attr.name)
+                map_attr._w_name = w_attr
             return w_attr
         return None
 

--- a/pypy/objspace/std/typeobject.py
+++ b/pypy/objspace/std/typeobject.py
@@ -191,6 +191,10 @@ class W_TypeObject(W_Root):
     # used to cache the type's __new__ function
     w_new_function = None
 
+    # cached W_UnicodeObject for __name__ and __qualname__
+    _w_name = None
+    _w_qualname = None
+
     # set to True by cpyext _before_ it even calls __init__() below
     flag_cpytype = False
 
@@ -1041,7 +1045,11 @@ def _check(space, w_type, msg="descriptor is for 'type'"):
 
 def descr_get__name__(space, w_type):
     w_type = _check(space, w_type)
-    return space.newtext(w_type.getname(space))
+    w_name = w_type._w_name
+    if w_name is None:
+        w_name = space.newtext(w_type.getname(space))
+        w_type._w_name = w_name
+    return w_name
 
 def descr_set__name__(space, w_type, w_value):
     w_type = _check(space, w_type)
@@ -1056,10 +1064,16 @@ def descr_set__name__(space, w_type, w_value):
         raise oefmt(space.w_ValueError, "type name must not contain null characters")
     _check_surrogate(space, name)
     w_type.name = name
+    w_type._w_name = w_value
+    w_type._w_qualname = None
 
 def descr_get__qualname__(space, w_type):
     w_type = _check(space, w_type)
-    return space.newtext(w_type.getqualname(space))
+    w_qualname = w_type._w_qualname
+    if w_qualname is None:
+        w_qualname = space.newtext(w_type.getqualname(space))
+        w_type._w_qualname = w_qualname
+    return w_qualname
 
 def descr_set__qualname__(space, w_type, w_value):
     w_type = _check(space, w_type)
@@ -1070,6 +1084,7 @@ def descr_set__qualname__(space, w_type, w_value):
                     "can only assign string to %N.__name__, not '%T'",
                     w_type, w_value)
     w_type.qualname = space.utf8_w(w_value)
+    w_type._w_qualname = w_value
 
 def descr_get__mro__(space, w_type):
     w_type = _check(space, w_type)


### PR DESCRIPTION
I was using perf and callgrind to examine a toy benchmark around docutils and polymorphic classes in the bare interpreter without the JIT. A few things jumped out:
- ~every frame checks stack overflow. The call is not inlined. I refactored the way the function is wrapped so it could be inlined.~
- calls to `func.__name__`, `func.__qual_name__` and `type.__name__` regenerate a `W_Unicode` object which should be inexpensive but instead calls `codepoints_in_utf8` to figure out the length each time. Caching these avoids the calls. This is heavily used in docutils. It is a bit of a micro-optimization to make the sphinx benchmark faster, but I think those attributes are frequently used elsewhere too.
- a simple refactor to avoid unneeded length calculation in a fast path