### PR TITLE
inline fastpath for stackoverflow check

### DIFF
--- a/rpython/rlib/rstack.py
+++ b/rpython/rlib/rstack.py
@@ -28,6 +28,16 @@ _stack_set_length_fraction = llexternal('LL_stack_set_length_fraction',
 _stack_too_big_slowpath = llexternal('LL_stack_too_big_slowpath',
                                      [lltype.Signed], lltype.Char,
                                      lambda cur: '\x00')
+
+# RPY_STACK_CHECK is a static inline function defined in src/stack.h that
+# contains the fast-path check inline.  insert_ll_stackcheck() in transform.py
+# inserts calls to this function pointer rather than to the pypy_g_stack_check
+# RPython graph, so the C backend emits RPY_STACK_CHECK() at each site and
+# GCC can inline it in every compilation unit without LTO.
+# The _callable is a no-op for the LL interpreter (untranslated tests).
+_stack_check_ll = llexternal('RPY_STACK_CHECK', [], lltype.Void,
+                             _callable=lambda: None)
+
 # the following is used by the JIT
 _stack_get_end_adr   = llexternal('LL_stack_get_end_adr',   [], lltype.Signed)
 _stack_get_length_adr= llexternal('LL_stack_get_length_adr',[], lltype.Signed)

--- a/rpython/translator/c/src/stack.h
+++ b/rpython/translator/c/src/stack.h
@@ -36,6 +36,19 @@ void LL_stack_set_length_fraction(double);
 /* some macros referenced from rpython.rlib.rstack */
 #define LL_stack_get_end() ((Signed)rpy_stacktoobig.stack_end)
 #define LL_stack_get_length() rpy_stacktoobig.stack_length
+
+/* Inline fast-path for the stack overflow check.  The generated C calls
+   pypy_g_stack_check() which lives in a separate compilation unit, so GCC
+   cannot inline it without LTO.  By putting the fast path here as a static
+   inline, every translation unit gets the check inlined directly, avoiding
+   the function-call and SSP-canary overhead at each of the ~2600 call sites.
+   The slow path (LL_stack_too_big_slowpath) stays out-of-line. */
+static inline void RPY_STACK_CHECK(void) {
+    Signed current = (Signed)&current;
+    if ((size_t)(rpy_stacktoobig.stack_end - (char *)current) >
+            (size_t)rpy_stacktoobig.stack_length)
+        LL_stack_too_big_slowpath(current);
+}
 #define LL_stack_get_end_adr()    ((Signed)&rpy_stacktoobig.stack_end)   /* JIT */
 #define LL_stack_get_length_adr() ((Signed)&rpy_stacktoobig.stack_length)/* JIT */
 

--- a/rpython/translator/driver.py
+++ b/rpython/translator/driver.py
@@ -375,21 +375,21 @@ class TranslationDriver(SimpleTaskEngine):
         from rpython.jit.tl import jittest
         jittest.jittest(self)
 
+    STACKCHECKINSERTION = 'stackcheckinsertion_lltype'
+    @taskdef([RTYPE, 'annotate'], "inserting stack checks")
+    def task_stackcheckinsertion_lltype(self):
+        from rpython.translator.transform import insert_ll_stackcheck
+        count = insert_ll_stackcheck(self.translator)
+        self.log.info("inserted %d stack checks." % (count,))
+
+
     BACKENDOPT = 'backendopt_lltype'
-    @taskdef([RTYPE, '??pyjitpl_lltype', '??jittest_lltype'], "lltype back-end optimisations")
+    @taskdef(['?'+STACKCHECKINSERTION, RTYPE, '??pyjitpl_lltype', '??jittest_lltype'], "lltype back-end optimisations")
     def task_backendopt_lltype(self):
         """ Run all backend optimizations - lltype version
         """
         from rpython.translator.backendopt.all import backend_optimizations
         backend_optimizations(self.translator, replace_we_are_jitted=True)
-
-
-    STACKCHECKINSERTION = 'stackcheckinsertion_lltype'
-    @taskdef(['?'+BACKENDOPT, RTYPE, 'annotate'], "inserting stack checks")
-    def task_stackcheckinsertion_lltype(self):
-        from rpython.translator.transform import insert_ll_stackcheck
-        count = insert_ll_stackcheck(self.translator)
-        self.log.info("inserted %d stack checks." % (count,))
 
 
     def possibly_check_for_boehm(self):

--- a/rpython/translator/test/test_stackcheck.py
+++ b/rpython/translator/test/test_stackcheck.py
@@ -24,7 +24,10 @@ def paths_naive(g):
     return accum
 
 def direct_target(spaceop):
-    return spaceop.args[0].value._obj.graph.name
+    obj = spaceop.args[0].value._obj
+    if hasattr(obj, 'graph'):
+        return obj.graph.name
+    return obj._name
 
 def direct_calls(p):
     names = []
@@ -34,15 +37,17 @@ def direct_calls(p):
     return names
 
             
+STACK_CHECK_NAME = 'stack_check___'
+
 def check(g, funcname, ignore=None):
     paths = paths_naive(g)
     relevant = []
     for p in paths:
         funcs_called = direct_calls(p)
         if funcname in funcs_called and ignore not in funcs_called:
-            assert 'stack_check___' in funcs_called
+            assert STACK_CHECK_NAME in funcs_called
             assert (funcs_called.index(funcname) >
-                    funcs_called.index('stack_check___'))
+                    funcs_called.index(STACK_CHECK_NAME))
             relevant.append(p)
     return relevant
     
@@ -112,9 +117,9 @@ def test_gctransformed():
                 target = direct_target(spaceop)
                 if target == 'f':
                     in_between = False
-                elif target == 'stack_check___':
+                elif target == STACK_CHECK_NAME:
                     in_between = True
             if in_between and spaceop.opname == 'gc_reload_possibly_moved':
                 reload += 1
-                
+
         assert reload == 0


### PR DESCRIPTION
Broken out of #5457.

I was using perf and callgrind to examine a toy benchmark around docutils and polymorphic classes in the bare interpreter without the JIT. I noticed that the call to check stack size is not inlined. I refactored the way the function is wrapped so it could be inlined.