### PR TITLE
fix pytest assertion rewriting on python 2

### DIFF
--- a/_pytest/assertion/rewrite.py
+++ b/_pytest/assertion/rewrite.py
@@ -561,7 +561,12 @@ class AssertionRewriter(ast.NodeVisitor):
         # Now actually insert the special imports.
         if sys.version_info >= (3, 10):
             aliases = [
-                ast.alias("builtins", "@py_builtins", lineno=lineno, col_offset=0),
+                ast.alias(
+                    py.builtin.builtins.__name__,
+                    "@py_builtins",
+                    lineno=lineno,
+                    col_offset=0,
+                ),
                 ast.alias(
                     "_pytest.assertion.rewrite",
                     "@pytest_ar",
@@ -571,7 +576,7 @@ class AssertionRewriter(ast.NodeVisitor):
             ]
         else:
             aliases = [
-                ast.alias("builtins", "@py_builtins"),
+                ast.alias(py.builtin.builtins.__name__, "@py_builtins"),
                 ast.alias("_pytest.assertion.rewrite", "@pytest_ar"),
             ]
         imports = [


### PR DESCRIPTION
python3 compatibility work in our vendored pytest on the py3* branches broke pytest on top of pypy2 (which is relevant e.g. for running the rpython tests). make it work on both pypy2/pypy3 again.