### PR TITLE
change getrecursionlimit, setrecursionlimit to mean python stack frames

### DIFF
--- a/pypy/interpreter/executioncontext.py
+++ b/pypy/interpreter/executioncontext.py
@@ -33,7 +33,8 @@ class ExecutionContext(object):
     def __init__(self, space):
         self.space = space
         self.topframeref = jit.vref_None
-        # Python-level recursion counter, counts down like CPython's py_recursion_remaining
+        # Python-level recursion counter, counts down
+        # In CPython it is called py_recursion_remaining
         self.recursion_remaining = space.sys.recursionlimit
         # this is exposed to app-level as 'sys.exc_info()'.  At any point in
         # time it is the exception caught by the topmost 'except ... as e:'
@@ -87,16 +88,21 @@ class ExecutionContext(object):
     def enter(self, frame):
         if self.space.reverse_debugging:
             self._revdb_enter(frame)
-        remaining = self.recursion_remaining
-        if remaining <= 0:
-            raise oefmt(self.space.w_RecursionError,
-                        "maximum recursion depth exceeded")
-        self.recursion_remaining = remaining - 1
+        # recursion_checking is a quasi-immutable flag: if noone called
+        # sys.setrecursionlimit() it stays False and theJIT folds this
+        # block away, the per-frame counter costs nothing on the hot path.
+        if self.space.actionflag.recursion_checking:
+            remaining = self.recursion_remaining
+            if remaining <= 0:
+                raise oefmt(self.space.w_RecursionError,
+                            "maximum recursion depth exceeded")
+            self.recursion_remaining = remaining - 1
         frame.f_backref = self.topframeref
         self.topframeref = jit.virtual_ref(frame)
 
     def leave(self, frame, w_exitvalue, got_exception):
-        self.recursion_remaining += 1
+        if self.space.actionflag.recursion_checking:
+            self.recursion_remaining += 1
         try:
             if self.profilefunc:
                 self._trace(frame, 'leaveframe', w_exitvalue)
@@ -476,7 +482,7 @@ class AbstractActionFlag(object):
     whenever we fire any of the asynchronous actions.
     """
 
-    _immutable_fields_ = ["checkinterval_scaled?"]
+    _immutable_fields_ = ["checkinterval_scaled?", "recursion_checking?"]
 
     def __init__(self):
         self._periodic_actions = []
@@ -484,6 +490,12 @@ class AbstractActionFlag(object):
         # a bitmask where the ith bit is set if self._nonperiodic_actions[i]
         # has fired
         self._fired_bitmask = r_uint(0)
+
+        # quasi-immutable: False until the app calls sys.setrecursionlimit().
+        # While False the JIT constant-folds away the per-frame Python
+        # recursion counting in ExecutionContext.enter/leave, and only the
+        # low-level C-stack check guards against segfaults (old PyPy behaviour).
+        self.recursion_checking = False
 
         self.has_bytecode_counter = False
         # the default value is not 100, unlike CPython 2.7, but a much

--- a/pypy/interpreter/executioncontext.py
+++ b/pypy/interpreter/executioncontext.py
@@ -1,5 +1,5 @@
 import sys
-from pypy.interpreter.error import OperationError
+from pypy.interpreter.error import OperationError, oefmt
 from rpython.rlib.unroll import unrolling_iterable
 from rpython.rlib.objectmodel import specialize, not_rpython
 from rpython.rlib import jit, rgc, objectmodel
@@ -33,6 +33,8 @@ class ExecutionContext(object):
     def __init__(self, space):
         self.space = space
         self.topframeref = jit.vref_None
+        # Python-level recursion counter, counts down like CPython's py_recursion_remaining
+        self.recursion_remaining = space.sys.recursionlimit
         # this is exposed to app-level as 'sys.exc_info()'.  At any point in
         # time it is the exception caught by the topmost 'except ... as e:'
         # app-level block.
@@ -85,10 +87,16 @@ class ExecutionContext(object):
     def enter(self, frame):
         if self.space.reverse_debugging:
             self._revdb_enter(frame)
+        remaining = self.recursion_remaining
+        if remaining <= 0:
+            raise oefmt(self.space.w_RecursionError,
+                        "maximum recursion depth exceeded")
+        self.recursion_remaining = remaining - 1
         frame.f_backref = self.topframeref
         self.topframeref = jit.virtual_ref(frame)
 
     def leave(self, frame, w_exitvalue, got_exception):
+        self.recursion_remaining += 1
         try:
             if self.profilefunc:
                 self._trace(frame, 'leaveframe', w_exitvalue)

--- a/pypy/module/sys/test/test_sysmodule.py
+++ b/pypy/module/sys/test/test_sysmodule.py
@@ -81,6 +81,35 @@ class AppTestAppSysTests:
             sys._settraceallthreads(None)
         assert trace_funcs == [tracer]
 
+    def test_setrecursionlimit_counts_frames(self):
+        import sys
+        orig = sys.getrecursionlimit()
+        def set_relative(n):
+            d = 1
+            while True:
+                try:
+                    sys.setrecursionlimit(d)
+                except RecursionError:
+                    d += 1
+                else:
+                    break
+            sys.setrecursionlimit(d + n)
+        depth = [0]
+        def rec():
+            depth[0] += 1
+            rec()
+        try:
+            set_relative(20)
+            try:
+                rec()
+            except RecursionError:
+                pass
+            # limit is ~20 above the current depth: recursion must stop soon,
+            # not run to the C-stack limit (~1800)
+            assert depth[0] <= 100, depth[0]
+        finally:
+            sys.setrecursionlimit(orig)
+
     def test_sys_in_modules(self):
         import sys
         modules = sys.modules

--- a/pypy/module/sys/vm.py
+++ b/pypy/module/sys/vm.py
@@ -93,15 +93,28 @@ def _stack_check_noinline():
     stack_check()
 _stack_check_noinline._dont_inline_ = True
 
+def _count_active_frames(ec):
+    # Current Python recursion depth, by walking the frame chain.  Needed when
+    # arming the counter, since recursion_remaining is not maintained until
+    # sys.setrecursionlimit() has been called at least once.
+    n = 0
+    frame = ec.gettopframe()
+    while frame is not None:
+        n += 1
+        frame = frame.f_backref()
+    return n
+
 @jit.dont_look_inside
 @unwrap_spec(new_limit="c_int")
 def setrecursionlimit(space, new_limit):
     """setrecursionlimit() sets the maximum number of nested Python calls
 that can occur before a RecursionError is raised.
 
