### PR TITLE
implement PEP709 inline comprehensions

### DIFF
--- a/lib-python/3/opcode.py
+++ b/lib-python/3/opcode.py
@@ -256,8 +256,8 @@ hasfree.append(139)
 # jrel_op('JUMP_BACKWARD', 140)    # Number of words to skip (backwards)
 # name_op('LOAD_SUPER_ATTR', 141)
 def_op('CALL_FUNCTION_EX', 142)  # Flags
-# def_op('LOAD_FAST_AND_CLEAR', 143)  # Local variable number
-# haslocal.append(143)
+def_op('LOAD_FAST_AND_CLEAR', 143)  # Local variable number
+haslocal.append(143)
 
 def_op('EXTENDED_ARG', 144)
 EXTENDED_ARG = 144

--- a/lib-python/3/test/test_compile.py
+++ b/lib-python/3/test/test_compile.py
@@ -1127,9 +1127,11 @@ class TestSpecifics(unittest.TestCase):
                 if y:
                     pass
 
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
         linenos = list(inst.positions.lineno
                        for inst in dis.get_instructions(f.__code__)
-                       if inst.opname == 'JUMP_BACKWARD')
+                       if inst.opname == jump_opname)
 
         self.assertTrue(len(linenos) > 0)
         self.assertTrue(all(l is not None for l in linenos))
@@ -1454,7 +1456,8 @@ class TestSourcePositions(unittest.TestCase):
         #  The "error msg":
         self.assertOpcodeSourcePositionIs(compiled_code, 'LOAD_CONST',
             line=3, end_line=3, column=19, end_column=30, occurrence=4)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'CALL',
+        call_opcode = 'CALL_FUNCTION' if sys.implementation.name == 'pypy' else 'CALL'
+        self.assertOpcodeSourcePositionIs(compiled_code, call_opcode,
             line=1, end_line=3, column=0, end_column=30, occurrence=1)
         self.assertOpcodeSourcePositionIs(compiled_code, 'RAISE_VARARGS',
             line=1, end_line=3, column=8, end_column=16, occurrence=1)
@@ -1473,10 +1476,18 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'YIELD_VALUE',
             line=1, end_line=2, column=1, end_column=8, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
