### PR TITLE
only re-retrieve next_instr when tracing or action_dispatch happens

### DIFF
--- a/pypy/interpreter/pyopcode.py
+++ b/pypy/interpreter/pyopcode.py
@@ -14,6 +14,7 @@ from rpython.tool.sourcetools import func_with_new_name
 from pypy.interpreter import (
     gateway, function, eval, pyframe, pytraceback, pycode
 )
+from pypy.interpreter.executioncontext import TICK_COUNTER_STEP
 from pypy.interpreter.baseobjspace import W_Root
 from pypy.interpreter.error import OperationError, oefmt
 from pypy.interpreter.nestedscope import Cell
@@ -151,8 +152,19 @@ class __extend__(pyframe.PyFrame):
                     ec.bytecode_only_trace(self)
                     next_instr = r_uint(self.last_instr)
             else:
-                ec.bytecode_trace(self)
-                next_instr = r_uint(self.last_instr)
+                # Only reload next_instr from last_instr when something that
+                # can modify it actually ran (trace function or action
+                # dispatcher). In the common case (no trace, positive ticker)
+                # next_instr is unchanged and the round-trip is skipped.
+                _d = self.debugdata
+                if ec.space.reverse_debugging or (
+                        _d is not None and _d.w_f_trace is not None):
+                    ec.bytecode_only_trace(self)
+                    next_instr = r_uint(self.last_instr)
+                actionflag = ec.space.actionflag
+                if actionflag.decrement_ticker(TICK_COUNTER_STEP) < 0:
+                    actionflag.action_dispatcher(ec, self)
+                    next_instr = r_uint(self.last_instr)
             opcode = ord(co_code[next_instr])
             next_instr += 1
 


### PR DESCRIPTION
I noticed a difference between the jitted and non-jitted code, in that `next_instr` was only re-retrieved when there was a chance it had changed. I extended this optimization to the non-jitted path, and ran a comparison after translation
```
perf stat -e instructions,cycles,L1-dcache-loads \
    ./pypy-c --jit off benchmarks/own/bm_mdp.py -n 1
```

The results show that although the number of instructions stay the same, the compiler can fill the pipelines and the ins/cycle went up.

| | Old | New | Delta |
|---|---|---|---|
| Instructions | ~156.9B | ~157.2B | +320M (+0.2%) |
| Cycles | ~71.0B | ~70.3B | **-720M (-1.0%)** |
| L1-dcache-loads | ~81.4B | ~81.7B | +300M (+0.4%) |
| instructions per cycle | 2.21 | 2.24 | **+0.03** |
| Wall time | ~17.1s | ~16.8s | **-1.5%** |

Instruction count slightly up due to two added null checks (`debugdata`, `w_f_trace`).
Cycle reduction reflects store-to-load forwarding stall removal on the critical path.