-On PyPy the limit counts Python frames, like CPython.  A separate lower-
-level check on the C stack still guards against segfaults; the C stack is
-grown to fit the limit but never shrunk below the default.
+On PyPy the limit counts Python frames, like CPython, but the per-frame
+counting is only turned on once this function is called: until then the
+limit is enforced approximately by the low-level C-stack check (which also
+guards against segfaults).  The C stack is grown to fit the limit but never
+shrunk below the default.
 """
     from rpython.rlib.rstack import _stack_set_length_fraction
     from rpython.rlib.rgc import increase_root_stack_depth
@@ -110,7 +123,13 @@ grown to fit the limit but never shrunk below the default.
                     "recursion limit must be greater or equal than 1")
     ec = space.getexecutioncontext()
     old_limit = space.sys.recursionlimit
-    depth = old_limit - ec.recursion_remaining
+    armed = space.actionflag.recursion_checking
+    if armed:
+        depth = old_limit - ec.recursion_remaining
+    else:
+        # first call: the counter has not been running, so measure the real
+        # depth of the calling thread directly.
+        depth = _count_active_frames(ec)
     if depth >= new_limit:
         raise oefmt(space.w_RecursionError,
                     "cannot set the recursion limit to %d at the recursion "
@@ -127,9 +146,22 @@ grown to fit the limit but never shrunk below the default.
     # publish the shared limit and re-derive each thread's remaining count,
     # preserving its current depth (cf. CPython's Py_SetRecursionLimit)
     space.sys.recursionlimit = new_limit
+    ec.recursion_remaining = new_limit - depth
     for other in space.threadlocals.getallvalues().values():
+        if other is ec:
+            continue
+        # Other threads: use the counter arithmetic.  On the first call,
+        # recursion_remaining is still the startup value (== old_limit), so
+        # this treats them as depth 0 - good enough, as other threads are
+        # typically shallow when setrecursionlimit is first called.
         d = old_limit - other.recursion_remaining
         other.recursion_remaining = new_limit - d
+    # arm the per-frame counter.  recursion_checking is quasi-immutable, so
+    # this flips the JIT-folded fast path in enter/leave to the counting path.
+    # Only write on the False->True transition, to invalidate the affected
+    # traces exactly once (setrecursionlimit may be called repeatedly).
+    if not armed:
+        space.actionflag.recursion_checking = True
 
 def getrecursionlimit(space):
     """Return the last value set by setrecursionlimit().

