### PR TITLE
jit: repair the stale rlist.ll_getitem() call in the codewriter builtin table

### DIFF
--- a/rpython/jit/codewriter/support.py
+++ b/rpython/jit/codewriter/support.py
@@ -198,7 +198,8 @@ _ll_1_newlist_hint.need_result_type = True
 def _ll_1_list_len(l):
     return l.ll_length()
 def _ll_2_list_getitem(l, index):
-    return rlist.ll_getitem(rlist.dum_checkidx, l, index)
+    return rlist.ll_getitem(rlist.dum_checkidx, rlist.ll_getitem_fast,
+                            l, index)
 def _ll_3_list_setitem(l, index, newitem):
     rlist.ll_setitem(rlist.dum_checkidx, l, index, newitem)
 def _ll_2_list_delitem(l, index):
@@ -213,7 +214,9 @@ _ll_2_list_delslice_startonly = rlist.ll_listdelslice_startonly
 _ll_3_list_delslice_startstop = rlist.ll_listdelslice_startstop
 _ll_2_list_inplace_mul = rlist.ll_inplace_mul
 
-_ll_2_list_getitem_foldable = _ll_2_list_getitem
+def _ll_2_list_getitem_foldable(l, index):
+    return rlist.ll_getitem(rlist.dum_checkidx,
+                            rlist.ll_getitem_foldable_nonneg, l, index)
 _ll_1_list_len_foldable     = _ll_1_list_len
 
 _ll_5_list_ll_arraycopy = rgc.ll_arraycopy

--- a/rpython/jit/codewriter/test/test_support.py
+++ b/rpython/jit/codewriter/test/test_support.py
@@ -144,6 +144,34 @@ def test_int_abs():
     assert _ll_1_int_abs(-10) == 10
     assert _ll_1_int_abs(-sys.maxint) == sys.maxint
 
+def test_list_getitem_calls_ll_getitem(monkeypatch):
+    # rlist.ll_getitem() is ll_getitem(func, basegetitem, l, index), so the
+    # wrapper has to pass four arguments or the list is bound to
+    # 'basegetitem' and the index is dropped
+    from rpython.rtyper import rlist
+    from rpython.jit.codewriter import support
+    seen = []
+    def fake_ll_getitem(func, basegetitem, l, index):
+        seen.append((func, basegetitem, l, index))
+        return 'the item'
+    monkeypatch.setattr(rlist, 'll_getitem', fake_ll_getitem)
+    assert support._ll_2_list_getitem('the list', 7) == 'the item'
+    assert seen == [(rlist.dum_checkidx, rlist.ll_getitem_fast,
+                     'the list', 7)]
+
+def test_list_getitem_foldable_calls_the_foldable_getter(monkeypatch):
+    # 'list.getitem_foldable' must not reach the mutable ll_getitem_fast
+    from rpython.rtyper import rlist
+    from rpython.jit.codewriter import support
+    seen = []
+    def fake_ll_getitem(func, basegetitem, l, index):
+        seen.append((func, basegetitem, l, index))
+        return 'the item'
+    monkeypatch.setattr(rlist, 'll_getitem', fake_ll_getitem)
+    assert support._ll_2_list_getitem_foldable('the list', 7) == 'the item'
+    assert seen == [(rlist.dum_checkidx, rlist.ll_getitem_foldable_nonneg,
+                     'the list', 7)]
+
 def test_int_floordiv_mod():
     from rpython.rtyper.lltypesystem.lloperation import llop
     from rpython.jit.codewriter.support import _ll_2_int_floordiv, _ll_2_int_mod


### PR DESCRIPTION
commit 72270f262488167a70bf4888aef9dcc42b388449 changed ll_getitem signature, but didn't update the its usage.

<!--

Thank you for contributing to PyPy. Please be sure to target one of our active branches:
- `main` for pypy2.7, rpython, and documentation changes
- `py3.10` for the legacy python3.10 branch
- `py3.11` for the current development branch targeting python3.11

Do not target the `branch/*` branches, they are artifacts of our migration from mercurial to git.
-->