### PR TITLE
use computed goto instead of a big switch

### DIFF
--- a/rpython/translator/c/funcgen.py
+++ b/rpython/translator/c/funcgen.py
@@ -30,6 +30,17 @@ COMPUTED_GOTO_THRESHOLD = 5
 # segment and cache without any dispatch benefit.
 COMPUTED_GOTO_MAX_SPARSE = 4
 
+def _split_exits(block):
+    """Return (non_default_links, default_link_or_None) for a switch block."""
+    non_default = []
+    defaultlink = None
+    for link in block.exits:
+        if link.exitcase == 'default':
+            defaultlink = link
+        else:
+            non_default.append(link)
+    return non_default, defaultlink
+
 def _use_computed_goto(non_default):
     if len(non_default) < COMPUTED_GOTO_THRESHOLD:
         return False
@@ -71,15 +82,19 @@ class FunctionCodeGenerator(object):
         self.illtypes = None
         self._uses_computed_goto = self._check_for_computed_goto()
 
-    def _check_for_computed_goto(self):
+    def _iter_computed_goto_blocks(self):
+        """Yield (block, non_default_links) for every block that uses computed goto."""
         for block in self.graph.iterblocks():
             if (block.exitswitch is not None and not block.canraise and
                     self.lltypemap_early(block.exitswitch) in (
                         Signed, Unsigned, SignedLongLong, UnsignedLongLong)):
-                non_default = [l for l in block.exits
-                               if l.exitcase != 'default']
+                non_default, _defaultlink = _split_exits(block)
                 if _use_computed_goto(non_default):
-                    return True
+                    yield block, non_default
+
+    def _check_for_computed_goto(self):
+        for _block, _non_default in self._iter_computed_goto_blocks():
+            return True
         return False
 
     def lltypemap_early(self, v):
@@ -248,15 +263,9 @@ class FunctionCodeGenerator(object):
 
         # Blocks that are targets of large switches must have labels so that
         # computed goto dispatch tables can reference them via &&blockN.
-        for block in graph.iterblocks():
-            if (block.exitswitch is not None and not block.canraise and
-                    self.lltypemap(block.exitswitch) in (
-                        Signed, Unsigned, SignedLongLong, UnsignedLongLong)):
-                non_default = [l for l in block.exits
-                               if l.exitcase != 'default']
-                if _use_computed_goto(non_default):
-                    for link in block.exits:
-                        self.inlinable_blocks.discard(link.target)
+        for block, _non_default in self._iter_computed_goto_blocks():
+            for link in block.exits:
+                self.inlinable_blocks.discard(link.target)
 
         yield ''
         for line in self.gen_goto(graph.startblock):
@@ -320,13 +329,8 @@ class FunctionCodeGenerator(object):
                         yield op
                 elif TYPE in (Signed, Unsigned, SignedLongLong,
                               UnsignedLongLong, Char, UniChar):
-                    defaultlink = None
                     expr = self.expr(block.exitswitch)
