### PR TITLE
Cherrypick

### DIFF
--- a/pypy/doc/release-v7.3.23.rst
+++ b/pypy/doc/release-v7.3.23.rst
@@ -1,17 +1,10 @@
 ==============================================================
-PyPy v7.3.23: release of python 2.7, 3.11, released 2026-xx-xx
+PyPy v7.3.23: release of python 2.7, 3.11, released 2026-05-26
 ==============================================================
 
 
 ..
   updated to ad87cbd9a6f27a94ae759905c171e87478490326
-
-.. note::
-       This is a pre-release announcement. When the release actually happens, it
-    will be announced on the PyPy blog_.
-
-.. note::
-      Need to add release date
 
 The PyPy team is proud to release version 7.3.23 of PyPy after the previous
 release on April 26, 2026. This is a bug-fix release that fixes an overeager

--- a/pypy/testrunner_cfg.py
+++ b/pypy/testrunner_cfg.py
@@ -35,3 +35,7 @@ def get_test_driver(testdir):
 _cherrypick = os.getenv('PYPYCHERRYPICK', '')
 if _cherrypick:
     cherrypick = _cherrypick.split(':')
+
+_ignoretest = os.getenv('PYPYIGNORETEST', '')
+if _ignoretest:
+    ignoretest = _ignoretest.split(':')