--- a/pypy/module/sys/vm.py
+++ b/pypy/module/sys/vm.py
@@ -96,39 +96,40 @@ _stack_check_noinline._dont_inline_ = True
 @jit.dont_look_inside
 @unwrap_spec(new_limit="c_int")
 def setrecursionlimit(space, new_limit):
-    """setrecursionlimit() sets the maximum number of nested calls that
-can occur before a RecursionError is raised.  On PyPy the limit
-is approximative and checked at a lower level.  The default 1000
-reserves 768KB of stack space, which should suffice (on Linux,
-depending on the compiler settings) for ~1400 calls.  Setting the
-value to N reserves N/1000 times 768KB of stack space.
+    """setrecursionlimit() sets the maximum number of nested Python calls
+that can occur before a RecursionError is raised.
 
-Note that there are other factors that also limit the stack size.
-The operating system typically sets a maximum which can be changed
-manually (e.g. with "ulimit" on Linux) for the main thread.  For other
-threads you can configure the limit by calling "threading.stack_size()".
+On PyPy the limit counts Python frames, like CPython.  A separate lower-
+level check on the C stack still guards against segfaults; the C stack is
+grown to fit the limit but never shrunk below the default.
 """
     from rpython.rlib.rstack import _stack_set_length_fraction
-    from rpython.rlib.rstackovf import StackOverflow
     from rpython.rlib.rgc import increase_root_stack_depth
-    if new_limit <= 0:
-        raise oefmt(space.w_ValueError, "recursion limit must be positive")
-    # Some programs use very large values to mean "don't check, I want to
-    # use as much as possible and then segfault".  Add a silent upper bound
-    # of 10**6 here, because huge values cause huge shadowstacks to be
-    # allocated (or MemoryErrors).
-    if new_limit > 1000000:
-        new_limit = 1000000
-    try:
-        _stack_set_length_fraction(new_limit * 0.001)
-        _stack_check_noinline()
-    except StackOverflow:
-        old_limit = space.sys.recursionlimit
-        _stack_set_length_fraction(old_limit * 0.001)
+    if new_limit < 1:
+        raise oefmt(space.w_ValueError,
+                    "recursion limit must be greater or equal than 1")
+    ec = space.getexecutioncontext()
+    old_limit = space.sys.recursionlimit
+    depth = old_limit - ec.recursion_remaining
+    if depth >= new_limit:
         raise oefmt(space.w_RecursionError,
-                "cannot set the recursion limit to %s at the recursion depth: the limit is too low")
+                    "cannot set the recursion limit to %d at the recursion "
+                    "depth %d: the limit is too low", new_limit, depth)
+    # grow (never shrink) the C stack so new_limit frames fit
+    c_limit = new_limit
+    if c_limit > 1000000:
+        c_limit = 1000000
+    fraction = c_limit * 0.001
+    if fraction < 1.0:
+        fraction = 1.0
+    _stack_set_length_fraction(fraction)
+    increase_root_stack_depth(int(fraction * 163840))
+    # publish the shared limit and re-derive each thread's remaining count,
+    # preserving its current depth (cf. CPython's Py_SetRecursionLimit)
     space.sys.recursionlimit = new_limit
-    increase_root_stack_depth(int(new_limit * 0.001 * 163840))
+    for other in space.threadlocals.getallvalues().values():
+        d = old_limit - other.recursion_remaining
+        other.recursion_remaining = new_limit - d
 
 def getrecursionlimit(space):
     """Return the last value set by setrecursionlimit().

--- a/pypy/objspace/fake/objspace.py
+++ b/pypy/objspace/fake/objspace.py
@@ -577,4 +577,5 @@ FakeObjSpace.sys = FakeModule()
 FakeObjSpace.sys.filesystemencoding = 'foobar'
 FakeObjSpace.sys.defaultencoding = 'ascii'
 FakeObjSpace.sys.dlopenflags = 123
+FakeObjSpace.sys.recursionlimit = 4321
 FakeObjSpace.builtin = FakeModule()


### PR DESCRIPTION
Until now the `sys.setrecursionlimit` and `sys.getrecursionlimit` interfaces on CPython relate to python frame depth, but on PyPy related to the c stack depth. In 238c2946b2c, I change the C stack overflow check to actually get the stack size at startup and check that the interpreter is not running out of stack. This check happens on almost every function call. This PR extends that work to check the pytohn frame depth for CPython compatibility. It means we have a new execution context attribute `recursion_remaining`, and check on entering every frame that the value is valid. By setting it high and decrementing, we do not need to look up the limit each time, we only decrement and check `>=0`. When exiting a frame we increment the value.

This does add some overhead, I want to benchmark to see how much.