### PR TITLE
aarch64: emit shorter MOVN/MOVK sequences for negative immediates

### DIFF
--- a/rpython/jit/backend/aarch64/codebuilder.py
+++ b/rpython/jit/backend/aarch64/codebuilder.py
@@ -509,12 +509,22 @@ class AbstractAarch64Builder(object):
     def gen_load_int(self, r, value):
         """r is the register number, value is the value to be loaded to the
         register"""
-        # XXX optimize!
         if value < 0:
-            if value < -65536:
-                self.gen_load_int_full(r, value)
-            else:
+            if value >= -65536:
                 self.MOVN_r_u16(r, ~value)
+                return
+            # MOVN sets every bit to 1 except the low 16, which it loads;
+            # then patch the higher 16-bit words that are not already
+            # all-ones with MOVK.  Emits 1-4 instructions (was always 4).
+            self.MOVN_r_u16(r, ~value & 0xFFFF)
+            value = value >> 16
+            shift = 16
+            while shift < 64:
+                hw = value & 0xFFFF
+                if hw != 0xFFFF:
+                    self.MOVK_r_u16(r, hw, shift)
+                shift += 16
+                value >>= 16
             return
         self.MOVZ_r_u16(r, value & 0xFFFF, 0)
         value = value >> 16


### PR DESCRIPTION
gen_load_int() used gen_load_int_full() for all values < -65536, always emitting four instructions. For negative values whose upper halfwords are already all ones, start with MOVN and emit MOVK only for halfwords that differ.

This preserves the existing maximum-size contract while reducing common negative constants from four instructions to two or three. gen_load_int_full() remains available for fixed-size patchable call sites.

test script
```python
def main():
    s = 0
    i = 0
    while i < 200000000:
        s = s + -65537
        s = s + -131072
        s = s + -4294967296
        i = i + 1
    print(s)

main()
```

measurment
```
python  measure_aarch64_negative.py
run=1 name=baseline sec=0.185118
run=1 name=patched sec=0.171309
run=2 name=baseline sec=0.183291
run=2 name=patched sec=0.172835
run=3 name=baseline sec=0.183275
run=3 name=patched sec=0.171214
run=4 name=baseline sec=0.182557
run=4 name=patched sec=0.171326
run=5 name=baseline sec=0.210774
run=5 name=patched sec=0.172411
run=6 name=baseline sec=0.181845
run=6 name=patched sec=0.172971
run=7 name=baseline sec=0.181410
run=7 name=patched sec=0.171917
--- summary ---
baseline avg=0.186896 median=0.183275 min=0.181410 max=0.210774
patched avg=0.171997 median=0.171917 min=0.171214 max=0.172971
speedup_median=1.066x reduction=6.2%
```

  <summary>

  measurement detail
  <details>

  Both binaries printed the same result:

  -859032781000000000

  baseline version:
```
  /tmp/pypy2-baseline-build/pypy2-baseline-min --version
  Python 2.7.18 (d3d629bf20c9, Jun 20 2026, 16:28:34)
  [PyPy 7.3.23 with GCC Apple LLVM 21.0.0 (clang-2100.1.1.101)]
```
  patched version:
```
  /tmp/pypy2-branch-build/pypy2-patched-min --version
  Python 2.7.18 (d3d629bf20c9, Jun 20 2026, 16:20:42)
  [PyPy 7.3.23 with GCC Apple LLVM 21.0.0 (clang-2100.1.1.101)]
```

script:
```python
#!/usr/bin/env python3
import statistics
import subprocess
import sys
import tempfile
import time


BASELINE = "/tmp/pypy2-baseline-build/pypy2-baseline-min"
PATCHED = "/tmp/pypy2-branch-build/pypy2-patched-min"
RUNS = 7
EXPECTED = "-859032781000000000"

SCRIPT = """\
def main():
    s = 0
    i = 0
    while i < 200000000:
        s = s + -65537
        s = s + -131072
        s = s + -4294967296
        i = i + 1
    print(s)


main()
"""


def measure(name, exe, script):
    start = time.perf_counter()
    proc = subprocess.run([exe, script], stdout=subprocess.PIPE, text=True)
    elapsed = time.perf_counter() - start
    output = proc.stdout.strip()
    if proc.returncode != 0 or output != EXPECTED:
        raise SystemExit("bad run: %s code=%s output=%r" % (name, proc.returncode, output))
    return elapsed


def main():
    baseline = sys.argv[1] if len(sys.argv) > 1 else BASELINE
    patched = sys.argv[2] if len(sys.argv) > 2 else PATCHED

    with tempfile.NamedTemporaryFile("w", suffix=".py") as f:
        f.write(SCRIPT)
        f.flush()

        results = {"baseline": [], "patched": []}
        for i in range(1, RUNS + 1):
            for name, exe in (("baseline", baseline), ("patched", patched)):
                sec = measure(name, exe, f.name)
                results[name].append(sec)
                print("run=%d name=%s sec=%.6f" % (i, name, sec))

    print("--- summary ---")
    for name in ("baseline", "patched"):
        values = sorted(results[name])
        print(
            "%s avg=%.6f median=%.6f min=%.6f max=%.6f"
            % (
                name,
                statistics.mean(values),
                statistics.median(values),
                values[0],
                values[-1],
            )
        )

    base = statistics.median(results["baseline"])
    new = statistics.median(results["patched"])
    print("speedup_median=%.3fx reduction=%.1f%%" % (base / new, (1.0 - new / base) * 100.0))


if __name__ == "__main__":
    main()

```

  </details>
  </summary>


<!--
Thank you for contributing to PyPy. Please be sure to target one of our active branches:
- `main` for pypy2.7, rpython, and documentation changes
- `py3.10` for the legacy python3.10 branch
- `py3.11` for the current development branch targeting python3.11

Do not target the `branch/*` branches, they are artifacts of our migration from mercurial to git.
-->