### PR TITLE
jit: compare the errno helpers by their _obj so the assert can fire

### DIFF
--- a/rpython/jit/codewriter/call.py
+++ b/rpython/jit/codewriter/call.py
@@ -119,8 +119,8 @@ class CallControl(object):
             if self.jitdriver_sd_from_portal_runner_ptr(funcptr) is not None:
                 return 'recursive'
             funcobj = funcptr._obj
-            assert (funcobj is not rposix._get_errno and
-                    funcobj is not rposix._set_errno), (
+            assert (funcobj is not rposix._get_errno._obj and
+                    funcobj is not rposix._set_errno._obj), (
                 "the JIT must never come close to _get_errno() or _set_errno();"
                 " it should all be done at a lower level")
             if getattr(funcobj, 'graph', None) is None:

--- a/rpython/jit/codewriter/test/test_call.py
+++ b/rpython/jit/codewriter/test/test_call.py
@@ -152,6 +152,14 @@ def test_guess_call_kind_and_calls_from_graphs():
     assert res is None
     assert cc.guess_call_kind(op) == 'residual'
 
+def test_guess_call_kind_refuses_the_errno_helpers():
+    # the helpers arrive as a _ptr, and guess_call_kind holds their ._obj
+    from rpython.rlib import rposix
+    cc = CallControl()
+    for funcptr in [rposix._get_errno, rposix._set_errno]:
+        op = SpaceOperation('direct_call', [Constant(funcptr)], Variable())
+        py.test.raises(AssertionError, cc.guess_call_kind, op)
+
 # ____________________________________________________________
 
 def test_get_jitcode(monkeypatch):

--- a/rpython/jit/codewriter/test/test_call.py
+++ b/rpython/jit/codewriter/test/test_call.py
@@ -1,4 +1,4 @@
-import py
+import pytest
 
 from rpython.flowspace.model import SpaceOperation, Constant, Variable
 from rpython.rtyper.lltypesystem import lltype, llmemory, rffi
@@ -158,7 +158,8 @@ def test_guess_call_kind_refuses_the_errno_helpers():
     cc = CallControl()
     for funcptr in [rposix._get_errno, rposix._set_errno]:
         op = SpaceOperation('direct_call', [Constant(funcptr)], Variable())
-        py.test.raises(AssertionError, cc.guess_call_kind, op)
+        with pytest.raises(AssertionError):
+            cc.guess_call_kind(op)
 
 # ____________________________________________________________
 
@@ -185,7 +186,7 @@ def test_get_jitcode(monkeypatch):
 # ____________________________________________________________
 
 def test_jit_force_virtualizable_effectinfo():
-    py.test.skip("XXX add a test for CallControl.getcalldescr() -> EF_xxx")
+    pytest.skip("XXX add a test for CallControl.getcalldescr() -> EF_xxx")
 
 def test_releases_gil_analyzer():
     from rpython.jit.backend.llgraph.runner import LLGraphCPU
@@ -246,7 +247,7 @@ def test_random_effects_on_stacklet_switch():
         from rpython.rlib._rffi_stacklet import switch, handle
     except CompilationError as e:
         if "Unsupported platform!" in e.out:
-            py.test.skip("Unsupported platform!")
+            pytest.skip("Unsupported platform!")
         else:
             raise e
     @jit.dont_look_inside
@@ -269,7 +270,7 @@ def test_no_random_effects_for_rotateLeft():
     from rpython.rlib.rarithmetic import r_uint
 
     if r_uint.BITS == 32:
-        py.test.skip("64-bit only")
+        pytest.skip("64-bit only")
 
     from rpython.rlib.rmd5 import _rotateLeft
     def f(n, m):
@@ -345,7 +346,8 @@ def test_elidable_kinds():
 
     call_op = f_graph.startblock.operations[4]
     assert call_op.opname == 'direct_call'
-    excinfo = py.test.raises(Exception, cc.getcalldescr, call_op)
+    with pytest.raises(Exception) as excinfo:
+        cc.getcalldescr(call_op)
     lines = excinfo.value.args[0].splitlines()
     assert "f5" in lines[2]
     assert "effect" in lines[3]
@@ -368,7 +370,8 @@ def test_raise_elidable_no_result():
     [f_graph] = [x for x in res if x.func is fancy_graph_name]
     call_op = f_graph.startblock.operations[0]
     assert call_op.opname == 'direct_call'
-    x = py.test.raises(Exception, cc.getcalldescr, call_op, calling_graph=f_graph)
+    with pytest.raises(Exception) as x:
+        cc.getcalldescr(call_op, calling_graph=f_graph)
     assert "fancy_graph_name" in str(x.value)
 
 def test_can_or_cannot_collect():


### PR DESCRIPTION
This is also another non-production type mismatch bug.

generated description below.

----

The assert in `guess_call_kind()` that is supposed to keep the JIT away from
`_get_errno()` and `_set_errno()` compares two different kinds of object, so it
can never fire.

```python
funcobj = funcptr._obj                          # a _func
assert (funcobj is not rposix._get_errno and    # a _ptr
        funcobj is not rposix._set_errno), (
    "the JIT must never come close to _get_errno() or _set_errno();"
    " it should all be done at a lower level")
```

| expression | type | value |
|---|---|---|
| `funcptr._obj` | `_func` | `<fn get_errno>` |
| `rposix._get_errno` | `_ptr` | `<* fn get_errno>` |

A `_func` is never a `_ptr`, so both conditions are unconditionally true for
every input, including the two functions they name.

### What the test raises without the patch

The test hands both helpers to `guess_call_kind()` and requires them to be
refused:

```python
def test_guess_call_kind_refuses_the_errno_helpers():
    # the helpers arrive as a _ptr, and guess_call_kind holds their ._obj
    from rpython.rlib import rposix
    cc = CallControl()
    for funcptr in [rposix._get_errno, rposix._set_errno]:
        op = SpaceOperation('direct_call', [Constant(funcptr)], Variable())
        py.test.raises(AssertionError, cc.guess_call_kind, op)
```

Without the change it fails at the `py.test.raises` line with

```
________________ test_guess_call_kind_refuses_the_errno_helpers ________________
>           py.test.raises(AssertionError, cc.guess_call_kind, op)
E           Failed: DID NOT RAISE <type 'exceptions.AssertionError'>

rpython/jit/codewriter/test/test_call.py:163: Failed
```

`DID NOT RAISE` is the bug in its exact shape: the assert is skipped and the
call goes on through. What `guess_call_kind()` returns for them today is

```
rposix._get_errno  -> 'residual'
rposix._set_errno  -> 'residual'
```

which is precisely what the assert exists to prevent. Both are declared with
`_nowrapper=True` and therefore have no graph, so the line right after the
assert classifies them as residual calls, and the JIT would emit a call to
`get_errno` inside a trace — reading errno at a point unrelated to the syscall
whose errno is meant.

`rpython/jit/codewriter/test/test_call.py` goes from 14 passed / 1 skipped to
15 passed / 1 skipped, i.e. exactly the new test.

### Why nothing hits this today

The rule is kept by hand, one decorator at a time.
`pypy/module/cpyext/pystrtod.py` and `pypy/module/cpyext/pyerrors.py` both carry
`@jit.dont_look_inside` with the comment `# direct use of _get_errno()` on it,
and rposix's own `fork()` and `forkpty()` are `dont_look_inside` as well. That is
what the assert is a backstop for: `dont_look_inside` protects the sites that
have it and says nothing about a site that lost it. Repairing the comparison
restores the only check that would notice.
