### PR TITLE
Int ovf to long without fromint

### DIFF
--- a/pypy/objspace/std/intobject.py
+++ b/pypy/objspace/std/intobject.py
@@ -312,9 +312,9 @@ def _pow_ovf2long(space, iv, w_iv, iw, w_iw, w_modulus):
     from pypy.objspace.std.longobject import W_LongObject, W_AbstractLongObject
     if w_iv is None or not isinstance(w_iv, W_AbstractLongObject):
         w_iv = W_LongObject.fromint(space, iv)
-    if w_iw is None or not isinstance(w_iw, W_AbstractLongObject):
-        w_iw = W_LongObject.fromint(space, iw)
-
+    # *don't* convert w_iw. W_LongObject.descr_pow can deal with w_iw being an
+    # int just fine
+    assert w_iw is not None
     return w_iv.descr_pow(space, w_iw, w_modulus)
 
 

--- a/pypy/objspace/std/intobject.py
+++ b/pypy/objspace/std/intobject.py
@@ -638,13 +638,7 @@ class W_IntObject(W_AbstractIntObject):
         if _recover_with_smalllong(space):
             return _lshift_ovf2small(space, x, y)
 
-        from pypy.objspace.std.longobject import W_LongObject, W_AbstractLongObject
-        if w_x is None or not isinstance(w_x, W_AbstractLongObject):
-            w_x = W_LongObject.fromint(space, x)
-
-        # crucially, *don't* convert w_y to W_LongObject, it will just be
-        # converted back (huge lshifts always overflow)
-        return w_x._int_lshift(space, y)
+        return space.newlong_from_rbigint(rbigint.lshift_int_int_bigint_result(x, y))
 
     descr_lshift, descr_rlshift = _make_descr_binop(
         _lshift, ovf_func=_ovf2long_lshift)

--- a/pypy/objspace/std/intobject.py
+++ b/pypy/objspace/std/intobject.py
@@ -333,6 +333,10 @@ def _make_ovf2long(opname, ovf2small=None):
             a = r_longlong(x)
             b = r_longlong(y)
             return W_SmallLongObject(op(a, b))
+        if opname == 'add':
+            return space.newlong_from_rbigint(rbigint.add_int_int_bigint_result(x, y))
+        if opname == 'sub':
+            return space.newlong_from_rbigint(rbigint.sub_int_int_bigint_result(x, y))
         if opname == 'mul':
             return space.newlong_from_rbigint(rbigint.mul_int_int_bigint_result(x, y))
         from pypy.objspace.std.longobject import W_LongObject, W_AbstractLongObject

--- a/pypy/objspace/std/test/test_intobject.py
+++ b/pypy/objspace/std/test/test_intobject.py
@@ -220,6 +220,21 @@ class TestW_IntObject:
         assert space.isinstance_w(v, space.w_long)
         assert space.bigint_w(v).eq(rbigint.fromlong(pow(10, 20)))
 
+    def test_pow_ovf_without_fromint(self, monkeypatch):
+        space = self.space
+        orig = rbigint.fromint
+        def fromint(x):
+            assert x == sys.maxint // 4 # it's not called for 16
+            return orig(x)
+        monkeypatch.setattr(rbigint, 'fromint', staticmethod(fromint))
+        x = sys.maxint // 4
+        y = 16
+        f1 = iobj.W_IntObject(x)
+        f2 = iobj.W_IntObject(y)
+        v = f1.descr_pow(space, f2)
+        assert space.bigint_w(v).eq(rbigint.fromlong(x ** y))
+
+
     try:
         from hypothesis import given, strategies, example
     except ImportError:

--- a/pypy/objspace/std/test/test_intobject.py
+++ b/pypy/objspace/std/test/test_intobject.py
@@ -82,12 +82,7 @@ class TestW_IntObject:
 
     def test_add_ovf_int_op_shortcut(self, monkeypatch):
         from pypy.objspace.std.longobject import W_LongObject, rbigint
-        @staticmethod
-        def fromint(space, x):
-            assert x == sys.maxint # only the maxint is converted, not the 1!
-            return W_LongObject(rbigint.fromint(x))
-
-        monkeypatch.setattr(W_LongObject, 'fromint', fromint)
+        monkeypatch.setattr(W_LongObject, 'fromint', None)
 
         space = self.space
         x = sys.maxint
@@ -113,6 +108,19 @@ class TestW_IntObject:
         v = f1.descr_sub(space, f2)
         assert space.isinstance_w(v, space.w_long)
         assert space.bigint_w(v).eq(rbigint.fromlong(sys.maxint - -1))
