### PR TITLE
fix unwind_fblock(F_HANDLER_CLEANUP) for bare except (issue 5490)

### DIFF
--- a/pypy/interpreter/astcompiler/codegen.py
+++ b/pypy/interpreter/astcompiler/codegen.py
@@ -346,8 +346,8 @@ class PythonCodeGenerator(assemble.PythonCodeMaker):
             self.emit_op(ops.POP_TOP)
             self.no_position_info()
         elif kind == F_HANDLER_CLEANUP:
-            if fblock.datum:
-                self.emit_op(_POP_BLOCK)  # end inner cleanup scope (SETUP_CLEANUP cleanup_end)
+            self.emit_op(_POP_BLOCK)  # end inner cleanup scope (SETUP_CLEANUP cleanup_end)
+            self.emit_op(_POP_BLOCK)  # end outer cleanup scope (SETUP_CLEANUP outer_cleanup)
             # new-mode: prev_exc is on value stack below tos (if preserve_tos)
             if preserve_tos:
                 self.emit_op(ops.ROT_TWO)  # bring prev_exc to TOS

--- a/pypy/interpreter/test/apptest_raise.py
+++ b/pypy/interpreter/test/apptest_raise.py
@@ -690,3 +690,38 @@ def test_reraise_with_replaced_traceback():
             raise
     except ValueError as err:
         assert err.__traceback__ is othr
+
+def test_bare_except_return_finally_no_context():
+    # return from bare except clears the exception; finally's raise must not
+    # report "During handling of the above exception, another exception occurred"
+    def foo():
+        try:
+            raise Exception("original")
+        except:
+            return
+        finally:
+            raise Exception("in finally")
+
+    try:
+        foo()
+    except Exception as e:
+        assert e.args[0] == "in finally"
+        assert e.__context__ is None, "expected no context, got: %r" % (e.__context__,)
+
+def test_bare_except_return_finally_runs_once():
+    # finally block must execute exactly once when return exits a bare except
+    log = []
+    def foo():
+        try:
+            raise Exception
+        except:
+            return
+        finally:
+            log.append(1)
+            raise Exception("in finally")
+
+    try:
+        foo()
+    except Exception:
+        pass
+    assert log == [1], "finally ran %d times, expected 1" % len(log)


### PR DESCRIPTION
During testing, I added dis.dis to show the exceptiontable, which made the problem very evident.

In `unwind_fblock(F_HANDLER_CLEANUP)` (the code path taken when return/break/continue exits an except handler), always emit __two__ `_POP_BLOCK` pseudo-ops before `POP_EXCEPT` — one to close the inner cleanup scope (`SETUP_CLEANUP` -> `cleanup_end`) and one to close the outer cleanup scope (`SETUP_CLEANUP` -> `outer_cleanup`). Previously, bare `except:` got zero, named `except E as x:` got one. The normal exit path at lines 1027–1029 already emitted two; this unwind path now matches it.

With both scopes closed, `POP_EXCEPT` falls under the `SETUP_FINALLY` scope (depth 0, no `lasti`), and the inlined `finally` body has no exception table coverage at all.

Fixes issue #5490 