### PR TITLE
tweak _is_cpyext* check for inpect

### DIFF
--- a/lib-python/3/inspect.py
+++ b/lib-python/3/inspect.py
@@ -153,7 +153,7 @@ from keyword import iskeyword
 from operator import attrgetter
 from collections import namedtuple, OrderedDict
 try:
-    from cpyext import is_cpyext_function as _is_cpyext_function
+    from cpyext import is_cpyext_builtin_function as _is_cpyext_function
 except ImportError:
     _is_cpyext_function = lambda obj: False
 

--- a/pypy/module/cpyext/interp_cpyext.py
+++ b/pypy/module/cpyext/interp_cpyext.py
@@ -1,4 +1,7 @@
-from .methodobject import W_PyCFunctionObject
+from .methodobject import W_PyCFunctionObject, W_PyCMethodObject
 
-def is_cpyext_function(space, w_arg):
-    return space.newbool(isinstance(w_arg, W_PyCFunctionObject))
+def is_cpyext_builtin_function(space, w_arg):
+    return space.newbool(
+        isinstance(w_arg, W_PyCFunctionObject) and
+        not isinstance(w_arg, W_PyCMethodObject)
+    )

--- a/pypy/module/cpyext/moduledef.py
+++ b/pypy/module/cpyext/moduledef.py
@@ -4,7 +4,7 @@ from pypy.module.cpyext import api
 
 class Module(MixedModule):
     interpleveldefs = {
-        'is_cpyext_function': 'interp_cpyext.is_cpyext_function',
+        'is_cpyext_builtin_function': 'interp_cpyext.is_cpyext_builtin_function',
         'FunctionType': 'methodobject.W_PyCFunctionObject',
     }
 

--- a/pypy/module/cpyext/test/test_cpyext.py
+++ b/pypy/module/cpyext/test/test_cpyext.py
@@ -506,7 +506,7 @@ class AppTestCpythonExtension(AppTestCpythonExtensionBase):
     def test_export_function(self):
         import sys
         if '__pypy__' in sys.modules:
-            from cpyext import is_cpyext_function
+            from cpyext import is_cpyext_builtin_function as is_cpyext_function
         else:
             import inspect
             is_cpyext_function = inspect.isbuiltin

--- a/pypy/module/cpyext/test/test_typeobject.py
+++ b/pypy/module/cpyext/test/test_typeobject.py
@@ -204,6 +204,9 @@ class AppTestTypeObject(AppTestCpythonExtensionBase):
         raises(TypeError, descr, None)
         assert descr.__doc__ == "Copy the foo."
         assert descr.__text_signature__ == '($self, /)'
+        import inspect
+        assert not inspect.isbuiltin(descr)
+        assert inspect.ismethoddescriptor(descr)
 
     def test_cython_fake_classmethod(self):
         module = self.import_module(name='foo')


### PR DESCRIPTION
Fixes #5472 

The new `_is_cpyext_function` function was including `W_PyCMethodObject` method descriptors, which led to `inspect` failures. Rename and restrict the function to be more precise.