+
+    def test_sub_ovf_int_op_shortcut(self, monkeypatch):
+        from pypy.objspace.std.longobject import W_LongObject, rbigint
+        monkeypatch.setattr(W_LongObject, 'fromint', None)
+
+        space = self.space
+        x = sys.maxint
+        y = -1
+        f1 = iobj.W_IntObject(x)
+        f2 = iobj.W_IntObject(y)
+        v = f1.descr_sub(space, f2)
+        assert space.isinstance_w(v, space.w_long)
+        assert space.bigint_w(v).eq(rbigint.fromlong(x - y))
 
     def test_mul(self):
         space = self.space
@@ -337,7 +345,6 @@ class TestW_IntObject:
         f2 = iobj.W_IntObject(y)
         v = f1.descr_lshift(space, f2)
         assert space.bigint_w(v).eq(rbigint.fromlong(x << y))
-
 
     def test_rshift(self):
         x = 12345678

--- a/pypy/objspace/std/test/test_intobject.py
+++ b/pypy/objspace/std/test/test_intobject.py
@@ -328,6 +328,17 @@ class TestW_IntObject:
         assert space.isinstance_w(v, space.w_long)
         assert space.bigint_w(v).eq(rbigint.fromlong(x << y))
 
+    def test_lshift_without_fromint(self, monkeypatch):
+        space = self.space
+        monkeypatch.setattr(rbigint, 'fromint', None)
+        x = sys.maxint // 4
+        y = 16
+        f1 = iobj.W_IntObject(x)
+        f2 = iobj.W_IntObject(y)
+        v = f1.descr_lshift(space, f2)
+        assert space.bigint_w(v).eq(rbigint.fromlong(x << y))
+
+
     def test_rshift(self):
         x = 12345678
         y = 2

--- a/rpython/rlib/rbigint.py
+++ b/rpython/rlib/rbigint.py
@@ -695,13 +695,13 @@ class rbigint(object):
     @jit.elidable
     def int_add(self, iother):
         selfsign = self.get_sign()
+        if selfsign == 0:
+            return rbigint.fromint(iother)
+        if iother == 0:
+            return self
         if not int_in_valid_range(iother):
             # Fallback to long.
             return self.add(rbigint.fromint(iother))
-        elif selfsign == 0:
-            return rbigint.fromint(iother)
-        elif iother == 0:
-            return self
 
         othersign = intsign(iother)
         if selfsign == othersign:
@@ -711,6 +711,45 @@ class rbigint(object):
             result._set_sign(-result.get_sign())
         result._set_sign(result.get_sign() * othersign)
         return result
+
+    @staticmethod
+    @jit.elidable
+    def add_int_int_bigint_result(iself, iother):
+        if not SUPPORT_INT128 or SHIFT != 63 or not int_in_valid_range(iself) or not int_in_valid_range(iother):
+            return rbigint.fromint(iself).int_add(iother)
+        return rbigint._add_int_int_helper(iself, iother)
+
+    @staticmethod
+    def _add_int_int_helper(iself, iother):
+        if iself == 0:
+            return rbigint.fromint(iother)
+        if iother == 0:
+            return rbigint.fromint(iself)
+
+        sign1 = intsign(iself)
+        sign2 = intsign(iother)
+        v1 = abs(iself)
+        v2 = abs(iother)
+
+        if sign1 == sign2:
+            sign = sign1
+            ures = UDIGIT_TYPE(v1) + UDIGIT_TYPE(v2)
+        else:
+            if v1 >= v2:
+                sign = sign1
+                ures = UDIGIT_TYPE(v1) - UDIGIT_TYPE(v2)
+            else:
+                sign = sign2
+                ures = UDIGIT_TYPE(v2) - UDIGIT_TYPE(v1)
+
+        if ures == 0:
+            return NULLRBIGINT
+
+        carry = ures >> SHIFT
+        if carry:
+            return rbigint([_store_digit(ures & MASK), _store_digit(carry)], sign, 2)
+        else:
+            return rbigint([_store_digit(ures & MASK)], sign, 1)
 
     @jit.elidable
     def sub(self, other):
@@ -743,6 +782,15 @@ class rbigint(object):
             result = _x_int_add(self, iother)
         result._set_sign(result.get_sign() * selfsign)
         return result
+
+    @staticmethod
+    @jit.elidable
+    def sub_int_int_bigint_result(iself, iother):
+        if not SUPPORT_INT128 or SHIFT != 63 or not int_in_valid_range(iself) or not int_in_valid_range(iother):
+            return rbigint.fromint(iself).int_sub(iother)
+        # -iother is safe here because int_in_valid_range(iother)
+        # checks that it's not minint
+        return rbigint._add_int_int_helper(iself, -iother)
 
     @jit.elidable
     def mul(self, other):

