### PR TITLE
Estimate GC nursery size via performance-core L2 cache (not efficiency) on Apple Silicon

### DIFF
--- a/rpython/memory/gc/env.py
+++ b/rpython/memory/gc/env.py
@@ -416,7 +416,24 @@ def get_L2cache_darwin():
     on the machine we are running on.
     """
     debug_start("gc-hardware")
-    L2cache = get_darwin_sysctl_signed("hw.l2cachesize")
+    # On Apple Silicon, `hw.l2cachesize` returns the *efficiency* cluster's
+    # L2 (e.g. 4 MB on an M-series chip) rather than the performance
+    # cluster's (16 MB and up). Apple documents per-cluster topology under
+    # `hw.perflevelN.*` and states that "lower values of N indicate
+    # higher-performance core types" — so `hw.perflevel0.l2cachesize` is
+    # the L2 for the cluster the work actually runs against. See
+    # https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_system_capabilities#3901385
+    # On Intel Macs `hw.perflevel0.*` is absent (returns 0), so this falls
+    # back to the legacy `hw.l2cachesize`.
+    L2cache = get_darwin_sysctl_signed("hw.perflevel0.l2cachesize")
+    if L2cache <= 0:
+        L2cache = get_darwin_sysctl_signed("hw.l2cachesize")
+    # `hw.l3cachesize` reports L3 on Intel Macs. On observed Apple Silicon
+    # systems this sysctl is absent and returns 0; Apple also documents
+    # `hw.perflevel0.l3cachesize` but in practice it appears unpopulated on
+    # at least some M-series chips. We keep the existing behavior (sum L2
+    # and L3, treating an absent L3 as 0) which yields the correct Intel
+    # answer and a conservative-but-not-pathological Apple Silicon answer.
     L3cache = get_darwin_sysctl_signed("hw.l3cachesize")
     debug_print("L2cache =", L2cache)
     debug_print("L3cache =", L3cache)


### PR DESCRIPTION
On Apple Silicon, `hw.l2cachesize` returns the *efficiency* cluster's L2 (e.g. 4 MB on a typical M-series), not the performance cluster's (16 MB and up). The result was that `get_L2cache_darwin()` returned 4 MB, which in `best_nursery_size_for_L2cache()` falls into the "no L3 present" branch (L2 <= 8 MB) and gives the 4 MB `NURSERY_SIZE_UNKNOWN_CACHE` fallback rather than half of the real performance-cluster L2.

  https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_system_capabilities#3901385

`hw.l3cachesize` (and Apple's documented `hw.perflevel0.l3cachesize`) both appear unpopulated on my M4 MacBook Air, so this commit doesn't try to recover an "L3" contribution there; heavily-allocating workloads may still want to set `PYPY_GC_NURSERY` higher, but the default is at least closer to correct.

On [rpylean](https://github.com/Julian/rpylean) this definitely looks like a performance improvement, 10% on workloads with 8MB vs 4MB, and closer to 40% with manually-set 64MB nursery -- I'm hoping it'll be obvious to y'all whether this change is safe to make for PyPy itself too.

Refs: 39b141959b (raise default gc nursery size to 4MB)