-            line=1, end_line=2, column=1, end_column=8, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
-            line=4, end_line=4, column=7, end_column=14, occurrence=1)
+        if sys.implementation.name == 'pypy':
+            # PyPy: JUMP_ABSOLUTE, and the implicit return is LOAD_CONST +
+            # RETURN_VALUE spanning the whole genexp
+            self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_ABSOLUTE',
+                line=1, end_line=2, column=1, end_column=8, occurrence=1)
+            self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_VALUE',
+                line=1, end_line=6, column=0, end_column=32, occurrence=1)
+        else:
+            self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+                line=1, end_line=2, column=1, end_column=8, occurrence=1)
+            self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
+                line=4, end_line=4, column=7, end_column=14, occurrence=1)
 
     def test_multiline_async_generator_expression(self):
         snippet = textwrap.dedent("""\
@@ -1490,10 +1501,18 @@ class TestSourcePositions(unittest.TestCase):
         compiled_code, _ = self.check_positions_against_ast(snippet)
         compiled_code = compiled_code.co_consts[0]
         self.assertIsInstance(compiled_code, types.CodeType)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'YIELD_VALUE',
-            line=1, end_line=2, column=1, end_column=8, occurrence=2)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
-            line=1, end_line=6, column=0, end_column=32, occurrence=1)
+        if sys.implementation.name == 'pypy':
+            # PyPy awaits with YIELD_FROM, so the elt yield is the only
+            # YIELD_VALUE; the implicit return carries the elt position
+            self.assertOpcodeSourcePositionIs(compiled_code, 'YIELD_VALUE',
+                line=1, end_line=2, column=1, end_column=8, occurrence=1)
+            self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_VALUE',
+                line=1, end_line=2, column=1, end_column=8, occurrence=1)
+        else:
+            self.assertOpcodeSourcePositionIs(compiled_code, 'YIELD_VALUE',
+                line=1, end_line=2, column=1, end_column=8, occurrence=2)
+            self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
+                line=1, end_line=6, column=0, end_column=32, occurrence=1)
 
     def test_multiline_list_comprehension(self):
         snippet = textwrap.dedent("""\
@@ -1508,7 +1527,9 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'LIST_APPEND',
             line=1, end_line=2, column=1, end_column=8, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
+        self.assertOpcodeSourcePositionIs(compiled_code, jump_opname,
             line=1, end_line=2, column=1, end_column=8, occurrence=1)
 
     def test_multiline_async_list_comprehension(self):
@@ -1528,9 +1549,13 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'LIST_APPEND',
             line=2, end_line=3, column=5, end_column=12, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
+        self.assertOpcodeSourcePositionIs(compiled_code, jump_opname,
             line=2, end_line=3, column=5, end_column=12, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
+        return_opname = ('RETURN_VALUE' if sys.implementation.name == 'pypy'
+                         else 'RETURN_CONST')
+        self.assertOpcodeSourcePositionIs(compiled_code, return_opname,
             line=2, end_line=7, column=4, end_column=36, occurrence=1)
 
     def test_multiline_set_comprehension(self):
@@ -1546,7 +1571,9 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'SET_ADD',
             line=1, end_line=2, column=1, end_column=8, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
+        self.assertOpcodeSourcePositionIs(compiled_code, jump_opname,
             line=1, end_line=2, column=1, end_column=8, occurrence=1)
 
     def test_multiline_async_set_comprehension(self):
@@ -1566,9 +1593,13 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'SET_ADD',
             line=2, end_line=3, column=5, end_column=12, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
+        self.assertOpcodeSourcePositionIs(compiled_code, jump_opname,
             line=2, end_line=3, column=5, end_column=12, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
+        return_opname = ('RETURN_VALUE' if sys.implementation.name == 'pypy'
+                         else 'RETURN_CONST')
+        self.assertOpcodeSourcePositionIs(compiled_code, return_opname,
             line=2, end_line=7, column=4, end_column=36, occurrence=1)
 
     def test_multiline_dict_comprehension(self):
@@ -1584,7 +1615,9 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'MAP_ADD',
             line=1, end_line=2, column=1, end_column=7, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
+        self.assertOpcodeSourcePositionIs(compiled_code, jump_opname,
             line=1, end_line=2, column=1, end_column=7, occurrence=1)
 
     def test_multiline_async_dict_comprehension(self):
@@ -1604,9 +1637,13 @@ class TestSourcePositions(unittest.TestCase):
         self.assertIsInstance(compiled_code, types.CodeType)
         self.assertOpcodeSourcePositionIs(compiled_code, 'MAP_ADD',
             line=2, end_line=3, column=5, end_column=11, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'JUMP_BACKWARD',
+        jump_opname = ('JUMP_ABSOLUTE' if sys.implementation.name == 'pypy'
+                       else 'JUMP_BACKWARD')
+        self.assertOpcodeSourcePositionIs(compiled_code, jump_opname,
             line=2, end_line=3, column=5, end_column=11, occurrence=1)
-        self.assertOpcodeSourcePositionIs(compiled_code, 'RETURN_CONST',
+        return_opname = ('RETURN_VALUE' if sys.implementation.name == 'pypy'
+                         else 'RETURN_CONST')
+        self.assertOpcodeSourcePositionIs(compiled_code, return_opname,
             line=2, end_line=7, column=4, end_column=36, occurrence=1)
 
     def test_matchcase_sequence(self):

--- a/pypy/interpreter/astcompiler/assemble.py
+++ b/pypy/interpreter/astcompiler/assemble.py
@@ -688,7 +688,7 @@ class PythonCodeMaker(ast.ASTVisitor):
                     continue
                 encode_single_position(table, instr.position_info, self.first_lineno)
                 for extra in range((instr.size() - 2) // 2):
-                    encode_single_position(table, UNKNOWN_POSITION, self.first_lineno)
+                    encode_single_position(table, instr.position_info, self.first_lineno)
         return table.build()
 
     def _build_code(self, blocks, size):
@@ -744,14 +744,18 @@ class PythonCodeMaker(ast.ASTVisitor):
         # CPython equivalent: guarantee_lineno_for_exits (compile.c).
         # After propagate_line_numbers, any block ending in RETURN_VALUE whose
         # last instruction is still UNSET gets the running lineno assigned to
-        # all its UNSET instructions.
+        # all its UNSET instructions.  Likewise for JUMP_ABSOLUTE: backward
+        # jumps must carry a line number for tracing (CPython gh-107901); a
+        # loop back-jump can remain unset when its block has several
+        # predecessors.
         lineno = self.first_lineno
         for block in blocks:
             if not block.instructions:
                 continue
             last = block.instructions[-1]
             if last.position_info[0] < 0:
-                if last.opcode == ops.RETURN_VALUE:
+                if last.opcode == ops.RETURN_VALUE or \
+                        last.opcode == ops.JUMP_ABSOLUTE:
                     for instr in block.instructions:
                         if instr.position_info[0] < 0:
                             instr.position_info = (lineno,
@@ -1553,6 +1557,7 @@ _static_opcode_stack_effects = {
     ops.DELETE_NAME: 0,
 
     ops.LOAD_FAST: 1,
+    ops.LOAD_FAST_AND_CLEAR: 1,
     ops.STORE_FAST: -1,
     ops.DELETE_FAST: 0,
 

--- a/pypy/interpreter/astcompiler/codegen.py
+++ b/pypy/interpreter/astcompiler/codegen.py
@@ -130,6 +130,7 @@ class __extend__(ast.GeneratorExp):
 
     def accept_comp_iteration(self, codegen, index):
         self.elt.walkabout(codegen)
+        codegen.update_position(self.elt)
         codegen.emit_op(ops.YIELD_VALUE)
         codegen.emit_op(ops.POP_TOP)
 
@@ -155,6 +156,7 @@ class __extend__(ast.ListComp):
 
     def accept_comp_iteration(self, codegen, index):
         self.elt.walkabout(codegen)
+        codegen.update_position(self.elt)
         codegen.emit_op_arg(ops.LIST_APPEND, index + 1)
 
 
@@ -169,6 +171,7 @@ class __extend__(ast.SetComp):
 
     def accept_comp_iteration(self, codegen, index):
         self.elt.walkabout(codegen)
+        codegen.update_position(self.elt)
         codegen.emit_op_arg(ops.SET_ADD, index + 1)
 
 
@@ -184,6 +187,10 @@ class __extend__(ast.DictComp):
     def accept_comp_iteration(self, codegen, index):
         self.key.walkabout(codegen)
         self.value.walkabout(codegen)
+        # start of the key through end of the value, like CPython
+        codegen.update_position((self.key.lineno, self.value.end_lineno,
+                                 self.key.col_offset,
+                                 self.value.end_col_offset))
         codegen.emit_op_arg(ops.MAP_ADD, index + 1)
 
 
@@ -255,6 +262,9 @@ class PythonCodeGenerator(assemble.PythonCodeMaker):
         self.frame_blocks = []
         self.interactive = False
         self.temporary_name_counter = 1
+        # PEP 709: names forced to fast locals while compiling an inlined
+        # comprehension in a non-function scope (CPython's u_fasthidden)
+        self.fasthidden = {}
         self.qualname = qualname
         self._allow_top_level_await = compile_info.flags & consts.PyCF_ALLOW_TOP_LEVEL_AWAIT
         self._compile(tree)
@@ -403,6 +413,11 @@ class PythonCodeGenerator(assemble.PythonCodeMaker):
         """Generate an operation appropriate for the scope of the identifier."""
         # node is used only for the possible syntax error
         self.check_forbidden_name(identifier, node, ctx)
+
+        if self.fasthidden.get(identifier, False):
+            self.emit_op_arg(name_ops_fast(ctx),
+                             self.add_name(self.var_names, identifier))
+            return
 
         scope = self.scope.lookup(identifier)
         op = ops.NOP
@@ -2246,16 +2261,113 @@ class PythonCodeGenerator(assemble.PythonCodeMaker):
 
         self._emit_async_for_handler(b_except, b_reraise, b_end)
 
+    def _restore_inlined_comp_locals(self, indices):
+        # stack: [saved_rotated..., tos] where tos is the result (normal path)
+        # or the exception (cleanup path); rotate tos below the saved values
+        # and store them back in reverse order, as in CPython's
+        # restore_inlined_comprehension_locals
+        n = len(indices)
+        if n == 0:      # e.g. "for () in it": nothing was saved
+            return
+        self.emit_op_arg(ops.SWAP, n + 1)
+        i = n - 1
+        while i >= 0:
+            self.emit_op_arg(ops.STORE_FAST, indices[i])
+            i -= 1
+
+    def _compile_inlined_comprehension(self, node, comp_scope):
+        # PEP 709: emit the comprehension body directly in this scope.  The
+        # names bound by the comprehension are isolated from the enclosing
+        # scope by saving+clearing them (LOAD_FAST_AND_CLEAR) and restoring
+        # them after, also on exception, matching CPython.  The saved values
+        # live at the bottom of the region and do not affect the loop's
+        # stack layout.
+        self.update_position(node)
+        saved_depth = self._stack_depth
+        first = node.get_generators()[0]
+        assert isinstance(first, ast.comprehension)
+        first.iter.walkabout(self)
+        if first.is_async:
+            self.emit_op(ops.GET_AITER)
+        else:
+            self.emit_op(ops.GET_ITER)
+        indices = []
+        bound_names = comp_scope.inlined_bound_names
+        assert bound_names is not None   # set when comp_inlined was set
+        # a name that resolves to anything but a plain fast local outside the
+        # comprehension (module dict, global, cell made by a sibling closure,
+        # closure) gets a fast-hidden slot while compiling the body
+        # (CPython's temp-symbols swap / u_fasthidden)
+        hidden_names = []
+        for name in bound_names:
+            index = self.add_name(self.var_names, name)
+            self.emit_op_arg(ops.LOAD_FAST_AND_CLEAR, index)
+            indices.append(index)
+            if not self.scope.can_be_optimized or \
+                    self.scope.lookup(name) != symtable.SCOPE_LOCAL:
+                hidden_names.append(name)
+        for name in hidden_names:
+            self.fasthidden[name] = True
+        n = len(indices)
+        # stack: [iter, saved1..savedN]; rotate the iterator back to the top
+        # (this leaves the saved values rotated, undone on restore)
+        if n:
+            self.emit_op_arg(ops.SWAP, n + 1)
+        # protect build+loop so that on exception the saved locals are
+        # restored before reraising
+        cleanup = self.new_block()
+        end = self.new_block()
+        self.emit_jump(_SETUP_FINALLY, cleanup)
+        if isinstance(node, ast.ListComp):
+            if len(node.get_generators()) == 1 and not first.ifs:
+                # preallocate via __length_hint__; [.., iter] -> [.., list, iter]
+                self.emit_op(ops.BUILD_LIST_FROM_ARG)
+            else:
+                self.emit_op_arg(ops.BUILD_LIST, 0)
+                self.emit_op_arg(ops.SWAP, 2)
+        elif isinstance(node, ast.SetComp):
+            self.emit_op_arg(ops.BUILD_SET, 0)
+            self.emit_op_arg(ops.SWAP, 2)
+        else:
+            assert isinstance(node, ast.DictComp)
+            self.emit_op_arg(ops.BUILD_MAP, 0)
+            self.emit_op_arg(ops.SWAP, 2)
+        # stack: [saved..., result, iter]
+        self._comp_generator(node, node.get_generators())
+        # like visit_For: FOR_ITER exhaustion popped the iterator, the linear
+        # counter is stale here; stack is [saved..., result]
+        self._stack_depth = saved_depth + n + 1
+        self.no_position_info()
+        self.emit_op(_POP_BLOCK)
+        self.emit_jump_noline(ops.JUMP_FORWARD, end)
+        # cleanup: [saved..., result, exc]; drop the incomplete result,
+        # restore the saved locals, reraise
+        self.use_next_block(cleanup)
+        self.emit_op_arg(ops.SWAP, 2)
+        self.emit_op(ops.POP_TOP)
+        self.update_position(node)
+        self._restore_inlined_comp_locals(indices)
+        self.emit_op_arg(ops.RERAISE, 0)
+        # end: [saved..., result]
+        self.use_next_block(end)
+        self._stack_depth = saved_depth + n + 1
+        self._restore_inlined_comp_locals(indices)
+        for name in hidden_names:
+            self.fasthidden[name] = False
+
     def _compile_comprehension(self, node, name, sub_scope):
-        is_async_function = self.scope.is_coroutine
-        code, qualname = self.sub_scope(sub_scope, name, node, node.lineno)
-        is_async_comprehension = self.symbols.find_scope(node).is_coroutine
+        comp_scope = self.symbols.find_scope(node)
+        is_async_comprehension = comp_scope.is_coroutine
         if is_async_comprehension and not self._check_async_function():
             if (not isinstance(node, ast.GeneratorExp) and
                     not isinstance(self.scope, symtable.AsyncFunctionScope) and
                     not isinstance(self.scope, symtable.ComprehensionScope)):
                 self.error("asynchronous comprehension outside of "
                            "an asynchronous function", node)
+        if comp_scope.comp_inlined:
+            self._compile_inlined_comprehension(node, comp_scope)
+            return
+        code, qualname = self.sub_scope(sub_scope, name, node, node.lineno)
 
         self.update_position(node)
         self._make_function(code, qualname=qualname)

--- a/pypy/interpreter/astcompiler/symtable.py
+++ b/pypy/interpreter/astcompiler/symtable.py
@@ -44,6 +44,15 @@ class Scope(object):
     can_be_optimized = False
     is_coroutine = False
     class_entry = None  # Set by AnnotationScope for class scope visibility
+    # PEP 709; defined here so plain attribute reads work on any Scope (no
+    # getattr in RPython).  maybe_inline/comp_inlined/inlined_bound_names are
+    # set on ComprehensionScope; comp_private_names is set on the enclosing
+    # scope: names known here only through an inlined comprehension, which
+    # must stay invisible to sibling child scopes.
+    maybe_inline = False
+    comp_inlined = False
+    inlined_bound_names = None
+    comp_private_names = None
 
     def __init__(self, name, lineno=0, col_offset=0):
         self.lineno = lineno
@@ -237,8 +246,89 @@ class Scope(object):
 
     _hide_bound_from_nested_scopes = False
 
+    def _inline_comprehension_children_module(self):
+        """PEP 709 at module level: comprehension-bound names become
+        fast-hidden locals, disjoint from the module dict, so no role merge
+        and no name-conflict or sibling-scope concerns apply (sibling scopes
+        reach module names through globals, never through cells)."""
+        for child in self.children:
+            if not isinstance(child, ComprehensionScope):
+                continue
+            if not child.maybe_inline or child.children:
+                continue
+            if child.is_coroutine:
+                # async comprehension with top-level await: keep the old path
+                continue
+            bound_names = []
+            for name, flags in child.roles.iteritems():
+                if name == '.0':
+                    continue
+                if flags & SYM_ASSIGNED and \
+                        not flags & (SYM_GLOBAL | SYM_NONLOCAL):
+                    bound_names.append(name)
+            child.inlined_bound_names = bound_names
+            child.comp_inlined = True
+
+    def _inline_comprehension_children(self):
+        """PEP 709: fold simple list/set/dict comprehension children into this
+        scope so their bodies can be emitted inline by the code generator."""
+        if isinstance(self, ModuleScope):
+            self._inline_comprehension_children_module()
+            return
+        if not isinstance(self, FunctionScope) or \
+                isinstance(self, AnnotationScope):
+            return
+        for child in self.children:
+            # A comprehension containing its own nested scopes would need
+            # per-execution cells (MAKE_CELL); keep those on the old path.
+            # Other siblings (functions, lambdas, genexprs) are fine: names
+            # merged from inlined comprehensions stay invisible to them.
+            if not isinstance(child, ComprehensionScope) or \
+                    not child.maybe_inline or child.children:
+                continue
+            bound_names = []
+            for name, flags in child.roles.iteritems():
+                if name == '.0':
+                    continue
+                if flags & (SYM_GLOBAL | SYM_NONLOCAL):
+                    # walrus target: resolves (and escapes) via this scope,
+                    # visit_NamedExpr already noted it here
+                    continue
+                pflags = self.roles.get(name, SYM_BLANK)
+                if flags & SYM_ASSIGNED:
+                    if pflags == SYM_BLANK or \
+                            (pflags & (SYM_BOUND | SYM_ANNOTATED) and
+                             not pflags & (SYM_GLOBAL | SYM_NONLOCAL)):
+                        # unknown here, or a local here too: share the slot.
+                        # Purely comp-private names must stay invisible to
+                        # sibling child scopes (they resolve as globals
+                        # there, like CPython).
+                        if pflags == SYM_BLANK:
+                            if self.comp_private_names is None:
+                                self.comp_private_names = {}
+                            self.comp_private_names[name] = None
+                        self.roles[name] = pflags | \
+                                (flags & (SYM_ASSIGNED | SYM_USED))
+                        bound_names.append(name)
+                    else:
+                        # used/global/nonlocal here but bound in the
+                        # comprehension: the code generator compiles it to a
+                        # fast-hidden slot inside the comprehension
+                        # (CPython's temp-symbols swap), leaving resolution
+                        # outside unchanged
+                        bound_names.append(name)
+                else:
+                    # merely used in the comprehension: resolves via this
+                    # scope
+                    self.roles[name] = pflags | (flags & SYM_USED)
+            # save/restore order is the roles insertion order, which is
+            # deterministic (RPython dicts and the host's are both ordered)
+            child.inlined_bound_names = bound_names
+            child.comp_inlined = True
+
     def finalize(self, bound, free, globs, typeparams):
         """Enter final bookeeping data in to self.symbols."""
+        self._inline_comprehension_children()
         self.symbols = {}
         local = {}
         new_globs = {}
@@ -258,8 +348,22 @@ class Scope(object):
             self._pass_on_bindings(local, bound, globs, new_bound, new_globs)
         else:
             self._pass_special_names(local, new_bound)
+        if self.comp_private_names is not None:
+            # names local here only because of an inlined comprehension are
+            # invisible to child scopes; in them they resolve as globals
+            for name in self.comp_private_names:
+                if name in new_bound:
+                    del new_bound[name]
         child_frees = {}
         for child in self.children:
+            if child.comp_inlined:
+                # Inlined comprehensions contribute no separate scope; their
+                # names were folded into this scope (or made fast-hidden).
+                # Still finalize them for introspection, discarding any
+                # effect on this scope.
+                child.finalize(new_bound.copy(), new_free.copy(),
+                               new_globs.copy(), new_typeparams)
+                continue
             # Symbol dictionaries are copied to avoid having child scopes
             # pollute each other's.
             child_free = new_free.copy()
@@ -381,6 +485,11 @@ class AsyncFunctionScope(FunctionScope):
 
 
 class ComprehensionScope(FunctionScope):
+    # PEP 709: list/set/dict comprehensions are inlined into the enclosing
+    # scope.  maybe_inline is set at build time for the simple shapes we
+    # currently inline; comp_inlined is set at analysis time once we confirm
+    # the enclosing scope can absorb it.  inlined_bound_names lists the names
+    # bound by the comprehension, to save/clear/restore.  (attributes on Scope)
     pass
 
 
@@ -783,6 +892,9 @@ class SymtableBuilder(ast.GenericASTVisitor):
         outer.iter.walkabout(self)
         self.scope.comp_iter_expr -= 1
         new_scope = ComprehensionScope("<genexpr>", node.lineno, node.col_offset)
+        # PEP 709: inline list/set/dict comprehensions, but not genexps
+        if not isinstance(node, ast.GeneratorExp):
+            new_scope.maybe_inline = True
         self.push_scope(new_scope, node)
         self.implicit_arg(0)
         new_scope.is_coroutine |= outer.is_async

--- a/pypy/interpreter/astcompiler/test/apptest_compiler.py
+++ b/pypy/interpreter/astcompiler/test/apptest_compiler.py
@@ -138,3 +138,25 @@ def test_backward_jump_has_lineno():
                if ins.opname == 'JUMP_ABSOLUTE']
     assert len(linenos) > 0
     assert all(l is not None for l in linenos)
+
+
+def test_inlined_comprehension_private_name_reuse():
+    x = 3
+
+    def f():
+        [x for x in [1]]
+        return [x for _ in [1]]
+
+    assert f() == [3]
+
+
+def test_inlined_comprehension_iterator_position():
+    import dis
+
+    code = compile("[x for x in BrokenIter()]", "<test>", "exec")
+    get_iter = [ins for ins in dis.get_instructions(code)
+                if ins.opname == "GET_ITER"][0]
+    position = get_iter.positions
+    assert (position.lineno, position.end_lineno,
+            position.col_offset, position.end_col_offset) == \
+           (1, 1, 12, 24)

--- a/pypy/interpreter/astcompiler/test/apptest_compiler.py
+++ b/pypy/interpreter/astcompiler/test/apptest_compiler.py
@@ -102,3 +102,39 @@ def test_compile_ast_object_pep695_type_alias():
     for src in ("type X = int\n", "type Stack[T] = list[T]\n"):
         tree = compile(src, "<test>", "exec", PyCF_ONLY_AST)
         compile(tree, "<test>", "exec")
+
+
+def test_extended_arg_keeps_source_position():
+    # An instruction needing an EXTENDED_ARG prefix (here UNPACK_EX for
+    # 'a, *b, c', oparg (1<<8)|1 == 257) must keep its source position on the
+    # real opcode, not only on the EXTENDED_ARG.
+    import dis
+    import textwrap
+    snippet = textwrap.dedent("""\
+        match x:
+            case a, *b, c:
+                pass
+        """)
+    code = compile(snippet, "<test>", "exec")
+    for ins in dis.get_instructions(code):
+        if ins.opname == "UNPACK_EX":
+            p = ins.positions
+            assert (p.lineno, p.end_lineno, p.col_offset, p.end_col_offset) == \
+                   (2, 2, 9, 17)
+            break
+    else:
+        assert False, "UNPACK_EX not found"
+
+
+def test_backward_jump_has_lineno():
+    # CPython gh-107901: backward jumps must carry a line number
+    import dis
+    def f():
+        for i in x:      # noqa: F821
+            if y:        # noqa: F821
+                pass
+    linenos = [ins.positions.lineno
+               for ins in dis.get_instructions(f.__code__)
+               if ins.opname == 'JUMP_ABSOLUTE']
+    assert len(linenos) > 0
+    assert all(l is not None for l in linenos)

--- a/pypy/interpreter/astcompiler/test/test_compiler.py
+++ b/pypy/interpreter/astcompiler/test/test_compiler.py
@@ -3471,15 +3471,17 @@ class TestOptimizations:
         assert self._blocks[0].instructions[1].jump is self._blocks[-1]
 
     def test_listcomp_assignment_hack(self):
-        self.count_instructions("""def listcomp_assignment_hack():
+        # the comprehension is inlined (PEP 709), so count FOR_ITER in the
+        # function's own code
+        counts = self.count_instructions("""def listcomp_assignment_hack():
             return [y for x in a for y in [f(x)]]
         """)
-        assert self._code.consts_w[1].co_code.count(chr(ops.FOR_ITER)) == 1
-        self.count_instructions("""def listcomp_assignment_hack2():
+        assert counts[ops.FOR_ITER] == 1
+        counts = self.count_instructions("""def listcomp_assignment_hack2():
             return [y for x in [1, 2, 3] for y in []]
         """)
         # it's really pointless to optimize this
-        assert self._code.consts_w[1].co_code.count(chr(ops.FOR_ITER)) == 2
+        assert counts[ops.FOR_ITER] == 2
 
 
 class TestHugeStackDepths:

--- a/pypy/interpreter/astcompiler/test/test_symtable.py
+++ b/pypy/interpreter/astcompiler/test/test_symtable.py
@@ -543,8 +543,10 @@ def f(x):
         assert scp.lookup("x") == symtable.SCOPE_GLOBAL_IMPLICIT
 
     def test_named_expr_list_comprehension(self):
+        # with the comprehension inlined (PEP 709) there is no child scope
+        # closing over y, so it is a plain local (CPython 3.12 agrees)
         fscp = self.func_scope("def f(): [(y := x) for x in range(5)]")
-        assert fscp.lookup("y") == symtable.SCOPE_CELL
+        assert fscp.lookup("y") == symtable.SCOPE_LOCAL
 
     # ==================== PEP 695 Type Parameter Tests ====================
 

--- a/pypy/interpreter/pycode.py
+++ b/pypy/interpreter/pycode.py
@@ -40,7 +40,8 @@ cpython_magic, = struct.unpack("<i", imp.get_magic())   # host magic number
 # time you make pyc files incompatible.  This value ends up in the frozen
 # importlib, via MAGIC_NUMBER in module/_frozen_importlib/__init__.
 
-pypy_incremental_magic = 448 # bump it by 16
+pypy_incremental_magic = 464 # bump it by 16
+# 464: PEP 709 inlined comprehensions (LOAD_FAST_AND_CLEAR)
 assert pypy_incremental_magic % 16 == 0
 assert pypy_incremental_magic < 3000 # the magic number of Python 3. There are
                                      # no known magic numbers below this value

--- a/pypy/interpreter/pyframe.py
+++ b/pypy/interpreter/pyframe.py
@@ -485,6 +485,13 @@ class PyFrame(W_Root):
         assert index >= 0
         self.locals_cells_stack_w[index] = ll_assert_not_none(w_object)
 
+    def settopvalue_maybe_none(self, w_object, index_from_top=0):
+        index_from_top = hint(index_from_top, promote=True)
+        index = self.valuestackdepth + ~index_from_top
+        self.assert_stack_index(index)
+        assert index >= 0
+        self.locals_cells_stack_w[index] = w_object
+
     @jit.unroll_safe
     def dropvaluesuntil(self, finaldepth):
         depth = self.valuestackdepth - 1
@@ -546,19 +553,23 @@ class PyFrame(W_Root):
         if w_locals is None:
             w_locals = self.space.newdict(instance=True)
             write = True
-        varnames = self.getcode().getvarnames()
-        for i in range(min(len(varnames), self.getcode().co_nlocals)):
-            name = varnames[i]
-            w_value = self.locals_cells_stack_w[i]
-            if w_value is not None:
-                self.space.setitem_str(w_locals, name, w_value)
-            else:
-                w_name = self.space.newtext(name)
-                try:
-                    self.space.delitem(w_locals, w_name)
-                except OperationError as e:
-                    if not e.match(self.space, self.space.w_KeyError):
-                        raise
+        if self.getcode().co_flags & consts.CO_OPTIMIZED:
+            varnames = self.getcode().getvarnames()
+            for i in range(min(len(varnames), self.getcode().co_nlocals)):
+                name = varnames[i]
+                w_value = self.locals_cells_stack_w[i]
+                if w_value is not None:
+                    self.space.setitem_str(w_locals, name, w_value)
+                else:
+                    w_name = self.space.newtext(name)
+                    try:
+                        self.space.delitem(w_locals, w_name)
+                    except OperationError as e:
+                        if not e.match(self.space, self.space.w_KeyError):
+                            raise
+        # else: the only fast locals in a non-optimized (module) code object
+        # are PEP 709 inlined-comprehension names; they are hidden from the
+        # locals dict (CPython's CO_FAST_HIDDEN) and must not be synced
 
         # cellvars are values exported to inner scopes
         # freevars are values coming from outer scopes
@@ -589,18 +600,21 @@ class PyFrame(W_Root):
         # Copy values from self.w_locals to the fastlocals
         w_locals = self.getorcreatedebug().w_locals
         assert w_locals is not None
-        varnames = self.getcode().getvarnames()
-        numlocals = self.getcode().co_nlocals
+        if self.getcode().co_flags & consts.CO_OPTIMIZED:
+            varnames = self.getcode().getvarnames()
+            numlocals = self.getcode().co_nlocals
 
-        new_fastlocals_w = [None] * numlocals
+            new_fastlocals_w = [None] * numlocals
 
-        for i in range(min(len(varnames), numlocals)):
-            name = varnames[i]
-            w_value = self.space.finditem_str(w_locals, name)
-            if w_value is not None:
-                new_fastlocals_w[i] = w_value
+            for i in range(min(len(varnames), numlocals)):
+                name = varnames[i]
+                w_value = self.space.finditem_str(w_locals, name)
+                if w_value is not None:
+                    new_fastlocals_w[i] = w_value
 
-        self.setfastscope(new_fastlocals_w)
+            self.setfastscope(new_fastlocals_w)
+        # else: PEP 709 fast-hidden comprehension locals; never seeded from
+        # nor synced to the locals dict, and must not be wiped here
 
         freevarnames = self.pycode.co_cellvars
         if self.pycode.co_flags & consts.CO_OPTIMIZED and not skip_free_vars:

--- a/pypy/interpreter/pyopcode.py
+++ b/pypy/interpreter/pyopcode.py
@@ -395,6 +395,8 @@ class __extend__(pyframe.PyFrame):
                 self.LOAD_CLASSDEREF(oparg, next_instr)
             elif opcode == opcodedesc.LOAD_FAST.index:
                 self.LOAD_FAST(oparg, next_instr)
+            elif opcode == opcodedesc.LOAD_FAST_AND_CLEAR.index:
+                self.LOAD_FAST_AND_CLEAR(oparg, next_instr)
             elif opcode == opcodedesc.LOAD_GLOBAL.index:
                 self.LOAD_GLOBAL(oparg, next_instr)
             elif opcode == opcodedesc.LOAD_NAME.index:
@@ -553,13 +555,21 @@ class __extend__(pyframe.PyFrame):
                     "local variable '%s' referenced before assignment",
                     varname)
 
+    def LOAD_FAST_AND_CLEAR(self, varindex, next_instr):
+        # push the local (or None if unbound) and clear it; used to isolate
+        # comprehension-bound locals when a comprehension is inlined.
+        w_value = self.locals_cells_stack_w[varindex]
+        self.locals_cells_stack_w[varindex] = None
+        self.pushvalue_maybe_none(w_value)
+
     def LOAD_CONST(self, constindex, next_instr):
         w_const = self.getconstant_w(constindex)
         self.pushvalue(w_const)
 
     def STORE_FAST(self, varindex, next_instr):
-        w_newvalue = self.popvalue()
-        assert w_newvalue is not None
+        # popvalue_maybe_none: the value may be None (unbound) when restoring a
+        # saved comprehension local via the STORE_FAST_MAYBE_NULL pseudo-op.
+        w_newvalue = self.popvalue_maybe_none()
         self.locals_cells_stack_w[varindex] = w_newvalue
 
     def getfreevarname(self, index):
@@ -1908,10 +1918,12 @@ class __extend__(pyframe.PyFrame):
         # CPython 3.11 SWAP i: swap TOS with the i-th item from the top (1-indexed).
         # SWAP 2 = ROT_TWO.
         assert oparg >= 2
-        w_top = self.peekvalue(0)
-        w_i = self.peekvalue(oparg - 1)
-        self.settopvalue(w_i, 0)
-        self.settopvalue(w_top, oparg - 1)
+        # _maybe_none: a stack slot may hold None (an unbound local saved by
+        # LOAD_FAST_AND_CLEAR) while an inlined comprehension is running.
+        w_top = self.peekvalue_maybe_none(0)
+        w_i = self.peekvalue_maybe_none(oparg - 1)
+        self.settopvalue_maybe_none(w_i, 0)
+        self.settopvalue_maybe_none(w_top, oparg - 1)
 
     def CHECK_EG_MATCH(self, oparg, next_instr):
         space = self.space

--- a/pypy/interpreter/test/apptest_pyframe.py
+++ b/pypy/interpreter/test/apptest_pyframe.py
@@ -10,6 +10,23 @@ def test_f_locals():
     f = sys._getframe()
     assert f.f_locals is locals()
 
+
+def test_module_comprehension_variable_in_locals():
+    namespace = {}
+    exec("result = [locals()['x'] for x in [1]]", namespace)
+    assert namespace["result"] == [1]
+
+
+def test_module_comprehension_variable_in_frame_locals():
+    namespace = {}
+    exec(
+        "import sys\n"
+        "result = [sys._getframe().f_locals['x'] for x in [1]]",
+        namespace,
+    )
+    assert namespace["result"] == [1]
+
+
 def test_f_globals():
     import sys
     f = sys._getframe()
@@ -1032,6 +1049,7 @@ def test_line_tracing_bug_exception_yieldfrom():
         pass
     finally:
         sys.settrace(None)
+
     assert tr == [
         ('call', 0), ('line', 1),
             ('call', -3), ('line', -2), ('line', -1),
@@ -1429,4 +1447,3 @@ def test_locals2fast_del_cell_var():
             f()
     finally:
         sys.settrace(None)
-


### PR DESCRIPTION
Fixes #5496 by implementing inline comprehensions. Along with the new `_inline_comprehension_children` and `_inline_comprehension_children_module`, there is a new opcode `LOAD_FAST_AND_CLEAR` and a `fasthidden` dict. Still to do, among others: python3.11 has a MAKE_CELL opcode that PyPy never implemented, it is needed to create a new cell per execution of comprehension. 