--- a/rpython/rlib/rbigint.py
+++ b/rpython/rlib/rbigint.py
@@ -1328,6 +1328,48 @@ class rbigint(object):
         return z
     lqshift._always_inline_ = True # It's so fast that it's always beneficial.
 
+    @staticmethod
+    @jit.elidable
+    def lshift_int_int_bigint_result(iself, int_other):
+        if not SUPPORT_INT128 or SHIFT != 63 or not int_in_valid_range(iself):
+            return rbigint.fromint(iself).lshift(int_other)
+        if int_other < 0:
+            raise ValueError("negative shift count")
+
+        if iself == 0:
+            return NULLRBIGINT
+        if int_other == 0:
+            return rbigint.fromint(iself)
+
+        selfsign = intsign(iself)
+
+        wordshift = int_other // SHIFT
+        remshift = int_other - wordshift * SHIFT
+        hishift = SHIFT - remshift
+
+        if iself < 0:
+            ival = -r_uint(iself)
+            carry = ival >> SHIFT
+            assert not carry
+        else:
+            assert iself > 0
+            ival = r_uint(iself)
+
+        if remshift:
+            lowerdigit = ival << remshift
+            upperdigit = ival >> hishift
+            if upperdigit:
+                resdigits = [NULLDIGIT] * (wordshift + 2)
+                resdigits[wordshift] = _store_digit(lowerdigit & MASK)
+                resdigits[wordshift + 1] = _store_digit(upperdigit & MASK)
+                return rbigint(resdigits, selfsign, wordshift + 2)
+        else:
+            lowerdigit = ival
+        # don't need to normalize
+        resdigits = [NULLDIGIT] * (wordshift + 1)
+        resdigits[wordshift] = _store_digit(lowerdigit & MASK)
+        return rbigint(resdigits, selfsign, wordshift + 1)
+
     @jit.elidable
     def rshift(self, int_other, dont_invert=False):
         if int_other < 0:

--- a/rpython/rlib/test/test_rbigint.py
+++ b/rpython/rlib/test/test_rbigint.py
@@ -1985,6 +1985,14 @@ class TestHypothesis(object):
         res = rbigint.mul_int_int_bigint_result(a, b)
         assert res.tolong() == a * b
 
+    @example(-sys.maxint-1, 5)
+    @example(-1, 10)
+    @example(1, 1071)
+    @given(ints, strategies.integers(0, 2000))
+    def test_lshift_int_int_rbigint_result(self, a, b):
+        res = rbigint.lshift_int_int_bigint_result(a, b)
+        assert res.tolong() == a << b
+
     @given(strategies.data())
     def test_format_lowest_level_divmod_int_results(self, data):
         b = data.draw(strategies.integers(1, MASK))

--- a/rpython/rlib/test/test_rbigint.py
+++ b/rpython/rlib/test/test_rbigint.py
@@ -631,6 +631,18 @@ class Test_rbigint(object):
                 result = f1.int_mul(y)
                 assert result.tolong() == x * y
 
+    def test_add_int_int_rbigint_result(self):
+        for x in signed_int_vals:
+            for y in signed_int_vals:
+                result = rbigint.add_int_int_bigint_result(x, y)
+                assert result.tolong() == x + y
+
+    def test_sub_int_int_rbigint_result(self):
+        for x in signed_int_vals:
+            for y in signed_int_vals:
+                result = rbigint.sub_int_int_bigint_result(x, y)
+                assert result.tolong() == x - y
+
     def test_mul_int_int_rbigint_result(self):
         for x in signed_int_vals:
             for y in signed_int_vals:
@@ -1979,6 +1991,16 @@ class TestHypothesis(object):
         x = a * a
         lx = rbigint.fromlong(x)
         assert lx.isqrt().tolong() == a
+
+    @given(ints, ints)
+    def test_add_int_int_rbigint_result(self, a, b):
+        res = rbigint.add_int_int_bigint_result(a, b)
+        assert res.tolong() == a + b
+
+    @given(ints, ints)
+    def test_sub_int_int_rbigint_result(self, a, b):
+        res = rbigint.sub_int_int_bigint_result(a, b)
+        assert res.tolong() == a - b
 
     @given(ints, ints)
     def test_mul_int_int_rbigint_result(self, a, b):


### PR DESCRIPTION
related to #5466: don't call `rbigint.fromint` for add, sub, lshift that overflow any more. instead, just compute the correct rbigint directly. we already use this approach for mul.