### PR TITLE
x86 jit: break cvtsi2sd false dependency with a zeroing idiom

### DIFF
--- a/rpython/jit/backend/x86/assembler.py
+++ b/rpython/jit/backend/x86/assembler.py
@@ -1471,6 +1471,11 @@ class Assembler386(BaseAssembler, VectorAssemblerMixin):
         self.mc.CVTTSD2SI(resloc, arglocs[0])
 
     def genop_cast_int_to_float(self, op, arglocs, resloc):
+        # CVTSI2SD preserves the high 64 bits of the destination, so it carries
+        # a false dependency on the register's prior value.  In a loop reusing
+        # the same XMM this serialises the conversion against the previous
+        # iteration; break it with a zeroing idiom (eliminated at rename).
+        self.mc.PXOR_xx(resloc.value, resloc.value)
         self.mc.CVTSI2SD(resloc, arglocs[0])
 
     def genop_cast_float_to_singlefloat(self, op, arglocs, resloc):


### PR DESCRIPTION
CVTSI2SD preserves the destination's high 64 bits, carrying a false dependency on the register's prior value. In a loop that reuses the same xmm this serialises the int->float conversion against the previous iteration. Emit a pxor zeroing idiom (eliminated at register rename) before the conversion to break it.

Output unchanged: cvtsi2sd overwrites the low 64 bits, so zeroing the rest is semantically inert for scalar doubles.

test script
```python
def main():
    s = 0.0
    i = 0
    while i < 200000000:
        s = s + i * 0.1
        i = i + 1
    print(s)

main()
```

measurement
```
pwsh .\measure.ps1                             
run=1 name=installed-pypy2 sec=0.485363 code=0
run=1 name=built-pypy2-cvtsi2sd sec=0.146969 code=0
run=2 name=installed-pypy2 sec=0.281597 code=0
run=2 name=built-pypy2-cvtsi2sd sec=0.144933 code=0
run=3 name=installed-pypy2 sec=0.282210 code=0
run=3 name=built-pypy2-cvtsi2sd sec=0.144413 code=0
run=4 name=installed-pypy2 sec=0.282383 code=0
run=4 name=built-pypy2-cvtsi2sd sec=0.145911 code=0
run=5 name=installed-pypy2 sec=0.281303 code=0
run=5 name=built-pypy2-cvtsi2sd sec=0.144684 code=0
run=6 name=installed-pypy2 sec=0.288980 code=0
run=6 name=built-pypy2-cvtsi2sd sec=0.144944 code=0
run=7 name=installed-pypy2 sec=0.281541 code=0
run=7 name=built-pypy2-cvtsi2sd sec=0.145592 code=0
--- summary ---
installed-pypy2 avg=0.311911 median=0.282383 min=0.281303 max=0.485363
built-pypy2-cvtsi2sd avg=0.145349 median=0.145592 min=0.144413 max=0.146969
speedup_median=1.940x reduction=48.4%
```

<summary>

measurement detail

<details>

baseline version:
```
pypy2 --version
Python 2.7.18 (d3d629bf20c9, May 26 2026, 06:09:05)
[PyPy 7.3.23 with MSC v.1941 64 bit (AMD64)]
```

patched version
```
pypy\goal\pypy-c.exe --version
Python 2.7.18 (4be9667c6636, Jun 19 2026, 16:09:59)
[PyPy 7.3.24-alpha0 with MSC v.1944 64 bit (AMD64)]
```


measure.ps1
```pwsh
$script = 'Z:\pyre-2\pyre\bench\float_loop.py'

$bins = @(
  @{ name = 'installed-pypy2'; exe = 'pypy2' },
  @{ name = 'built-pypy2-cvtsi2sd'; exe = 'Z:\pypy-main-cvtsi2sd\pypy\goal\pypy-c.exe' }
)

$results = @()

for ($i = 1; $i -le 7; $i++) {
  foreach ($b in $bins) {
    $sw = [System.Diagnostics.Stopwatch]::StartNew()
    $out = & $b.exe $script
    $code = $LASTEXITCODE
    $sw.Stop()

    $sec = [double]$sw.Elapsed.TotalSeconds
    $results += [pscustomobject]@{
      run = $i
      name = $b.name
      seconds = $sec
      code = $code
      output = ($out -join ' ')
    }

    "run={0} name={1} sec={2:N6} code={3}" -f $i, $b.name, $sec, $code
  }
}

"--- summary ---"

foreach ($name in ($bins | ForEach-Object { $_.name })) {
  $xs = @(
    $results |
      Where-Object { $_.name -eq $name } |
      ForEach-Object { [double]$_.seconds } |
      Sort-Object
  )

  $avg = ($xs | Measure-Object -Average).Average
  $median = $xs[[int]($xs.Count / 2)]
  $min = $xs[0]
  $max = $xs[$xs.Count - 1]

  "{0} avg={1:N6} median={2:N6} min={3:N6} max={4:N6}" -f `
    $name, $avg, $median, $min, $max
}

$base = @(
  $results |
    Where-Object { $_.name -eq 'installed-pypy2' } |
    ForEach-Object { [double]$_.seconds } |
    Sort-Object
)

$new = @(
  $results |
    Where-Object { $_.name -eq 'built-pypy2-cvtsi2sd' } |
    ForEach-Object { [double]$_.seconds } |
    Sort-Object
)

$baseMed = $base[[int]($base.Count / 2)]
$newMed = $new[[int]($new.Count / 2)]

"speedup_median={0:N3}x reduction={1:N1}%" -f `
  ($baseMed / $newMed), ((1 - ($newMed / $baseMed)) * 100)

```
</details>
</summary>

<!----

Thank you for contributing to PyPy. Please be sure to target one of our active branches:
- `main` for pypy2.7, rpython, and documentation changes
- `py3.10` for the legacy python3.10 branch
- `py3.11` for the current development branch targeting python3.11

Do not target the `branch/*` branches, they are artifacts of our migration from mercurial to git.
--?>