### PR TITLE
Move implementation of `str.splitlines` to a helper for the JIT

### DIFF
--- a/pypy/module/pypyjit/test_pypy_c/test_string.py
+++ b/pypy/module/pypyjit/test_pypy_c/test_string.py
@@ -474,6 +474,19 @@ class TestString(BaseTestPyPyC):
         assert "call_r" not in opnames
         assert opnames.count("call_i") == 2 # _strip_none_ascii_unboxed_left/right
 
+    def test_unicode_splitlines_doesnt_allocate_uniobject(self):
+        log = self.run("""
+        def main(n):
+            res = 0
+            for i in range(n):
+                data = str(i) + "\\n"
+                res += len(data.splitlines()) # ID: splitlines
+            return res
+        """, [10000])
+        loop, = log.loops_by_filename(self.filepath)
+        opnames = log.opnames(loop.ops_by_id('splitlines'))
+        assert "new_with_vtable" not in opnames
+
     def test_textiowrapper_write_is_inlined(self):
         log = self.run("""
         def main(n):

--- a/pypy/objspace/std/unicodeobject.py
+++ b/pypy/objspace/std/unicodeobject.py
@@ -929,31 +929,7 @@ class W_UnicodeObject(W_Root):
     @unwrap_spec(keepends=bool)
     def descr_splitlines(self, space, keepends=False):
         value = self._utf8
-        length = len(value)
-        strs_w = []
-        pos = 0
-        while pos < length:
-            sol = pos
-            lgt = 0
-            while pos < length and not rutf8.islinebreak(value, pos):
-                pos = rutf8.next_codepoint_pos(value, pos)
-                lgt += 1
-            eol = pos
-            if pos < length:
-                # read CRLF as one line break
-                if (value[pos] == '\r' and pos + 1 < length
-                                       and value[pos + 1] == '\n'):
-                    pos += 2
-                    line_end_chars = 2
-                else:
-                    pos = rutf8.next_codepoint_pos(value, pos)
-                    line_end_chars = 1
-                if keepends:
-                    eol = pos
-                    lgt += line_end_chars
-            assert eol >= 0
-            assert sol >= 0
-            strs_w.append(W_UnicodeObject(value[sol:eol], lgt))
+        strs_w = unicode_splitlines(value, keepends)
         return space.newlist(strs_w)
 
     def descr_upper(self, space):
@@ -1630,6 +1606,34 @@ def unicode_rsplit_none(value, maxsplit=-1):
 
     res.reverse()
     return res
+
+def unicode_splitlines(value, keepends):
+    length = len(value)
+    strs_w = []
+    pos = 0
+    while pos < length:
+        sol = pos
+        lgt = 0
+        while pos < length and not rutf8.islinebreak(value, pos):
+            pos = rutf8.next_codepoint_pos(value, pos)
+            lgt += 1
+        eol = pos
+        if pos < length:
+            # read CRLF as one line break
+            if (value[pos] == '\r' and pos + 1 < length
+                                   and value[pos + 1] == '\n'):
+                pos += 2
+                line_end_chars = 2
+            else:
+                pos = rutf8.next_codepoint_pos(value, pos)
+                line_end_chars = 1
+            if keepends:
+                eol = pos
+                lgt += line_end_chars
+        assert eol >= 0
+        assert sol >= 0
+        strs_w.append(W_UnicodeObject(value[sol:eol], lgt))
+    return strs_w
 
 def _isidentifier(u):
     if not u:


### PR DESCRIPTION
Carl's idea, it allows the JIT to unbox the wrapped string if it saw the allocation earlier in the trace. This is already done for `split(()`.