### PR TITLE
use tar.gz compression (issue 5353)

### DIFF
--- a/pypy/tool/release/check_versions.py
+++ b/pypy/tool/release/check_versions.py
@@ -12,7 +12,10 @@ Can be run as check_versions.py <filename>, in which case it will check the file
 https://buildbot.pypy.org/mirror/
 """
 
+import argparse
+import hashlib
 import json
+import re
 from urllib import request, error
 import sys
 import time
@@ -31,6 +34,59 @@ def assert_different(a, b):
 def assert_in(a, b):
     if a not in b:
         raise ValueError(f"'{a}' not in '{b}'")
+
+
+# A checksums entry is a '<sha256>  <filename>' pair. Match those directly so
+# the same parser works on both the reStructuredText source and the rendered
+# HTML at https://pypy.org/checksums, where each block's first line is glued to
+# the surrounding <pre> markup and would not survive a naive line.split().
+_CHECKSUM_RE = re.compile(r'([0-9a-fA-F]{64})[ \t]+(pypy[^\s<]+)')
+
+
+def parse_checksums(text):
+    """Parse a checksums document into {filename: sha256}.
+
+    Works on both the checksums.rst source and the rendered HTML page, since we
+    extract every '<sha256>  <filename>' pair and ignore any surrounding markup.
+    """
+    checksums = {}
+    for digest, filename in _CHECKSUM_RE.findall(text):
+        checksums[filename] = digest.lower()
+    return checksums
+
+
+# sha256-verify only downloads from releases made within this many days, so a
+# routine run does not re-download the entire back-catalogue of releases.
+CHECKSUM_MAX_AGE_DAYS = 31
+
+
+def released_recently(d, now=None):
+    """True if release entry d has a 'date' within CHECKSUM_MAX_AGE_DAYS of now."""
+    date = d.get('date')
+    if not date:
+        return False
+    try:
+        released = time.mktime(time.strptime(date, "%Y-%m-%d"))
+    except ValueError:
+        return False
+    if now is None:
+        now = time.time()
+    return 0 <= (now - released) <= CHECKSUM_MAX_AGE_DAYS * 24 * 60 * 60
+
+
+def load_checksums(source):
+    """Load checksums from a local path or an http(s) URL, or None if not given."""
+    if source is None:
+        return None
+    if source.startswith('http://') or source.startswith('https://'):
+        text = request.urlopen(source).read().decode('utf-8')
+    else:
+        with open(source) as fid:
+            text = fid.read()
+    checksums = parse_checksums(text)
+    if not checksums:
+        raise ValueError(f"no sha256 checksums found in '{source}'")
+    return checksums
 
 
 pypy_versions = {
@@ -195,7 +251,8 @@ def check_tags(data):
             raise ValueError(f"could not find {tag}' on github. Does the tag exist (forgotten git push --tags)?") from None
         assert_equal(r.getcode(), 200)
 
-def check_versions(data, url, verbose=0, check_times=True, nightly_only=False):
+def check_versions(data, url, verbose=0, check_times=True, nightly_only=False,
+                   checksums=None):
     for d in data:
         if verbose > 0:
             print(f"checking {d['python_version']} {d['pypy_version']}")
@@ -275,24 +332,62 @@ def check_versions(data, url, verbose=0, check_times=True, nightly_only=False):
                     raise ValueError(f"expected {modified_time_str} to be within 2 weeks of {target}")
                 else:
                     print(f" {delta_days} days", end='')
+            if checksums is not None and released_recently(d):
+                # Real verification of the hosted bytes against the trusted
+                # checksums (e.g. from https://pypy.org/checksums). We only do
+                # this for recently-released files to avoid re-downloading the
+                # whole back-catalogue on every run.
+                expected = checksums.get(f['filename'])
+                if expected is None:
+                    raise ValueError(
+                        f"no sha256 for '{f['filename']}' in the checksums file")
+                actual = hashlib.sha256(r.read()).hexdigest()
+                if actual != expected:
+                    raise ValueError(
+                        f"sha256 mismatch for '{f['filename']}': "
+                        f"hosted {actual} != checksums {expected}")
+                if verbose > 0:
+                    print(' sha256-ok', end='')
             if verbose > 0:
                 print(f' ok')
         if verbose > 0:
             print(f"{d['python_version']} {d['pypy_version']} ok")
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        print(f'checking local file "{sys.argv[1]}"')
-        with open(sys.argv[1]) as fid:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        'filename', nargs='?',
+        help="local versions.json to check against https://buildbot.pypy.org/mirror/; "
+             "if omitted, download versions.json from buildbot and check "
+             "https://downloads.python.org/pypy/")
+    parser.add_argument(
+        '--nightly-only', action='store_true',
+        help="only check the nightly builds")
+    parser.add_argument(
+        '--checksums', metavar='PATH_OR_URL',
+        default='https://pypy.org/checksums',
+        help="checksums file (local path or http(s) URL) holding the trusted "
+             "sha256 values; defaults to %(default)s. Files from releases made in "
+             f"the last {CHECKSUM_MAX_AGE_DAYS} days are downloaded and their "
+             "sha256 is verified against it. Pass an empty string to skip "
+             "checksum verification")
+    args = parser.parse_args()
+
+    checksums = load_checksums(args.checksums or None)
+
+    if args.filename:
+        print(f'checking local file "{args.filename}"')
+        with open(args.filename) as fid:
             data = json.loads(fid.read())
-        nightly_only = '--nightly-only' in sys.argv
         check_versions(data, 'https://buildbot.pypy.org/mirror/', verbose=1,
-                       nightly_only=nightly_only)
+                       nightly_only=args.nightly_only, checksums=checksums)
     else:
         print('downloading versions.json')
         response = request.urlopen('https://buildbot.pypy.org/pypy/versions.json')
         assert_equal(response.getcode(), 200)
         data = json.loads(response.read())
-        check_versions(data, None, verbose=1)
+        check_versions(data, None, verbose=1, checksums=checksums)
     check_tags(data)
     print('ok')

--- a/pypy/tool/release/package.py
+++ b/pypy/tool/release/package.py
@@ -309,20 +309,25 @@ def create_package(basedir, options, _fake=False):
                     zf.write(filename)
             zf.close()
         else:
-            archive = str(builddir.join(name + '.tar.bz2'))
+            archive = str(builddir.join(name + '.tar.gz'))
+            # Pipe through 'gzip -9 -n' rather than tar's --use-compress-program:
+            # the latter cannot pass arguments to the compressor before GNU tar
+            # 1.30, and the build images ship 1.26, so we cannot request -9 that
+            # way. Piping is version-independent and works with bsdtar too.
+            gzip_pipe = ' -cf - ' + name + ' | gzip -9 -n > ' + archive
             if ARCH == 'darwin':
                 print("Warning: tar on current platform does not suport "
                       "overriding the uid and gid for its contents. The tarball "
                       "will contain your uid and gid. If you are building the "
                       "actual release for the PyPy website, you may want to be "
                       "using another platform...", file=sys.stderr)
-                e = os.system('tar --numeric-owner -cjf ' + archive + " " + name)
+                e = os.system('tar --numeric-owner' + gzip_pipe)
             elif sys.platform.startswith('freebsd'):
-                e = os.system('tar --uname=root --gname=wheel -cjf ' + archive + " " + name)
+                e = os.system('tar --uname=root --gname=wheel' + gzip_pipe)
             elif sys.platform == 'cygwin':
-                e = os.system('tar --owner=Administrator --group=Administrators --numeric-owner -cjf ' + archive + " " + name)
+                e = os.system('tar --owner=Administrator --group=Administrators --numeric-owner' + gzip_pipe)
             else:
-                e = os.system('tar --owner=root --group=root --numeric-owner -cjf ' + archive + " " + name)
+                e = os.system('tar --owner=root --group=root --numeric-owner' + gzip_pipe)
             if e:
                 raise OSError('"tar" returned exit status %r' % e)
     finally:

--- a/pypy/tool/release/repackage.sh
+++ b/pypy/tool/release/repackage.sh
@@ -62,24 +62,24 @@ function repackage_builds {
     for plat in linux linux64 macos_x86_64 macos_arm64 aarch64
       do
         echo downloading package for $plat
-        if wget -q --show-progress http://buildbot.pypy.org/nightly/$branchname/pypy-c-jit-latest-$plat.tar.bz2
+        if wget -q --show-progress http://buildbot.pypy.org/nightly/$branchname/pypy-c-jit-latest-$plat.tar.gz
         then
-            echo $plat downloaded 
+            echo $plat downloaded
         else
             echo $plat no download available
             continue
         fi
-        gitcheck=`tar -tf pypy-c-jit-latest-$plat.tar.bz2 |head -n1 | cut -d- -f5`
+        gitcheck=`tar -tf pypy-c-jit-latest-$plat.tar.gz |head -n1 | cut -d- -f5`
         if [ "$gitcheck" != "$githash" ]
         then
             echo xxxxxxxxxxxxxxxxxxxxxx
             echo $plat git short hash mismatch, expected $githash, got $gitcheck
             echo xxxxxxxxxxxxxxxxxxxxxx
-            rm pypy-c-jit-latest-$plat.tar.bz2
+            rm pypy-c-jit-latest-$plat.tar.gz
             continue
         fi
-        tar -xf pypy-c-jit-latest-$plat.tar.bz2
-        rm pypy-c-jit-latest-$plat.tar.bz2
+        tar -xf pypy-c-jit-latest-$plat.tar.gz
+        rm pypy-c-jit-latest-$plat.tar.gz
 
         # Check that this is the correct version
         if [ "$pmin" == "7" ] # python2.7, 3.7
@@ -105,11 +105,13 @@ function repackage_builds {
         fi
         mv pypy-c-jit-*-$plat $rel-$plat_final
         echo packaging $plat_final
+        # Pipe through 'gzip -9 -n': tar's --use-compress-program cannot pass
+        # arguments to the compressor before GNU tar 1.30.
         if [[ "$OSTYPE" == darwin* ]]; then
             # install gtar with brew install gnu-tar
-            gtar --owner=root --group=root --numeric-owner -cjf $rel-$plat_final.tar.bz2 $rel-$plat_final
+            gtar --owner=root --group=root --numeric-owner -cf - $rel-$plat_final | gzip -9 -n > $rel-$plat_final.tar.gz
         else
-            tar --owner=root --group=root --numeric-owner -cjf $rel-$plat_final.tar.bz2 $rel-$plat_final
+            tar --owner=root --group=root --numeric-owner -cf - $rel-$plat_final | gzip -9 -n > $rel-$plat_final.tar.gz
         fi
         rm -rf $rel-$plat_final
       done
@@ -152,13 +154,13 @@ function repackage_source {
     echo "node: $githash" > ../.hg_archival.txt
     echo "branch: $branchname" >> ../.hg_archival.txt
     echo "tag: $tagname" >> ../.hg_archival.txt
-    git config tar.tar.bz2.command "bzip2 -c"
-    $(cd ..; git archive --prefix $rel-src/ --add-file=.hg_archival.txt --output=${cwd}/$rel-src.tar.bz2 $tagname)
+    git config tar.tar.gz.command "gzip -9 -cn"
+    $(cd ..; git archive --prefix $rel-src/ --add-file=.hg_archival.txt --output=${cwd}/$rel-src.tar.gz $tagname)
     $(cd ..; git archive --prefix $rel-src/ --add-file=.hg_archival.txt --output=${cwd}/$rel-src.zip $tagname)
 }
 
 function print_sha256 {
-    sha256sum *.bz2 *.zip
+    sha256sum *.gz *.zip
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
@@ -168,5 +170,5 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     repackage_source
     print_sha256
 fi
-# Now upload all the bz2 and zip
+# Now upload all the gz and zip
 echo don\'t forget to push the tags "git push --tags"

--- a/pypy/tool/release/test/test_package.py
+++ b/pypy/tool/release/test/test_package.py
@@ -39,8 +39,8 @@ class TestPackaging:
             zh = zipfile.ZipFile(str(builddir.join('%s.zip' % test)))
             assert zh.open('%s/lib_pypy/syslog.py' % test)
         else:
-            th = tarfile.open(str(builddir.join('%s.tar.bz2' % test)))
-            syslog = th.getmember('%s/lib_pypy/syslog.py' % test)
+            th = tarfile.open(str(builddir.join('%s.tar.gz' % test)))
+            syslog = th.getmember('%s/lib_pypy/syslog.py' % (test))
             exe = th.getmember('%s/%s' % (test, self.exe_name_in_archive))
             assert syslog.mode == 0644
             assert exe.mode == 0755

--- a/pypy/tool/release/versions.json
+++ b/pypy/tool/release/versions.json
@@ -4177,7 +4177,7 @@
         "download_url": "https://downloads.python.org/pypy/pypy3.6-v7.3.3rc1-aarch64.tar.bz2"
       },
       {
-        "filename": "pypy3.6-v7.3.3-linux32rc1.tar.bz2",
+        "filename": "pypy3.6-v7.3.3rc1-linux32.tar.bz2",
         "arch": "i686",
         "platform": "linux",
         "download_url": "https://downloads.python.org/pypy/pypy3.6-v7.3.3rc1-linux32.tar.bz2"
@@ -4195,7 +4195,7 @@
         "download_url": "https://downloads.python.org/pypy/pypy3.6-v7.3.3rc1-osx64.tar.bz2"
       },
       {
-        "filename": "pypy3.6-v7.3.3-win32rc1.zip",
+        "filename": "pypy3.6-v7.3.3rc1-win32.zip",
         "arch": "x86",
         "platform": "win32",
         "download_url": "https://downloads.python.org/pypy/pypy3.6-v7.3.3rc1-win32.zip"
@@ -4474,194 +4474,6 @@
         "arch": "x64",
         "platform": "win64",
         "download_url": "https://buildbot.pypy.org/nightly/main/pypy-c-jit-latest-win64.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-s390x.tar.bz2",
-        "arch": "s390x",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/main/pypy-c-jit-latest-s390x.tar.bz2"
-      }
-    ]
-  },
-  {
-    "pypy_version": "nightly",
-    "python_version": "3.7",
-    "stable": false,
-    "latest_pypy": false,
-    "files": [
-      {
-        "filename": "pypy-c-jit-latest-aarch64.tar.bz2",
-        "arch": "aarch64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-aarch64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux.tar.bz2",
-        "arch": "i686",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-linux.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux64.tar.bz2",
-        "arch": "x64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-linux64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-win64.zip",
-        "arch": "x64",
-        "platform": "win64",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-win64.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-win32.zip",
-        "arch": "x86",
-        "platform": "win32",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-win32.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-s390x.tar.bz2",
-        "arch": "s390x",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-s390x.tar.bz2"
-      }
-    ]
-  },
-  {
-    "pypy_version": "nightly",
-    "python_version": "3.6",
-    "stable": false,
-    "latest_pypy": false,
-    "files": [
-      {
-        "filename": "pypy-c-jit-latest-aarch64.tar.bz2",
-        "arch": "aarch64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-aarch64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux.tar.bz2",
-        "arch": "i686",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-linux.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux64.tar.bz2",
-        "arch": "x64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-linux64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-win32.zip",
-        "arch": "x86",
-        "platform": "win32",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-win32.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-s390x.tar.bz2",
-        "arch": "s390x",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-s390x.tar.bz2"
-      }
-    ]
-  },
-  {
-    "pypy_version": "nightly",
-    "python_version": "3.8",
-    "stable": false,
-    "latest_pypy": false,
-    "files": [
-      {
-        "filename": "pypy-c-jit-latest-aarch64.tar.bz2",
-        "arch": "aarch64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-aarch64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux.tar.bz2",
-        "arch": "i686",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-linux.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux64.tar.bz2",
-        "arch": "x64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-linux64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-macos_x86_64.tar.bz2",
-        "arch": "x64",
-        "platform": "darwin",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-macos_x86_64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-macos_arm64.tar.bz2",
-        "arch": "arm64",
-        "platform": "darwin",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-macos_arm64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-win64.zip",
-        "arch": "x64",
-        "platform": "win64",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-win64.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-s390x.tar.bz2",
-        "arch": "s390x",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-s390x.tar.bz2"
-      }
-    ]
-  },
-  {
-    "pypy_version": "nightly",
-    "python_version": "3.9",
-    "stable": false,
-    "latest_pypy": false,
-    "files": [
-      {
-        "filename": "pypy-c-jit-latest-aarch64.tar.bz2",
-        "arch": "aarch64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-aarch64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux.tar.bz2",
-        "arch": "i686",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-linux.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-linux64.tar.bz2",
-        "arch": "x64",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-linux64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-macos_x86_64.tar.bz2",
-        "arch": "x64",
-        "platform": "darwin",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-macos_x86_64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-macos_arm64.tar.bz2",
-        "arch": "arm64",
-        "platform": "darwin",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-macos_arm64.tar.bz2"
-      },
-      {
-        "filename": "pypy-c-jit-latest-win64.zip",
-        "arch": "x64",
-        "platform": "win64",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-win64.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-s390x.tar.bz2",
-        "arch": "s390x",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.9/pypy-c-jit-latest-s390x.tar.bz2"
       }
     ]
   },
@@ -4706,12 +4518,6 @@
         "arch": "x64",
         "platform": "win64",
         "download_url": "https://buildbot.pypy.org/nightly/py3.10/pypy-c-jit-latest-win64.zip"
-      },
-      {
-        "filename": "pypy-c-jit-latest-s390x.tar.bz2",
-        "arch": "s390x",
-        "platform": "linux",
-        "download_url": "https://buildbot.pypy.org/nightly/py3.10/pypy-c-jit-latest-s390x.tar.bz2"
       }
     ]
   },

--- a/pypy/tool/release/versions.json
+++ b/pypy/tool/release/versions.json
@@ -7,34 +7,34 @@
     "date": "2026-05-26",
     "files": [
       {
-        "filename": "pypy3.11-v7.3.23-aarch64.tar.bz2",
+        "filename": "pypy3.11-v7.3.23-aarch64.tar.gz",
         "arch": "aarch64",
         "platform": "linux",
-        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-aarch64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-aarch64.tar.gz"
       },
       {
-        "filename": "pypy3.11-v7.3.23-linux32.tar.bz2",
+        "filename": "pypy3.11-v7.3.23-linux32.tar.gz",
         "arch": "i686",
         "platform": "linux",
-        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux32.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux32.tar.gz"
       },
       {
-        "filename": "pypy3.11-v7.3.23-linux64.tar.bz2",
+        "filename": "pypy3.11-v7.3.23-linux64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux64.tar.gz"
       },
       {
-        "filename": "pypy3.11-v7.3.23-macos_x86_64.tar.bz2",
+        "filename": "pypy3.11-v7.3.23-macos_x86_64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-macos_x86_64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-macos_x86_64.tar.gz"
       },
       {
-        "filename": "pypy3.11-v7.3.23-macos_arm64.tar.bz2",
+        "filename": "pypy3.11-v7.3.23-macos_arm64.tar.gz",
         "arch": "arm64",
         "platform": "darwin",
-        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-macos_arm64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-macos_arm64.tar.gz"
       },
       {
         "filename": "pypy3.11-v7.3.23-win64.zip",
@@ -52,34 +52,34 @@
     "date": "2026-05-26",
     "files": [
       {
-        "filename": "pypy2.7-v7.3.23-aarch64.tar.bz2",
+        "filename": "pypy2.7-v7.3.23-aarch64.tar.gz",
         "arch": "aarch64",
         "platform": "linux",
-        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-aarch64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-aarch64.tar.gz"
       },
       {
-        "filename": "pypy2.7-v7.3.23-linux32.tar.bz2",
+        "filename": "pypy2.7-v7.3.23-linux32.tar.gz",
         "arch": "i686",
         "platform": "linux",
-        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux32.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux32.tar.gz"
       },
       {
-        "filename": "pypy2.7-v7.3.23-linux64.tar.bz2",
+        "filename": "pypy2.7-v7.3.23-linux64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux64.tar.gz"
       },
       {
-        "filename": "pypy2.7-v7.3.23-macos_x86_64.tar.bz2",
+        "filename": "pypy2.7-v7.3.23-macos_x86_64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-macos_x86_64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-macos_x86_64.tar.gz"
       },
       {
-        "filename": "pypy2.7-v7.3.23-macos_arm64.tar.bz2",
+        "filename": "pypy2.7-v7.3.23-macos_arm64.tar.gz",
         "arch": "arm64",
         "platform": "darwin",
-        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-macos_arm64.tar.bz2"
+        "download_url": "https://downloads.python.org/pypy/pypy2.7-v7.3.23-macos_arm64.tar.gz"
       },
       {
         "filename": "pypy2.7-v7.3.23-win64.zip",


### PR DESCRIPTION
Use tar.gz compression when creating tarballs. Also clean up check_versions and remove non-existant nightly builds from the versions.json. I moved buildbot master to a new host and did not bother copying over the very old 3.6, 3.7, 3.8 and 3.9 nightlies as well as the s390x ones. Of course any historical releases are still available, just not nightly builds.