### PR TITLE
only re-retrieve next_instr when tracing or action_dispatch (py3.11)

### DIFF
--- a/pypy/interpreter/pyopcode.py
+++ b/pypy/interpreter/pyopcode.py
@@ -15,6 +15,7 @@ from rpython.tool.sourcetools import func_with_new_name
 from pypy.interpreter import (
     gateway, function, eval, pyframe, pytraceback, pycode
 )
+from pypy.interpreter.executioncontext import TICK_COUNTER_STEP
 from pypy.interpreter.baseobjspace import W_Root
 from pypy.interpreter.error import OperationError, oefmt, oefmt_name_error, raise_import_error
 from pypy.interpreter.nestedscope import Cell
@@ -198,10 +199,21 @@ class __extend__(pyframe.PyFrame):
             assert next_instr & 1 == 0
             self.last_instr = intmask(next_instr)
             if jit.we_are_jitted():
-                ec.bytecode_only_trace(self)
+                _d = self.debugdata
+                if ec.space.reverse_debugging or (
+                        _d is not None and _d.w_f_trace is not None):
+                    ec.bytecode_only_trace(self)
+                    next_instr = r_uint(self.last_instr)
             else:
-                ec.bytecode_trace(self)
-            next_instr = r_uint(self.last_instr)
+                _d = self.debugdata
+                if ec.space.reverse_debugging or (
+                        _d is not None and _d.w_f_trace is not None):
+                    ec.bytecode_only_trace(self)
+                    next_instr = r_uint(self.last_instr)
+                actionflag = ec.space.actionflag
+                if actionflag.decrement_ticker(TICK_COUNTER_STEP) < 0:
+                    actionflag.action_dispatcher(ec, self)
+                    next_instr = r_uint(self.last_instr)
             assert next_instr & 1 == 0
             opcode = ord(co_code[next_instr])
             oparg = ord(co_code[next_instr + 1])


### PR DESCRIPTION
Adapt #5494 to py3.11. Here the results were even better, and additionally the optimization was missing on the JITted path. I only ran the benchmark with `--jit off`.

| | Old (py3.11-head) | New (pypy3.11-c) | Delta |
|---|---|---|---|
| Instructions | ~146.7B | ~144.5B | **-2.2B (-1.5%)** |
| Cycles | ~70.2B | ~68.1B | **-2.1B (-3.0%)** |
| L1-dcache-loads | ~73.9B | ~72.4B | **-1.5B (-2.0%)** |
| instructions per cycle | 2.09 | 2.12 | **+0.03** |
| Wall time | ~17.06s | ~16.57s | **-2.9%** |

