### PR TITLE
count an empty needle in the code point domain

### DIFF
--- a/pypy/objspace/std/test/test_unicodeobject.py
+++ b/pypy/objspace/std/test/test_unicodeobject.py
@@ -1001,6 +1001,18 @@ class AppTestUnicodeString:
         assert u'aaa'.count(u'a', 0, -10) == 0
         assert u'ababa'.count(u'aba') == 1
 
+        # An empty string matches between code points, so the result must not
+        # depend on the number of bytes used to encode the receiver.
+        assert u'\xe9\xe8\xe9\xe8\xe9'.count(u'') == 6
+        assert u'\u4e00\u4e8c'.count(u'') == 3
+        assert u'\U0001f600'.count(u'') == 2
+        assert u'a\xe9\u4e00\U0001f600'.count(u'') == 5
+        assert u'\xe9\xe8\xe9\xe8\xe9'.count(u'', 1, 3) == 3
+        for s in [u'aaa', u'\xe9\xe8\xe9', u'\u4e00\u4e8c',
+                  u'\U0001f600', u'a\xe9\u4e00\U0001f600']:
+            assert s.count(u'') == len(s) + 1
+            assert s.count(u'') == s.rfind(u'') - s.find(u'') + 1
+
     def test_count_str_unicode(self):
         assert 'aaa'.count(u'a') == 3
         assert 'aaa'.count(u'b') == 0

--- a/pypy/objspace/std/unicodeobject.py
+++ b/pypy/objspace/std/unicodeobject.py
@@ -875,6 +875,21 @@ class W_UnicodeObject(W_Root):
         start_index, end_index = self._unwrap_and_compute_idx_params(
             space, w_start, w_end)
         sub = self.convert_arg_to_w_unicode(space, w_sub)._utf8
+        if len(sub) == 0:
+            # The empty string matches between code points, so the result is a
+            # number of code points.  start_index and end_index are byte
+            # offsets, and counting the matches in that domain would answer the
+            # width of the encoded form instead.  end_index can be one past the
+            # end, which is how an out of range start is signalled; clip it the
+            # way the search below would.
+            if end_index > len(value):
+                end_index = len(value)
+            if start_index > end_index:
+                return space.newint(0)
+            if start_index == 0 and end_index == len(value):
+                return space.newint(self._len() + 1)
+            return space.newint(
+                self._codepoints_in_utf8(start_index, end_index) + 1)
         return space.newint(value.count(sub, start_index, end_index))
 
     def descr_contains(self, space, w_sub):


### PR DESCRIPTION
descr_count passed the byte bounds from _unwrap_and_compute_idx_params straight to rstring's search, which answers end - start + 1 for an empty needle, so '\xe9\xe8\xe9\xe8\xe9'.count('') was 11 rather than 6. Answer it from _codepoints_in_utf8 instead, with start_index > end_index giving 0 as rstring.py:827 does, and the whole-string case reading self._len() so the call stays O(1) -- rutf8.codepoints_in_utf8 is a linear scan.

test_count_unicode in apptest_unicode.py now passes; test_unicode, test_bytes, test_string and test_userstring stay green.

