### PR TITLE
jit: normalize a force_cast to Bool from an unsigned byte type

### DIFF
--- a/rpython/jit/codewriter/jtransform.py
+++ b/rpython/jit/codewriter/jtransform.py
@@ -1435,6 +1435,14 @@ class Transformer(object):
         assert size1 <= rffi.sizeof(lltype.Signed)
         assert size2 <= rffi.sizeof(lltype.Signed)
 
+        # a Bool destination always needs the 0/1 normalization, so it must
+        # be handled before the range checks below: Bool is itself (size 1,
+        # unsigned), so for a UCHAR or Char source the "target type includes
+        # the source range" test succeeds and no operation would be emitted,
+        # leaving the raw byte to be used as a Bool
+        if v_result.concretetype is lltype.Bool:
+            return [SpaceOperation('int_is_true', [v_arg], v_result)]
+
         # the target type is LONG or ULONG
         if size2 == rffi.sizeof(lltype.Signed):
             return
@@ -1447,9 +1455,7 @@ class Transformer(object):
             return
 
         result = []
-        if v_result.concretetype is lltype.Bool:
-            result.append(SpaceOperation('int_is_true', [v_arg], v_result))
-        elif min2:
+        if min2:
             c_bytes = Constant(size2, lltype.Signed)
             result.append(SpaceOperation('int_signext', [v_arg, c_bytes],
                                          v_result))

--- a/rpython/jit/codewriter/test/test_flatten.py
+++ b/rpython/jit/codewriter/test/test_flatten.py
@@ -850,6 +850,7 @@ class TestFlatten:
             (rffi.SIGNEDCHAR, rffi.USHORT, "int_and %i0, $65535 -> %i1"),
             (rffi.SIGNEDCHAR, rffi.LONG, ""),
             (rffi.SIGNEDCHAR, rffi.ULONG, ulong_cast),
+            (rffi.SIGNEDCHAR, lltype.Bool, "int_is_true %i0 -> %i1"),
 
             (rffi.UCHAR, rffi.SIGNEDCHAR, "int_signext %i0, $1 -> %i1"),
             (rffi.UCHAR, rffi.UCHAR, ""),
@@ -857,6 +858,7 @@ class TestFlatten:
             (rffi.UCHAR, rffi.USHORT, ""),
             (rffi.UCHAR, rffi.LONG, ""),
             (rffi.UCHAR, rffi.ULONG, ""),
+            (rffi.UCHAR, lltype.Bool, "int_is_true %i0 -> %i1"),
 
             (rffi.SHORT, rffi.SIGNEDCHAR, "int_signext %i0, $1 -> %i1"),
             (rffi.SHORT, rffi.UCHAR, "int_and %i0, $255 -> %i1"),
@@ -864,6 +866,7 @@ class TestFlatten:
             (rffi.SHORT, rffi.USHORT, "int_and %i0, $65535 -> %i1"),
             (rffi.SHORT, rffi.LONG, ""),
             (rffi.SHORT, rffi.ULONG, ulong_cast),
+            (rffi.SHORT, lltype.Bool, "int_is_true %i0 -> %i1"),
 
             (rffi.USHORT, rffi.SIGNEDCHAR, "int_signext %i0, $1 -> %i1"),
             (rffi.USHORT, rffi.UCHAR, "int_and %i0, $255 -> %i1"),
@@ -937,6 +940,17 @@ class TestFlatten:
                     expectedstr = '\n'.join(expected)
                     self.encoding_test(f, [rffi.cast(FROM, 42)], expectedstr,
                                        transform=True)
+
+    def test_force_cast_char_to_bool(self):
+        # lltype.Char is (size 1, unsigned), and so is Bool itself, so the
+        # "the target type already includes the source range" shortcut must
+        # not be allowed to skip the 0/1 normalization here
+        def f(n):
+            return rffi.cast(lltype.Bool, n)
+        self.encoding_test(f, [rffi.cast(lltype.Char, 42)], """
+            int_is_true %i0 -> %i1
+            int_return %i1
+        """, transform=True)
 
     def test_force_cast_pointer(self):
         def h(p):

--- a/rpython/jit/metainterp/test/test_ajit.py
+++ b/rpython/jit/metainterp/test/test_ajit.py
@@ -3241,6 +3241,20 @@ class BasicTests:
         res = self.meta_interp(f, [32])
         assert res == f(32)
 
