### PR TITLE
Stackcheck explicit inline

### DIFF
--- a/rpython/translator/backendopt/test/test_canraise.py
+++ b/rpython/translator/backendopt/test/test_canraise.py
@@ -36,7 +36,15 @@ class TestCanRaise(object):
         t, ra = self.translate(f, [int])
         insert_ll_stackcheck(t)
         ggraph = graphof(t, g)
-        result = ra.can_raise(ggraph.startblock.operations[-1])
+        # after inlining the stack check, the call to f is no longer in startblock
+        # so search all blocks for a direct_call operation
+        call_op = None
+        for block in ggraph.iterblocks():
+            for op in block.operations:
+                if op.opname == 'direct_call':
+                    call_op = op
+        assert call_op is not None
+        result = ra.can_raise(call_op)
         assert result # due to stack check every recursive function can raise
 
     def test_bug_graphanalyze_recursive(self):

--- a/rpython/translator/backendopt/test/test_writeanalyze.py
+++ b/rpython/translator/backendopt/test/test_writeanalyze.py
@@ -47,7 +47,15 @@ class TestWriteAnalyze(BaseTest):
         t, wa = self.translate(f, [int])
         insert_ll_stackcheck(t)
         ggraph = graphof(t, g)
-        result = wa.analyze(ggraph.startblock.operations[-1])
+        # after inlining the stack check, the call to f is no longer in startblock
+        # so search all blocks for a direct_call operation
+        call_op = None
+        for block in ggraph.iterblocks():
+            for op in block.operations:
+                if op.opname == 'direct_call':
+                    call_op = op
+        assert call_op is not None
+        result = wa.analyze(call_op)
         assert not result
 
     def test_write_to_new_struct(self):

--- a/rpython/translator/exceptiontransform.py
+++ b/rpython/translator/exceptiontransform.py
@@ -363,7 +363,7 @@ class ExceptionTransformer(object):
         block.exits[0].exitcase = block.exits[0].llexitcase = None
         # use the dangerous second True flag :-)
         inliner = inline.OneShotInliner(
-            self.translator, graph, self.lltype_to_classdef,
+            self.translator, graph, None,
             inline_guarded_calls=True, inline_guarded_calls_no_matter_what=True,
             raise_analyzer=self.raise_analyzer)
         inliner.inline_once(block, len(block.operations)-1)

--- a/rpython/translator/test/test_stackcheck.py
+++ b/rpython/translator/test/test_stackcheck.py
@@ -24,7 +24,10 @@ def paths_naive(g):
     return accum
 
 def direct_target(spaceop):
-    return spaceop.args[0].value._obj.graph.name
+    obj = spaceop.args[0].value._obj
+    if hasattr(obj, 'graph'):
+        return obj.graph.name
+    return obj._name
 
 def direct_calls(p):
     names = []
@@ -33,16 +36,19 @@ def direct_calls(p):
             names.append(direct_target(spaceop))
     return names
 
-            
+SLOWPATH_NAME = 'stack_check_slowpath__Signed'
+# First call in the inlined stack_check body; present on every path (fast and slow).
+FASTPATH_SENTINEL = 'LL_stack_get_end'
+
 def check(g, funcname, ignore=None):
     paths = paths_naive(g)
     relevant = []
     for p in paths:
         funcs_called = direct_calls(p)
         if funcname in funcs_called and ignore not in funcs_called:
-            assert 'stack_check___' in funcs_called
+            assert FASTPATH_SENTINEL in funcs_called
             assert (funcs_called.index(funcname) >
-                    funcs_called.index('stack_check___'))
+                    funcs_called.index(FASTPATH_SENTINEL))
             relevant.append(p)
     return relevant
     
@@ -112,9 +118,35 @@ def test_gctransformed():
                 target = direct_target(spaceop)
                 if target == 'f':
                     in_between = False
-                elif target == 'stack_check___':
+                elif target == FASTPATH_SENTINEL:
                     in_between = True
             if in_between and spaceop.opname == 'gc_reload_possibly_moved':
                 reload += 1
                 
         assert reload == 0
+
+def all_direct_calls(g):
+    """Return all direct_call target names across every block in the graph."""
+    names = []
+    for block in g.iterblocks():
+        for op in block.operations:
+            if op.opname == 'direct_call':
+                names.append(direct_target(op))
+    return names
+
+def test_fastpath_inlined():
+    # After insert_ll_stackcheck the stack_check function must be inlined at
+    # each call site: no direct_call to stack_check___ should remain, and the
+    # slow-path call must be present instead.
+    t = TranslationContext()
+    a = t.buildannotator()
+    a.build_types(g, [int])
+    a.simplify()
+    t.buildrtyper().specialize()
+    backend_optimizations(t)
+    t.checkgraphs()
+    insert_ll_stackcheck(t)
+    t.checkgraphs()
+    calls = all_direct_calls(graphof(t, f))
+    assert 'stack_check___' not in calls
+    assert SLOWPATH_NAME in calls

--- a/rpython/translator/transform.py
+++ b/rpython/translator/transform.py
@@ -199,6 +199,7 @@ def cutoff_alwaysraising_block(self, block):
 
 def insert_ll_stackcheck(translator):
     from rpython.translator.backendopt.support import find_calls_from
+    from rpython.translator.backendopt import canraise, inline
     from rpython.rlib.rstack import stack_check
     from rpython.tool.algo.graphlib import Edge, make_edge_dict, break_cycles_v
     rtyper = translator.rtyper
@@ -231,6 +232,8 @@ def insert_ll_stackcheck(translator):
     for block in break_cycles_v(edgedict, edgedict):
         insert_in.add(block)
 
+    raise_analyzer = canraise.RaiseAnalyzer(translator)
+    lltype_to_classdef = translator.rtyper.lltype_to_classdef_mapping()
     for block in insert_in:
         v = Variable()
         v.concretetype = lltype.Void
@@ -240,6 +243,10 @@ def insert_ll_stackcheck(translator):
         # not consume any stack, so would turn into potentially infinite loops
         graph = block2graph[block]
         graph.inhibit_tail_call = True
+        inliner = inline.OneShotInliner(
+            translator, graph, lltype_to_classdef,
+            raise_analyzer=raise_analyzer)
+        inliner.inline_once(block, 0)
     return len(insert_in)
 
 


### PR DESCRIPTION
Alternative to #5460

I translated 
```
$ cat rpython/translator/goal/targetfibstandalone.py
import os

def fib(n):
    if n < 2:
        return n
    return fib(n - 1) + fib(n - 2)

def entry_point(argv):
    i = 0
    while i < 10:
        os.write(2, str(fib(35)) + "\n")
        i += 1
    return 0

def target(*args):
    return entry_point, None 
```

once on main (fib_main) and once on this branch (fib_inline) with gcc14. The instruction count under callgrind drops from 5.8M to 4.3M:
```
$ valgrind --tool=callgrind /tmp/fib_main 
...
9227465
9227465
9227465
9227465
9227465
9227465
9227465
9227465
9227465
9227465
==575835== 
==575835== Events    : Ir
==575835== Collected : 5801468960
==575835== 
==575835== I   refs:      5,801,468,960

$ valgrind --tool=callgrind /tmp/fib_inline 
...
9227465
9227465
9227465
9227465
9227465
9227465
9227465
9227465
9227465
9227465
==575895== 
==575895== Events    : Ir
==575895== Collected : 4335272067
==575895== 
==575895== I   refs:      4,335,272,067
```