### PR TITLE
jit: thread handling_ovf into generate_last_exc() so a re-raised OverflowError survives

### DIFF
--- a/rpython/jit/codewriter/flatten.py
+++ b/rpython/jit/codewriter/flatten.py
@@ -151,7 +151,7 @@ class GraphFlattener(object):
             and link.last_exc_value not in link.args):
             self.make_return(link.args)     # optimization only
             return
-        self.insert_renamings(link)
+        self.insert_renamings(link, handling_ovf)
         self.make_bytecode_block(link.target, handling_ovf)
 
     def make_exception_link(self, link, handling_ovf):
@@ -303,7 +303,7 @@ class GraphFlattener(object):
                 self.emitline('-live-')
                 self.make_link(switch, handling_ovf)
 
-    def insert_renamings(self, link):
+    def insert_renamings(self, link, handling_ovf):
         renamings = {}
         lst = [(self.getcolor(v), self.getcolor(link.target.inputargs[i]))
                for i, v in enumerate(link.args)
@@ -331,13 +331,30 @@ class GraphFlattener(object):
                         self.emitline('%s_pop' % kind, "->", w)
                     else:
                         self.emitline('%s_copy' % kind, v, "->", w)
-        self.generate_last_exc(link, link.target.inputargs)
+        self.generate_last_exc(link, link.target.inputargs, handling_ovf)
 
-    def generate_last_exc(self, link, inputargs):
+    def generate_last_exc(self, link, inputargs, handling_ovf):
         # Write 'last_exc_xxx' operations that load the last exception
         # directly into the locations specified by 'inputargs'.  This
         # must be done at the end of the link renamings.
         if link.last_exception is link.last_exc_value is None:
+            return
+        if handling_ovf:
+            # this link is reached by int_xxx_jump_if_ovf, which jumps
+            # without writing the exception slots, so read a constant
+            # OverflowError instead of reading them
+            exc_data = self.cpu.rtyper.exceptiondata
+            ll_ovf = exc_data.get_standard_ll_exc_instance_by_class(
+                OverflowError)
+            c_class = Constant(ll_ovf.typeptr,
+                               concretetype=lltype.typeOf(ll_ovf.typeptr))
+            c_inst = Constant(ll_ovf, concretetype=lltype.typeOf(ll_ovf))
+            for v, w in zip(link.args, inputargs):
+                if v is link.last_exception:
+                    self.emitline("int_copy", c_class, "->", self.getcolor(w))
+            for v, w in zip(link.args, inputargs):
+                if v is link.last_exc_value:
+                    self.emitline("ref_copy", c_inst, "->", self.getcolor(w))
             return
         for v, w in zip(link.args, inputargs):
             if v is link.last_exception:

--- a/rpython/jit/codewriter/test/test_flatten.py
+++ b/rpython/jit/codewriter/test/test_flatten.py
@@ -2,7 +2,7 @@ import py, sys
 from rpython.jit.codewriter import support
 from rpython.jit.codewriter.flatten import flatten_graph, reorder_renaming_list
 from rpython.jit.codewriter.flatten import GraphFlattener, ListOfKind, Register
-from rpython.jit.codewriter.format import assert_format
+from rpython.jit.codewriter.format import assert_format, format_assembler
 from rpython.jit.codewriter import longlong
 from rpython.jit.codewriter.effectinfo import EffectInfo
 from rpython.jit.metainterp.history import AbstractDescr
@@ -155,6 +155,7 @@ class TestFlatten:
             compute_liveness(ssarepr)
         if expected is not None:
             assert_format(ssarepr, expected)
+        return format_assembler(ssarepr)
 
     def test_simple(self):
         def f(n):
@@ -630,6 +631,29 @@ class TestFlatten:
             L1:
             raise $<* struct object>
         """, transform=True, liveness=True)
+
+    def test_ovfcheck_reraise_caught_again_in_the_same_function(self):
+        # catching it a second time needs a class check on the exception, so
+        # the link reaches generate_last_exc() instead of the shortcut in
+        # make_exception_link() above.  int_add_jump_if_ovf jumps without
+        # writing the exception slots, so the exception has to be a constant
+        # here too.  Not a full expectation: the class check brings in a
+        # residual call whose arguments print as symbolics.
+        def f(i, j):
+            try:
+                try:
+                    return ovfcheck(j + i)
+                except OverflowError:
+                    raise
+            except OverflowError:
+                return 3
+        asm = self.encoding_test(f, [7, 2], None, transform=True,
+                                 liveness=True)
+        assert 'int_add_jump_if_ovf' in asm
+        assert 'last_exception' not in asm
+        assert 'last_exc_value' not in asm
+        assert 'int_copy $' in asm
+        assert 'ref_copy $' in asm
 
     def test_residual_call_raising(self):
         @dont_look_inside

--- a/rpython/jit/metainterp/test/test_ajit.py
+++ b/rpython/jit/metainterp/test/test_ajit.py
@@ -938,6 +938,36 @@ class BasicTests:
         res = self.interp_operations(f, [3, 2])
         assert res == 6
 
+    def test_ovf_reraise_caught_again_in_the_same_function(self):
+        # catching it a second time needs a class check on the exception, so
+        # generate_last_exc() emits last_exception/last_exc_value reads right
+        # after int_mul_jump_if_ovf -- which jumps without ever writing those
+        # slots.  Whether the first handler does any work is irrelevant.
+        def f(x, y):
+            try:
+                try:
+                    return ovfcheck(x * y)
+                except OverflowError:
+                    raise
+            except OverflowError:
+                return 3
+
+        def g(x, y):
+            try:
+                try:
+                    return ovfcheck(x * y)
+                except OverflowError:
+                    x += 1
+                    raise
+            except OverflowError:
+                return 3
+
+        for fn in [f, g]:
+            res = self.interp_operations(fn, [sys.maxint, 2])
+            assert res == 3
+            res = self.interp_operations(fn, [3, 2])
+            assert res == 6
+
     def test_int_sub_ovf(self):
         def f(x, y):
             try:


### PR DESCRIPTION
generated report below. I asked to scan every re-raise patterns and currently no code triggers this

----

An `OverflowError` from `ovfcheck()` that is re-raised out of its handler and
caught again in the same function raises `AttributeError` through the JIT.

## Reproducer

```python
from rpython.rlib.rarithmetic import ovfcheck

def f(n):
    try:
        try:
            return ovfcheck(n * n)
        except OverflowError:
            raise              # caught again just below
    except OverflowError:
        return -1
```

## How to run it

```python
from rpython.jit.metainterp.test.support import LLJitMixin

class Runner(LLJitMixin):
    pass

print f(4000000000)                                    # plain Python
print Runner().interp_operations(f, [4000000000])      # through the JIT
```

## Expected vs actual

Expected, and what plain Python and llinterp both give: `-1`.

Actual, through the JIT:

```
  File "rpython/jit/metainterp/blackhole.py", line 989, in bhimpl_last_exception
    real_instance = self.exception_last_value
AttributeError: 'BlackholeInterpreter' object has no attribute 'exception_last_value'
```

Blackhole trace, last two lines:

```
bh: int_mul_jump_if_ovf [11, 4000000000, 4000000000] -> (0, 11)
bh: last_exception [<BHInterp <JitCode 'f'>>] -> AttributeError!
```

## Emitted jitcode

Before:

```
 3  int_mul_jump_if_ovf L1, %i0, %i0 -> %i0
 9  int_return %i0
11  last_exception -> %i1
13  last_exc_value -> %r0
15  inline_call_ir_i <JitCode 'll_issubclass_const__object_vtablePtr_Signed_Signed'>, ...
```

After:

```
 3  int_mul_jump_if_ovf L1, %i0, %i0 -> %i0
 9  int_return %i0
11  int_copy $<* struct object_vtable> -> %i1
14  ref_copy $<* struct object> -> %r0
33  int_return $-1
38  raise %r0
```

## Which shapes are affected

`interp_operations(fn, [4000000000])`:

| shape | before | after |
|---|---|---|
| `try: ovfcheck(n*n)` / `except OverflowError: return -1` | `-1` | `-1` |
| the same, binding `except OverflowError as e` | `-1` | `-1` |
| nested, inner handler is a bare `raise` | **`AttributeError`** | `-1` |
| nested, inner handler does work, then `raise` | **`AttributeError`** | `-1` |
| `raise` with no outer handler in this function | `LLException 'OverflowError'` | unchanged |

## Tests

* `metainterp/test/test_ajit.py::test_ovf_reraise_caught_again_in_the_same_function`
  — end-to-end, covering both the bare re-raise and the does-work shape. Without
  the patch: `AttributeError: 'BlackholeInterpreter' object has no attribute
  'exception_last_value'`.
* `codewriter/test/test_flatten.py::test_ovfcheck_reraise_caught_again_in_the_same_function`
  — asserts `int_add_jump_if_ovf` is emitted and `last_exception` /
  `last_exc_value` are not. Without the patch the emitted assembler still
  contains `last_exception -> %i3`.

`encoding_test()` in `test_flatten.py` now returns the formatted assembler; it
previously returned `None`.
