### PR TITLE
fix d21acd93b0d for pybind11-style classes (issue 5481)

### DIFF
--- a/pypy/module/cpyext/test/test_typeobject.py
+++ b/pypy/module/cpyext/test/test_typeobject.py
@@ -1647,6 +1647,62 @@ class AppTestSlots(AppTestCpythonExtensionBase):
         with raises(SystemError):
             module.test_zero()
 
+    def test_multiple_inheritance_small_basicsize(self):
+        # Regression test: two manually-allocated heap types whose tp_basicsize
+        # is smaller than sizeof(PyHeapTypeObject) (as pybind11 does) must be
+        # combinable in multiple inheritance when they share the same
+        # tp_basicsize, because there is no actual instance-layout conflict.
+        module = self.import_extension('foo', [
+           ("new_obj", "METH_NOARGS",
+            '''
+                /* Simulate pybind11: instance struct is PyObject_HEAD + one ptr,
+                   which is << sizeof(PyHeapTypeObject). */
+                typedef struct { PyObject_HEAD; void *extra; } SmallInst;
+                Py_ssize_t inst_size = (Py_ssize_t)sizeof(SmallInst);
+
+                PyTypeObject *B1, *B2, *B12;
+                B1  = (PyTypeObject*)PyType_Type.tp_alloc(&PyType_Type, 0);
+                B2  = (PyTypeObject*)PyType_Type.tp_alloc(&PyType_Type, 0);
+                B12 = (PyTypeObject*)PyType_Type.tp_alloc(&PyType_Type, 0);
+
+                PyObject *n1  = PyUnicode_FromString("B1");
+                PyObject *n2  = PyUnicode_FromString("B2");
+                PyObject *n12 = PyUnicode_FromString("B12");
+
+                B1->tp_name  = "B1";
+                B2->tp_name  = "B2";
+                B12->tp_name = "B12";
+
+                B1->tp_basicsize  = inst_size;
+                B2->tp_basicsize  = inst_size;
+                B12->tp_basicsize = inst_size;
+
+                ((PyHeapTypeObject*)B1)->ht_name  = n1;
+                ((PyHeapTypeObject*)B2)->ht_name  = n2;
+                ((PyHeapTypeObject*)B12)->ht_name = n12;
+                ((PyHeapTypeObject*)B1)->ht_qualname  = n1;
+                ((PyHeapTypeObject*)B2)->ht_qualname  = n2;
+                ((PyHeapTypeObject*)B12)->ht_qualname = n12;
+
+                B1->tp_flags  = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+                B2->tp_flags  = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE;
+                B12->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE;
+
+                B12->tp_base  = B1;
+                B12->tp_bases = PyTuple_Pack(2, B1, B2);
+
+                if (PyType_Ready(B1)  < 0) return NULL;
+                if (PyType_Ready(B2)  < 0) return NULL;
+                if (PyType_Ready(B12) < 0) return NULL;
+
+                PyObject *obj = PyObject_New(PyObject, B12);
+                return obj;
+            '''
+            ),
+            ])
+        obj = module.new_obj()
+        assert 'B12' in str(obj)
+
     def test_multiple_inheritance_fetch_tp_bases(self):
         module = self.import_extension('foo', [
            ("foo", "METH_O",

--- a/pypy/objspace/std/typeobject.py
+++ b/pypy/objspace/std/typeobject.py
@@ -1375,9 +1375,24 @@ def check_and_find_best_base(space, bases_w, is_cpytype=False):
         if isinstance(w_base, W_TypeObject):
             layout = w_base.layout
             if not best_layout.issublayout(layout):
+                if is_cpytype and _layouts_equivalent(best_layout, layout):
+                    continue
                 raise oefmt(space.w_TypeError,
                             "instance layout conflicts in multiple inheritance")
     return w_bestbase
+
+def _layouts_equivalent(l1, l2):
+    """Return True if two Layout objects are structurally identical — same
+    typedef, nslots, slot names, and base chain — but are different Python
+    objects because force_new_layout created them independently.
+
+    Used to allow multiple inheritance between two cpytypes that have the same
+    tp_basicsize/tp_itemsize. CPython's solid_base() logic permits
+    this combination because both types share the same solid ancestor."""
+    return (l1.typedef is l2.typedef and
+            l1.nslots == l2.nslots and
+            l1.newslotnames == l2.newslotnames and
+            l1.base_layout is l2.base_layout)
 
 def copy_flags_from_bases(w_self, w_bestbase):
     hasoldstylebase = False

--- a/rpython/translator/c/funcgen.py
+++ b/rpython/translator/c/funcgen.py
@@ -379,8 +379,12 @@ class FunctionCodeGenerator(object):
         table_size = max_val - min_val + 1
 
         # Per-case entry label: _cgoto_N_CASE (N=switch block, CASE=opcode).
+        # Negative values use 'n' prefix so the label is a valid C identifier.
         def case_label(exitcase):
-            return '_cgoto_%d_%d' % (myblocknum, int(exitcase))
+            v = int(exitcase)
+            if v < 0:
+                return '_cgoto_%d_n%d' % (myblocknum, -v)
+            return '_cgoto_%d_%d' % (myblocknum, v)
 
         if defaultlink is not None:
             default_label = '_cgoto_%d_default' % myblocknum

--- a/rpython/translator/c/test/test_genc.py
+++ b/rpython/translator/c/test/test_genc.py
@@ -682,3 +682,39 @@ def test_computed_goto_correctness():
     for i in range(8):
         assert f(i) == 100 + i
     assert f(99) == -1
+
+def test_computed_goto_negative_cases():
+    # Switches with negative case values must produce valid C label names.
+    # A label like _cgoto_N_-1 is invalid C; it must be encoded (e.g. _cgoto_N_n1).
+    def dispatch(opcode):
+        if opcode == -4: return 10
+        elif opcode == -3: return 20
+        elif opcode == -2: return 30
+        elif opcode == -1: return 40
+        elif opcode == 0: return 50
+        else: return -1
+
+    c_src = get_generated_c_source(dispatch, [int])
+    assert '_cgoto_' in c_src, "expected computed goto table in C source"
+    # A label name containing '-' would be a C syntax error.
+    import re
+    assert not re.search(r'_cgoto_\d+_-', c_src), \
+        "negative case values must not produce '-' in C label names"
+
+def test_computed_goto_negative_cases_correctness():
+    # Verify computed goto with negative cases produces correct results.
+    def dispatch(opcode):
+        if opcode == -4: return 10
+        elif opcode == -3: return 20
+        elif opcode == -2: return 30
+        elif opcode == -1: return 40
+        elif opcode == 0: return 50
+        else: return -1
+
+    f = compile(dispatch, [int])
+    assert f(-4) == 10
+    assert f(-3) == 20
+    assert f(-2) == 30
+    assert f(-1) == 40
+    assert f(0) == 50
+    assert f(99) == -1


### PR DESCRIPTION
Fixes #5481 

In commit d21acd93b0d I forced some c-extension heap types to get new layouts, which broke pybind11's multiple inheritance tests. This PR is a little more surgical in checking for incompatible type layouts, but only when is_cpytype so it should not impact performance for app level classes.