### PR TITLE
jit: slice the kind in rewrite_op_getarrayitem so the raw_r guard can fire

### DIFF
--- a/rpython/jit/codewriter/jtransform.py
+++ b/rpython/jit/codewriter/jtransform.py
@@ -760,9 +760,9 @@ class Transformer(object):
         if op.args[0] in self.vable_array_vars:     # for virtualizables
             vars = self.vable_array_vars[op.args[0]]
             (v_base, arrayfielddescr, arraydescr) = vars
-            kind = getkind(op.result.concretetype)
+            kind = getkind(op.result.concretetype)[0]
             return [SpaceOperation('-live-', [], None),
-                    SpaceOperation('getarrayitem_vable_%s' % kind[0],
+                    SpaceOperation('getarrayitem_vable_%s' % kind,
                                    [v_base, op.args[1], arrayfielddescr,
                                     arraydescr], op.result)]
         # normal case follows
@@ -771,7 +771,7 @@ class Transformer(object):
         if immut:
             pure = '_pure'
         arraydescr = self.cpu.arraydescrof(ARRAY)
-        kind = getkind(op.result.concretetype)
+        kind = getkind(op.result.concretetype)[0]
         if ARRAY._gckind != 'gc':
             assert ARRAY._gckind == 'raw'
             if kind == 'r':
@@ -779,7 +779,7 @@ class Transformer(object):
             pure = ''   # always redetected from pyjitpl.py: we don't need
                         # a '_pure' version of getarrayitem_raw
         return SpaceOperation('getarrayitem_%s_%s%s' % (ARRAY._gckind,
-                                                        kind[0], pure),
+                                                        kind, pure),
                               [op.args[0], op.args[1], arraydescr],
                               op.result)
 

--- a/rpython/jit/codewriter/test/test_jtransform.py
+++ b/rpython/jit/codewriter/test/test_jtransform.py
@@ -1419,6 +1419,36 @@ def test_no_gcstruct_nesting_outside_of_OBJECT():
     tr = Transformer(None, None)
     py.test.raises(NotImplementedError, tr.rewrite_operation, op)
 
+def _rewrite_getarrayitem_raw(ITEM):
+    A = rffi.CArray(ITEM)
+    assert A._gckind == 'raw'
+    op = SpaceOperation('getarrayitem',
+                        [varoftype(lltype.Ptr(A)),
+                         Constant(0, lltype.Signed)],
+                        varoftype(ITEM))
+    tr = Transformer(FakeCPU(), None)
+    tr.vable_array_vars = {}
+    return tr.rewrite_operation(op)
+
+def test_getarrayitem_raw_of_gc_pointers_is_rejected():
+    # neither blackhole.py nor pyjitpl.py has a getarrayitem_raw_r, so this
+    # has to be refused right here instead of surfacing much later
+    S = lltype.GcStruct('S', ('x', lltype.Signed))
+    e = py.test.raises(Exception, _rewrite_getarrayitem_raw, lltype.Ptr(S))
+    assert 'getarrayitem_raw_r not supported' in str(e.value)
+
+def test_getarrayitem_raw_of_everything_else_is_accepted():
+    # only a GC pointer gets kind 'r'; the item's width is irrelevant, and
+    # a pointer to a raw struct is an 'i' too.  These are the kinds that do
+    # have a bhimpl_, so the guard above must not widen to them
+    RAW = lltype.Struct('RAW', ('x', lltype.Signed))
+    for ITEM, expected in [(rffi.UCHAR, 'getarrayitem_raw_i'),
+                           (rffi.SHORT, 'getarrayitem_raw_i'),
+                           (lltype.Signed, 'getarrayitem_raw_i'),
+                           (lltype.Float, 'getarrayitem_raw_f'),
+                           (lltype.Ptr(RAW), 'getarrayitem_raw_i')]:
+        assert _rewrite_getarrayitem_raw(ITEM).opname == expected
+
 def test_no_fixedsizearray():
     A = lltype.FixedSizeArray(lltype.Signed, 5)
     v_x = varoftype(lltype.Ptr(A))

--- a/rpython/jit/metainterp/test/test_ajit.py
+++ b/rpython/jit/metainterp/test/test_ajit.py
@@ -3255,6 +3255,21 @@ class BasicTests:
         res = self.interp_operations(f, [127 - 256 * 29])
         assert res == 127
 
+    def test_getarrayitem_raw_of_gc_pointers_is_refused(self):
+        # there is no getarrayitem_raw_r anywhere: no bhimpl_, no opimpl_, and
+        # resoperation.py spells the operation 'GETARRAYITEM_RAW/2d/fi'.  The
+        # codewriter has to say so itself, instead of emitting the opcode and
+        # letting the blackhole interpreter fail to find a handler for it.
+        S = lltype.GcStruct('S', ('x', lltype.Signed))
+        A = rffi.CArray(lltype.Ptr(S))
+        def f(n):
+            a = lltype.malloc(A, 5, flavor='raw', zero=True)
+            res = 1 if a[n] else 0
+            lltype.free(a, flavor='raw')
+            return res
+        e = py.test.raises(Exception, self.interp_operations, f, [0])
+        assert 'getarrayitem_raw_r not supported' in str(e.value)
+
     def test_bug_inline_short_preamble_can_be_inconsistent_in_optimizeopt(self):
         myjitdriver = JitDriver(greens = [], reds = "auto")
         class Str(object):


### PR DESCRIPTION
Unify indexing to `getkind(...)[0]` to avoid manual check for every use case 