+    def test_force_cast_to_bool(self):
+        # a cast to Bool has to normalize to 0/1 whatever the source is, and
+        # Bool is itself (size 1, unsigned), so the byte types are the ones
+        # whose range it covers and for which the cast can look like a no-op
+        def f(n):
+            return int(rffi.cast(lltype.Bool, rffi.cast(rffi.UCHAR, n)))
+        def g(n):
+            return int(rffi.cast(lltype.Bool, rffi.cast(rffi.SIGNEDCHAR, n)))
+        for fn in [f, g]:
+            assert self.interp_operations(fn, [0]) == 0
+            assert self.interp_operations(fn, [1]) == 1
+            assert self.interp_operations(fn, [2]) == 1
+            assert self.interp_operations(fn, [200]) == 1
+
     def test_int_signext(self):
         def f(n):
             return rffi.cast(rffi.SIGNEDCHAR, n)


### PR DESCRIPTION
`rewrite_op_force_cast` skips the `int_is_true` that makes a `Bool` 0/1 when the
source is an unsigned 1-byte type, so the JIT carries the raw byte instead:

```python
def f(n):
    c = rffi.cast(rffi.UCHAR, n)
    return int(rffi.cast(lltype.Bool, c))
```

```
today                        with this patch
  int_and %i0, $255 -> %i0     int_and %i0, $255 -> %i0
  int_return %i0               int_is_true %i0 -> %i0
                               int_return %i0
```

`f(200)` is 200 under the JIT and 1 under llinterp and the C backend, where
`bool_t` is `_Bool`. `translator/c/test/test_typed.py::test_bool_2` states the
contract: `rffi.cast(lltype.Bool, 2)` is 1, "`# and not 2`".

**Why only that source.** `Bool` is itself `(size 1, unsigned)`, so a `Char` or
`UCHAR` source satisfies the "target type includes the source range" early
return and never reaches the `Bool` arm below it. A *signed* byte has
`min1 == -128`, so it fails that test and is normalized correctly today, as is
every wider type.

**Why this looks like an oversight rather than an exemption.** The range
shortcut is `e3369a43fb1` (Armin, 2010), from a revision where `Bool` appears
nowhere in `rewrite_op_force_cast`. The `Bool` arm is `90387dd1964` (fijal and
plan_rich, 2015, *"fix for JIT force_cast(Bool, xyz)"*), added below that early
return together with a single test row — `(rffi.LONG, lltype.Bool, ...)`, 8
bytes wide, and so on the working side of it. `test_force_cast_ints` still has
no `Bool` row for any 1-byte source.

The same commit taught `check_force_cast()` that `int_is_true` means
`bool(value)`, so it can be asked whether today's behaviour is writable as a
correct expectation. It is not:

```
UCHAR -> Bool,   ""            REJECTED
UCHAR -> Bool,   int_is_true   ok
UCHAR -> USHORT, ""            ok     <- control: "" is accepted when correct
```

**The fix.** The range shortcut licenses skipping a conversion that would have
*preserved* the value; a cast to `Bool` has to *reduce* it, so the `Bool` case
belongs above the range tests rather than in the `elif` chain below them.
`Bool -> Bool` is unaffected — equal types return at the top of the function.

**Reachability.** Nothing hits this today. `force_cast` is produced only by
`rffi.cast()`, and the three non-test `rffi.cast(lltype.Bool, ...)` sites cast
from `rffi.INT` and from `rwin32.BOOL`, which is `rffi.LONG`. So this is a
latent miscompile. I would still rather fix it than guard it: `int_is_true` is
what this same function already emits for every other width, so the correct
behaviour is not an open question, and `rffi.cast(lltype.Bool, some_char)` is
legal RPython that the C backend compiles correctly — refusing it here would
break translation with the JIT for code that works without it.

**Tests.** The three missing `Bool` rows in `test_force_cast_ints`;
`test_force_cast_char_to_bool` for `lltype.Char`, which that table does not
cover; and `test_force_cast_to_bool` in `test_ajit.py`, end to end, with a
`SIGNEDCHAR` control arm that passes either way. All three fail without the fix,
the last with `assert 2 == 1`. Against the parent commit,
`jit/codewriter/test/` goes 508 → 509 passed and `test_ajit.py` 218 → 219.