-                    non_default = [l for l in block.exits
-                                   if l.exitcase != 'default']
-                    for link in block.exits:
-                        if link.exitcase == 'default':
-                            defaultlink = link
+                    non_default, defaultlink = _split_exits(block)
                     if (TYPE not in (Char, UniChar) and
                             _use_computed_goto(non_default)):
                         for line in self.gen_computed_goto(

--- a/rpython/translator/c/funcgen.py
+++ b/rpython/translator/c/funcgen.py
@@ -384,6 +384,7 @@ class FunctionCodeGenerator(object):
             default_label = None
 
         yield '#ifdef __GNUC__'
+        yield ';'  # null stmt: block label may immediately precede this declaration
 
         # Emit the static dispatch table.
         table_name = '_cgoto_%d' % myblocknum

--- a/rpython/translator/c/funcgen.py
+++ b/rpython/translator/c/funcgen.py
@@ -2,6 +2,7 @@ import sys
 from rpython.translator.c.support import cdecl
 from rpython.translator.c.support import llvalue_from_constant, gen_assignments
 from rpython.translator.c.support import c_string_constant, barebonearray
+from rpython.translator.c.support import log
 from rpython.flowspace.model import Variable, Constant, mkentrymap
 from rpython.rtyper.lltypesystem.lltype import (Ptr, Void, Bool, Signed, Unsigned,
     SignedLongLong, Float, UnsignedLongLong, Char, UniChar, ContainerType,
@@ -17,6 +18,24 @@ from rpython.rlib.objectmodel import CDefinedIntSymbolic
 LOCALVAR = 'l_%s'
 
 KEEP_INLINED_GRAPHS = False
+
+# Switches with at least this many cases use computed goto dispatch instead
+# of a C switch statement.  Computed goto (a GCC extension) turns the switch
+# into a direct jump through a static label-address table, collapsing all
+# case blocks into a single C function and enabling GCC to do global register
+# allocation and inlining across opcode handlers.
+COMPUTED_GOTO_THRESHOLD = 5
+# Maximum ratio of table slots to actual cases.  Switches where the opcode
+# space is too sparse (e.g. Unicode codepoints, JIT resop codes) waste data
+# segment and cache without any dispatch benefit.
+COMPUTED_GOTO_MAX_SPARSE = 4
+
+def _use_computed_goto(non_default):
+    if len(non_default) < COMPUTED_GOTO_THRESHOLD:
+        return False
+    case_vals = [int(link.exitcase) for link in non_default]
+    table_size = max(case_vals) - min(case_vals) + 1
+    return table_size <= COMPUTED_GOTO_MAX_SPARSE * len(non_default)
 
 def make_funcgen(graph, db, exception_policy, functionname):
     graph._seen_by_the_backend = True
@@ -50,6 +69,22 @@ class FunctionCodeGenerator(object):
             db.gettype(T)  # force the type to be considered by the database
 
         self.illtypes = None
+        self._uses_computed_goto = self._check_for_computed_goto()
+
+    def _check_for_computed_goto(self):
+        for block in self.graph.iterblocks():
+            if (block.exitswitch is not None and not block.canraise and
+                    self.lltypemap_early(block.exitswitch) in (
+                        Signed, Unsigned, SignedLongLong, UnsignedLongLong)):
+                non_default = [l for l in block.exits
+                               if l.exitcase != 'default']
+                if _use_computed_goto(non_default):
+                    return True
+        return False
+
+    def lltypemap_early(self, v):
+        T = v.concretetype
+        return T
 
     def collect_var_and_types(self):
         #
@@ -156,14 +191,25 @@ class FunctionCodeGenerator(object):
         for a in self.graph.getargs():
             seen.add(a.name)
 
+        # When computed goto is used, GCC cannot track control flow through
+        # the indirect jump and emits false -Wmaybe-uninitialized warnings.
+        # Zero-initializing all locals suppresses these; GCC optimizes away
+        # the initializer wherever it can prove assignment happens first.
+        init_suffix = ' = 0' if self._uses_computed_goto else ''
+
         result_by_name = []
         for v in self.allvariables():
             name = v.name
             if name not in seen:
                 seen.add(name)
-                result = cdecl(self.lltypename(v), LOCALVAR % name) + ';'
-                if self.lltypemap(v) is Void:
+                T = self.lltypemap(v)
+                if T is Void:
                     continue  #result = '/*%s*/' % result
+                if self._uses_computed_goto and isinstance(T, Ptr):
+                    suffix = ' = NULL'
+                else:
+                    suffix = init_suffix
+                result = cdecl(self.lltypename(v), LOCALVAR % name) + suffix + ';'
                 result_by_name.append((v._name, result))
         result_by_name.sort()
         return [result for name, result in result_by_name]
@@ -199,6 +245,18 @@ class FunctionCodeGenerator(object):
         entrymap = mkentrymap(graph)
         self.inlinable_blocks = {
             block for block in entrymap if len(entrymap[block]) == 1}
+
+        # Blocks that are targets of large switches must have labels so that
+        # computed goto dispatch tables can reference them via &&blockN.
+        for block in graph.iterblocks():
+            if (block.exitswitch is not None and not block.canraise and
+                    self.lltypemap(block.exitswitch) in (
+                        Signed, Unsigned, SignedLongLong, UnsignedLongLong)):
+                non_default = [l for l in block.exits
+                               if l.exitcase != 'default']
+                if _use_computed_goto(non_default):
+                    for link in block.exits:
+                        self.inlinable_blocks.discard(link.target)
 
         yield ''
         for line in self.gen_goto(graph.startblock):
@@ -264,27 +322,120 @@ class FunctionCodeGenerator(object):
                               UnsignedLongLong, Char, UniChar):
                     defaultlink = None
                     expr = self.expr(block.exitswitch)
-                    yield 'switch (%s) {' % self.expr(block.exitswitch)
+                    non_default = [l for l in block.exits
+                                   if l.exitcase != 'default']
                     for link in block.exits:
                         if link.exitcase == 'default':
                             defaultlink = link
-                            continue
-                        yield 'case %s:' % self.db.get(link.llexitcase)
-                        for op in self.gen_link(link):
-                            yield '\t' + op
-                        # 'break;' not needed, as gen_link ends in a 'goto'
-                    # Emit default case
-                    yield 'default:'
-                    if defaultlink is None:
-                        yield '\tassert(!"bad switch!!"); abort();'
+                    if (TYPE not in (Char, UniChar) and
+                            _use_computed_goto(non_default)):
+                        for line in self.gen_computed_goto(
+                                block, expr, non_default, defaultlink):
+                            yield line
                     else:
-                        for op in self.gen_link(defaultlink):
-                            yield '\t' + op
-
-                    yield '}'
+                        for line in self.gen_switch(
+                                expr, non_default, defaultlink):
+                            yield line
                 else:
                     raise TypeError("exitswitch type not supported"
                                     "  Got %r" % (TYPE,))
+
+    def gen_switch(self, expr, non_default, defaultlink):
+        """Emit a plain C switch statement for the given cases."""
+        yield 'switch (%s) {' % expr
+        for link in non_default:
+            yield 'case %s:' % self.db.get(link.llexitcase)
+            for op in self.gen_link(link):
+                yield '\t' + op
+            # 'break;' not needed, as gen_link ends in 'goto'
+        yield 'default:'
+        if defaultlink is None:
+            yield '\tassert(!"bad switch!!"); abort();'
+        else:
+            for op in self.gen_link(defaultlink):
+                yield '\t' + op
+        yield '}'
+
+    def gen_computed_goto(self, block, expr, non_default, defaultlink):
+        """Emit a computed goto dispatch table instead of a switch statement.
+
+        Uses GCC label-address extension (&&label, goto *expr).  Falls back to
+        a plain switch on non-GCC compilers (e.g. MSVC) via #ifdef __GNUC__.
+
+        Each case gets a per-case entry label (_cgoto_N_CASE) that performs
+        the link assignments for that edge, then falls through to the target
+        block's label.  This handles SSA link args correctly while still
+        using computed goto for the dispatch itself.
+        """
+        myblocknum = self.blocknum[block]
+        case_vals = [int(link.exitcase) for link in non_default]
+        log.computedgoto('%s: %d cases' % (self.functionname, len(case_vals)))
+        min_val = min(case_vals)
+        max_val = max(case_vals)
+        table_size = max_val - min_val + 1
+
+        # Per-case entry label: _cgoto_N_CASE (N=switch block, CASE=opcode).
+        def case_label(exitcase):
+            return '_cgoto_%d_%d' % (myblocknum, int(exitcase))
+
+        if defaultlink is not None:
+            default_label = '_cgoto_%d_default' % myblocknum
+        else:
+            default_label = None
+
+        yield '#ifdef __GNUC__'
+
+        # Emit the static dispatch table.
+        table_name = '_cgoto_%d' % myblocknum
+        yield 'static const void * const %s[%d] = {' % (table_name, table_size)
+        val_to_link = {int(lnk.exitcase): lnk for lnk in non_default}
+        for i in range(table_size):
+            v = min_val + i
+            if v in val_to_link:
+                label = case_label(v)
+            elif default_label is not None:
+                label = default_label
+            else:
+                label = '_cgoto_abort_%d' % myblocknum
+            yield '    /* %d */ &&%s,' % (v, label)
+        yield '};'
+
+        # Emit bounds check and indirect jump.
+        if min_val == 0:
+            bounds_expr = '(unsigned)(%s) < %d' % (expr, table_size)
+        else:
+            bounds_expr = ('(unsigned)(%s - %d) < %d'
+                           % (expr, min_val, table_size))
+        if default_label is not None:
+            yield 'if (!(%s)) goto %s;' % (bounds_expr, default_label)
+        else:
+            yield 'if (!(%s)) { assert(!"bad switch!!"); abort(); }' % bounds_expr
+        if min_val == 0:
+            yield 'goto *%s[%s];' % (table_name, expr)
+        else:
+            yield 'goto *%s[%s - %d];' % (table_name, expr, min_val)
+
+        # Emit per-case entry points (assignments + jump to target block).
+        for link in non_default:
+            yield '%s:' % case_label(link.exitcase)
+            for line in self.gen_link(link):
+                yield '\t' + line
+
+        # Emit default entry point.
+        if defaultlink is not None:
+            yield '%s:' % default_label
+            for line in self.gen_link(defaultlink):
+                yield '\t' + line
+
+        # Emit abort for gap entries when there is no default.
+        if default_label is None and table_size > len(non_default):
+            yield '_cgoto_abort_%d:' % myblocknum
+            yield '    assert(!"bad switch!!"); abort();'
+
+        yield '#else  /* no computed goto -- fallback for MSVC and other compilers */'
+        for line in self.gen_switch(expr, non_default, defaultlink):
+            yield line
+        yield '#endif  /* __GNUC__ */'
 
     def gen_link(self, link):
         "Generate the code to jump across the given Link."

--- a/rpython/translator/c/test/test_genc.py
+++ b/rpython/translator/c/test/test_genc.py
@@ -639,3 +639,42 @@ def test_generated_c_source_no_gotos():
     c_src = get_generated_c_source(main, [int])
     assert 'goto' not in c_src
     assert not re.search(r'block\w*:(?! \(inlined\))', c_src)
+
+def test_computed_goto_large_switch():
+    # A switch with >= COMPUTED_GOTO_THRESHOLD arg-free cases must use
+    # a computed goto table rather than a C switch statement.
+    def dispatch(opcode):
+        if opcode == 0: return 100
+        elif opcode == 1: return 101
+        elif opcode == 2: return 102
+        elif opcode == 3: return 103
+        elif opcode == 4: return 104
+        elif opcode == 5: return 105
+        elif opcode == 6: return 106
+        elif opcode == 7: return 107
+        else: return -1
+
+    c_src = get_generated_c_source(dispatch, [int])
+    assert '_cgoto_' in c_src, "expected computed goto table in C source"
+    assert '#ifdef __GNUC__' in c_src, "expected GCC guard in C source"
+    assert 'goto *' in c_src, "expected indirect goto in C source"
+    # Spot-check: the table must be a static const array of void pointers.
+    assert 'static const void * const _cgoto_' in c_src
+
+def test_computed_goto_correctness():
+    # Verify that computed goto dispatch produces correct results.
+    def dispatch(opcode):
+        if opcode == 0: return 100
+        elif opcode == 1: return 101
+        elif opcode == 2: return 102
+        elif opcode == 3: return 103
+        elif opcode == 4: return 104
+        elif opcode == 5: return 105
+        elif opcode == 6: return 106
+        elif opcode == 7: return 107
+        else: return -1
+
+    f = compile(dispatch, [int])
+    for i in range(8):
+        assert f(i) == 100 + i
+    assert f(99) == -1

--- a/rpython/translator/c/test/test_genc.py
+++ b/rpython/translator/c/test/test_genc.py
@@ -660,6 +660,10 @@ def test_computed_goto_large_switch():
     assert 'goto *' in c_src, "expected indirect goto in C source"
     # Spot-check: the table must be a static const array of void pointers.
     assert 'static const void * const _cgoto_' in c_src
+    # GCC 10 rejects a declaration directly after a label; verify the null
+    # statement that separates the block label from the table declaration.
+    import re
+    assert re.search(r';\s*\n\s*static const void \* const _cgoto_', c_src)
 
 def test_computed_goto_correctness():
     # Verify that computed goto dispatch produces correct results.


### PR DESCRIPTION
## What this does

Replaces C `switch` statements with GCC computed goto dispatch tables (`goto *table[opcode]`)
for large integer switches in generated RPython C code. The main beneficiary is
`dispatch_bytecode`, in the base interpreter (`--jit off`) which has a 124-case switch on the opcode.

Falls back to a plain `switch` on non-GCC compilers (MSVC, etc.) via `#ifdef __GNUC__`
in the generated C.

Threshold: switches with fewer than 5 cases keep using `switch`, switches with many missing values (i.e. unicodedata and jit optimizer) will keep using `switch`. The PR is contained to only the function code generation.

A new log line is emitted during codegen where computed gotos are emitted.

## Benchmark result

~4% faster interpreter on fannkuch (`--jit off`). Other benchmarks like deltablue, nbody, nqueens and richards did not see a base-interpreter improvement.

## Why only maybe 4% when CPython saw ~20%?

CPython's Antoine Pitrou [reported ~20% speedup in 2009](https://bugs.python.org/issue4753).
Why does RPython gets less?

### Inlined vs. call-out handlers

Inspecting the generated `dispatch_bytecode` C function on `main` (py2.7):

- **124 opcode cases total**
- **~78 are fully inlined** — LOAD_FAST, LOAD_CONST, JUMP_ABSOLUTE, binary arithmetic, etc.
  The entire handler is emitted as C code inside `dispatch_bytecode` with no function call.
- **46 call out to separate C functions** — CALL_FUNCTION, STORE_ATTR, LOAD_METHOD,
  RAISE_VARARGS, FOR_ITER, BUILD_LIST, etc.

Inlined handlers benefit fully: GCC can do cross-handler register allocation across the
entire function, and the computed goto table eliminates branch-predictor pressure from
a 124-way switch.

Call-out handlers benefit only marginally: computed goto saves one indirect branch per
dispatch, but the function call itself flushes register state anyway. These
46 handlers happen to be the heavily used ones in benchmarks — CALL_FUNCTION, LOAD_METHOD, STORE_ATTR dominate the benchmark profile.

### Why are the heavy handlers separate functions?

RPython's CollectAnalyzer marks any function that may trigger GC allocation as
"might collect". Call sites of such functions must save live GC roots to the shadow stack
before the call and restore them after. Even if these functions were small enough to inline, this save/restore wrapping forces the handler into a separate C function — GCC cannot inline across a shadow-stack boundary because the surrounding code in `dispatch_bytecode` holds live GC roots.

CPython has no equivalent constraint: all handler code lives in one
`_PyEvalFrameDefault` function and GCC sees everything at once.