--- a/pypy/tool/release/check_versions.py
+++ b/pypy/tool/release/check_versions.py
@@ -34,6 +34,9 @@ def assert_in(a, b):
 
 
 pypy_versions = {
+                 '7.3.23': {'python_version': ['3.11.15', '2.7.18'],
+                           'date': '2026-05-26',
+                          },
                  '7.3.22': {'python_version': ['3.11.15', '2.7.18'],
                            'date': '2026-04-28',
                           },

--- a/pypy/tool/release/repackage.sh
+++ b/pypy/tool/release/repackage.sh
@@ -2,12 +2,14 @@
 
 set -e
 
-# Edit these appropriately before running this script
+# Edit these appropriately and tag the repo
+# like this but replace the versions and branch
+# git tag -a release-pypy3.11-v7.3.22 release-pypy3.11-v7.x -m"tag release pypy3.11-v7.3.22"
 pmaj=3  # python main version: 2 or 3
 pmin=11  # python minor version
 maj=7
 min=3
-rev=22
+rev=23
 #rc=rc2  # comment this line for actual release
 
 function maybe_exit {

--- a/pypy/tool/release/versions.json
+++ b/pypy/tool/release/versions.json
@@ -1,9 +1,98 @@
 [
   {
-    "pypy_version": "7.3.22",
+    "pypy_version": "7.3.23",
     "python_version": "3.11.15",
     "stable": true,
     "latest_pypy": true,
+    "date": "2026-05-26",
+    "files": [
+      {
+        "filename": "pypy3.11-v7.3.23-aarch64.tar.bz2",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-aarch64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.11-v7.3.23-linux32.tar.bz2",
+        "arch": "i686",
+        "platform": "linux",
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux32.tar.bz2"
+      },
+      {
+        "filename": "pypy3.11-v7.3.23-linux64.tar.bz2",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.11-v7.3.23-macos_x86_64.tar.bz2",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-macos_x86_64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.11-v7.3.23-macos_arm64.tar.bz2",
+        "arch": "arm64",
+        "platform": "darwin",
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-macos_arm64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.11-v7.3.23-win64.zip",
+        "arch": "x64",
+        "platform": "win64",
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-win64.zip"
+      }
+    ]
+  },
+  {
+    "pypy_version": "7.3.23",
+    "python_version": "2.7.18",
+    "stable": true,
+    "latest_pypy": true,
+    "date": "2026-05-26",
+    "files": [
+      {
+        "filename": "pypy2.7-v7.3.23-aarch64.tar.bz2",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-aarch64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.23-linux32.tar.bz2",
+        "arch": "i686",
+        "platform": "linux",
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux32.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.23-linux64.tar.bz2",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.23-macos_x86_64.tar.bz2",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-macos_x86_64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.23-macos_arm64.tar.bz2",
+        "arch": "arm64",
+        "platform": "darwin",
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-macos_arm64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.23-win64.zip",
+        "arch": "x64",
+        "platform": "win64",
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-win64.zip"
+      }
+    ]
+  },  {
+    "pypy_version": "7.3.22",
+    "python_version": "3.11.15",
+    "stable": true,
+    "latest_pypy": false,
     "date": "2026-04-28",
     "files": [
       {
@@ -48,7 +137,7 @@
     "pypy_version": "7.3.22",
     "python_version": "2.7.18",
     "stable": true,
-    "latest_pypy": true,
+    "latest_pypy": false,
     "date": "2026-04-28",
     "files": [
       {

--- a/testrunner/runner.py
+++ b/testrunner/runner.py
@@ -299,6 +299,7 @@ class RunParam(object):
     parallel_runs = 1
     timeout = None
     cherrypick = None
+    ignoretest = None
 
     def __init__(self, root):
         self.root = root
@@ -330,6 +331,9 @@ class RunParam(object):
             p = self.root
 
         reldir = self.reltoroot(p)
+        if p.check(file=1):
+            self.collect_one_testdir(testdirs, reldir, [reldir])
+            return
         if p.check():
             entries = [p1 for p1 in p.listdir(fil=lambda x: 'test_pypy_c' not in str(x)) if p1.check(dotfile=0)]
         else:
@@ -407,6 +411,10 @@ def main(args):
             run_param.collect_testdirs(testdirs, root.join(p))
     else:
         run_param.collect_testdirs(testdirs)
+
+    if run_param.ignoretest:
+        testdirs = [d for d in testdirs
+                    if not any(d.startswith(ign) for ign in run_param.ignoretest)]
 
     if opts.parallel_runs:
         run_param.parallel_runs = opts.parallel_runs

--- a/testrunner/test/test_runner.py
+++ b/testrunner/test/test_runner.py
@@ -417,6 +417,34 @@ class TestRunnerNoThreads(RunnerTests):
 
         assert sorted(res) == ['pkg/test_normal2', 'test_normal1']
 
+    def test_cherrypick_dir(self):
+        run_param = runner.RunParam(self.manydir)
+        run_param.cherrypick = ['two/test_normal1']
+        testdirs = []
+        for p in run_param.cherrypick:
+            run_param.collect_testdirs(testdirs, self.manydir.join(p))
+        assert testdirs == ['two/test_normal1']
+
+    def test_cherrypick_file(self):
+        test_file = sorted(self.manydir.join('two', 'test_normal1').listdir('test_*.py'))[0]
+        relpath = 'two/test_normal1/' + test_file.basename
+        run_param = runner.RunParam(self.manydir)
+        run_param.cherrypick = [relpath]
+        testdirs = []
+        for p in run_param.cherrypick:
+            run_param.collect_testdirs(testdirs, self.manydir.join(p))
+        assert testdirs == [relpath]
+
+    def test_ignoretest(self):
+        run_param = runner.RunParam(self.manydir)
+        testdirs = []
+        run_param.collect_testdirs(testdirs)
+        assert sorted(testdirs) == ['one/test_normal', 'two/pkg/test_normal2', 'two/test_normal1']
+        run_param.ignoretest = ['two/pkg']
+        filtered = [d for d in testdirs
+                    if not any(d.startswith(ign) for ign in run_param.ignoretest)]
+        assert sorted(filtered) == ['one/test_normal', 'two/test_normal1']
+
 
 class TestRunner(RunnerTests):
     pass


### PR DESCRIPTION
Add a PYPYIGNORETEST and extend PYPYCHERRYPICK so that both can accept single test files. This is for the win-rpython branch, which is expanding the github actions rpython test runs to run all the rpython tests. In order to spread out the tests on 5 jobs and balance the times, I want to be able to specify "these directories on this runner, these test files on this test runner"