### PR TITLE
Fix dylib linking without input files on macOS

### DIFF
--- a/rpython/translator/tool/cbuild.py
+++ b/rpython/translator/tool/cbuild.py
@@ -331,6 +331,12 @@ class ExternalCompilationInfo(object):
             '-DRPY_EXTERN=RPY_EXPORTED',)
         for define in defines:
             d['compile_extra'] += ('-D%s' % define,)
+        if (sys.platform == 'darwin' and not d['separate_module_files'] and
+                not d['link_files']):
+            d['separate_module_sources'] = ('/* empty translation unit */',)
+            self = ExternalCompilationInfo(**d).convert_sources_to_files()
+        else:
+            self = ExternalCompilationInfo(**d)
         # On ELF platforms (Linux), prevent symbol interposition: when the host
         # interpreter (e.g. pypy2.7) also exports symbols like pypysig_counter,
         # the shared lib's own references would otherwise resolve to the host's
@@ -339,8 +345,6 @@ class ExternalCompilationInfo(object):
         # under a host interpreter (tests), not during translation.
         if symbolic and sys.platform not in ('win32', 'darwin'):
             d['link_extra'] = d['link_extra'] + ('-Wl,-Bsymbolic',)
-        self = ExternalCompilationInfo(**d)
-
         lib = str(host.compile([], self, outputfilename=outputfilename,
                                standalone=False))
         d = self._copy_attributes()

--- a/rpython/translator/tool/test/test_cbuild.py
+++ b/rpython/translator/tool/test/test_cbuild.py
@@ -1,6 +1,7 @@
 import py
 
 from rpython.tool.udir import udir
+from rpython.translator.tool import cbuild
 from rpython.translator.tool.cbuild import ExternalCompilationInfo
 from subprocess import Popen, PIPE, STDOUT
 
@@ -93,6 +94,25 @@ class TestEci:
         assert not hasattr(ctypes.CDLL(neweci.libraries[0]), 'shouldnt_export')
         assert not neweci.separate_module_sources
         assert not neweci.separate_module_files
+
+    def test_make_shared_lib_without_link_inputs_on_darwin(self, monkeypatch):
+        archive = self.tmpdir.join('libempty.a')
+        archive.write('')
+        eci = ExternalCompilationInfo(link_files=[str(archive)])
+        compiled = []
+
+        def compile(cfiles, compilation_eci, outputfilename, standalone):
+            compiled.append(compilation_eci)
+            return self.tmpdir.join('empty.dylib')
+
+        monkeypatch.setattr(cbuild.sys, 'platform', 'darwin')
+        monkeypatch.setattr(cbuild.host, 'compile', compile)
+        neweci = eci.compile_shared_lib(ignore_a_files=True)
+
+        assert len(compiled) == 1
+        assert len(compiled[0].separate_module_files) == 1
+        assert compiled[0].link_files == ()
+        assert neweci.link_files == ()
 
     def test_from_compiler_flags(self):
         flags = ('-I/some/include/path -I/other/include/path '


### PR DESCRIPTION
I found that some AArch64 backend tests fail on macOS while `ll2ctypes` prepares a C function call. For example:

```
$ pypy --jit off ./pytest.py rpython/jit/backend/aarch64/test/test_runner.py::TestARM64::test_call_to_c_function

...
[platform:Error] clang: error: no input files
```

This is because `compile_shared_lib(ignore_a_files=True)` removes static archives from the ECI before linking.
In this case, `libffi.a` is the only link input, and there are no separate module files, so the compiler driver is invoked without an input file.

On macOS, this change supplies an empty translation unit when removing the archive would otherwise leave the link command without an input.

A new test covers the empty-input case. Other link commands are unchanged.