### PR TITLE
jit: the assembler's register limit is never diagnosed

### DIFF
--- a/rpython/jit/codewriter/assembler.py
+++ b/rpython/jit/codewriter/assembler.py
@@ -38,6 +38,7 @@ class Assembler(object):
         self.setup(ssarepr.name)
         if num_regs is not None:
             self.count_regs.update(num_regs)
+            self.check_num_regs()
         ssarepr._insns_pos = []
         for insn in ssarepr.insns:
             ssarepr._insns_pos.append(len(self.code))
@@ -261,6 +262,17 @@ class Assembler(object):
                 target = self.label_positions[switchlabel.name]
                 as_dict[key] = target
             descr.attach(as_dict)
+
+    def check_num_regs(self):
+        # Limitation of the number of registers, from the single-byte
+        # encoding.  This has to be checked before writing the instructions:
+        # emit_reg() would otherwise chr() an index above 255, and
+        # check_result() below only runs once that has already happened.
+        # The bound is 255 and not 256 because JitCode.setup() stores the
+        # count itself in a single character.
+        for kind in KINDS:
+            assert self.count_regs[kind] <= 255, (
+                "too many %s registers: %d" % (kind, self.count_regs[kind]))
 
     def check_result(self):
         # Limitation of the number of registers, from the single-byte encoding

--- a/rpython/jit/codewriter/test/test_assembler.py
+++ b/rpython/jit/codewriter/test/test_assembler.py
@@ -221,6 +221,21 @@ def test_num_regs():
     assert jitcode.num_regs_r() == 28
     assert jitcode.num_regs_f() == 0
 
+def test_num_regs_too_many():
+    # a register index is one byte and JitCode.setup() stores the count in
+    # one character, so 255 is the most there can be.  Without the check in
+    # assemble(), 256 reaches JitCode.setup()'s own bare assert and 257 dies
+    # in emit_reg() with "chr() arg not in range(256)"
+    def assemble(n):
+        assembler = Assembler()
+        ssarepr = SSARepr("test")
+        ssarepr.insns = [('int_return', Register('int', n - 1))]
+        return assembler.assemble(ssarepr, num_regs={'int': n})
+    assert assemble(255).num_regs_i() == 255
+    for n in [256, 257]:
+        e = py.test.raises(AssertionError, assemble, n)
+        assert 'too many int registers: %d' % n in str(e.value)
+
 def test_liveness():
     ssarepr = SSARepr("test")
     i0, i1, i2 = Register('int', 0), Register('int', 1), Register('int', 2)


### PR DESCRIPTION
Not sure it is worth to fix or not, but trivially reproducible by:
<details> 
<summary>example.py</summary>

```
def f(x):
    v0 = x + 1
    v1 = v0 + 1
    v2 = v1 + 1
    v3 = v2 + 1
    v4 = v3 + 1
    v5 = v4 + 1
    v6 = v5 + 1
    v7 = v6 + 1
    v8 = v7 + 1
    v9 = v8 + 1
    v10 = v9 + 1
    v11 = v10 + 1
    v12 = v11 + 1
    v13 = v12 + 1
    v14 = v13 + 1
    v15 = v14 + 1
    v16 = v15 + 1
    v17 = v16 + 1
    v18 = v17 + 1
    v19 = v18 + 1
    v20 = v19 + 1
    v21 = v20 + 1
    v22 = v21 + 1
    v23 = v22 + 1
    v24 = v23 + 1
    v25 = v24 + 1
    v26 = v25 + 1
    v27 = v26 + 1
    v28 = v27 + 1
    v29 = v28 + 1
    v30 = v29 + 1
    v31 = v30 + 1
    v32 = v31 + 1
    v33 = v32 + 1
    v34 = v33 + 1
    v35 = v34 + 1
    v36 = v35 + 1
    v37 = v36 + 1
    v38 = v37 + 1
    v39 = v38 + 1
    v40 = v39 + 1
    v41 = v40 + 1
    v42 = v41 + 1
    v43 = v42 + 1
    v44 = v43 + 1
    v45 = v44 + 1
    v46 = v45 + 1
    v47 = v46 + 1
    v48 = v47 + 1
    v49 = v48 + 1
    v50 = v49 + 1
    v51 = v50 + 1
    v52 = v51 + 1
    v53 = v52 + 1
    v54 = v53 + 1
    v55 = v54 + 1
    v56 = v55 + 1
    v57 = v56 + 1
    v58 = v57 + 1
    v59 = v58 + 1
    v60 = v59 + 1
    v61 = v60 + 1
    v62 = v61 + 1
    v63 = v62 + 1
    v64 = v63 + 1
    v65 = v64 + 1
    v66 = v65 + 1
    v67 = v66 + 1
    v68 = v67 + 1
    v69 = v68 + 1
    v70 = v69 + 1
    v71 = v70 + 1
    v72 = v71 + 1
    v73 = v72 + 1
    v74 = v73 + 1
    v75 = v74 + 1
    v76 = v75 + 1
    v77 = v76 + 1
    v78 = v77 + 1
    v79 = v78 + 1
    v80 = v79 + 1
    v81 = v80 + 1
    v82 = v81 + 1
    v83 = v82 + 1
    v84 = v83 + 1
    v85 = v84 + 1
    v86 = v85 + 1
    v87 = v86 + 1
    v88 = v87 + 1
    v89 = v88 + 1
    v90 = v89 + 1
    v91 = v90 + 1
    v92 = v91 + 1
    v93 = v92 + 1
    v94 = v93 + 1
    v95 = v94 + 1
    v96 = v95 + 1
    v97 = v96 + 1
    v98 = v97 + 1
    v99 = v98 + 1
    v100 = v99 + 1
    v101 = v100 + 1
    v102 = v101 + 1
    v103 = v102 + 1
    v104 = v103 + 1
    v105 = v104 + 1
    v106 = v105 + 1
    v107 = v106 + 1
    v108 = v107 + 1
    v109 = v108 + 1
    v110 = v109 + 1
    v111 = v110 + 1
    v112 = v111 + 1
    v113 = v112 + 1
    v114 = v113 + 1
    v115 = v114 + 1
    v116 = v115 + 1
    v117 = v116 + 1
    v118 = v117 + 1
    v119 = v118 + 1
    v120 = v119 + 1
    v121 = v120 + 1
    v122 = v121 + 1
    v123 = v122 + 1
    v124 = v123 + 1
    v125 = v124 + 1
    v126 = v125 + 1
    v127 = v126 + 1
    v128 = v127 + 1
    v129 = v128 + 1
    v130 = v129 + 1
    v131 = v130 + 1
    v132 = v131 + 1
    v133 = v132 + 1
    v134 = v133 + 1
    v135 = v134 + 1
    v136 = v135 + 1
    v137 = v136 + 1
    v138 = v137 + 1
    v139 = v138 + 1
    v140 = v139 + 1
    v141 = v140 + 1
    v142 = v141 + 1
    v143 = v142 + 1
    v144 = v143 + 1
    v145 = v144 + 1
    v146 = v145 + 1
    v147 = v146 + 1
    v148 = v147 + 1
    v149 = v148 + 1
    v150 = v149 + 1
    v151 = v150 + 1
    v152 = v151 + 1
    v153 = v152 + 1
    v154 = v153 + 1
    v155 = v154 + 1
    v156 = v155 + 1
    v157 = v156 + 1
    v158 = v157 + 1
    v159 = v158 + 1
    v160 = v159 + 1
    v161 = v160 + 1
    v162 = v161 + 1
    v163 = v162 + 1
    v164 = v163 + 1
    v165 = v164 + 1
    v166 = v165 + 1
    v167 = v166 + 1
    v168 = v167 + 1
    v169 = v168 + 1
    v170 = v169 + 1
    v171 = v170 + 1
    v172 = v171 + 1
    v173 = v172 + 1
    v174 = v173 + 1
    v175 = v174 + 1
    v176 = v175 + 1
    v177 = v176 + 1
    v178 = v177 + 1
    v179 = v178 + 1
    v180 = v179 + 1
    v181 = v180 + 1
    v182 = v181 + 1
    v183 = v182 + 1
    v184 = v183 + 1
    v185 = v184 + 1
    v186 = v185 + 1
    v187 = v186 + 1
    v188 = v187 + 1
    v189 = v188 + 1
    v190 = v189 + 1
    v191 = v190 + 1
    v192 = v191 + 1
    v193 = v192 + 1
    v194 = v193 + 1
    v195 = v194 + 1
    v196 = v195 + 1
    v197 = v196 + 1
    v198 = v197 + 1
    v199 = v198 + 1
    v200 = v199 + 1
    v201 = v200 + 1
    v202 = v201 + 1
    v203 = v202 + 1
    v204 = v203 + 1
    v205 = v204 + 1
    v206 = v205 + 1
    v207 = v206 + 1
    v208 = v207 + 1
    v209 = v208 + 1
    v210 = v209 + 1
    v211 = v210 + 1
    v212 = v211 + 1
    v213 = v212 + 1
    v214 = v213 + 1
    v215 = v214 + 1
    v216 = v215 + 1
    v217 = v216 + 1
    v218 = v217 + 1
    v219 = v218 + 1
    v220 = v219 + 1
    v221 = v220 + 1
    v222 = v221 + 1
    v223 = v222 + 1
    v224 = v223 + 1
    v225 = v224 + 1
    v226 = v225 + 1
    v227 = v226 + 1
    v228 = v227 + 1
    v229 = v228 + 1
    v230 = v229 + 1
    v231 = v230 + 1
    v232 = v231 + 1
    v233 = v232 + 1
    v234 = v233 + 1
    v235 = v234 + 1
    v236 = v235 + 1
    v237 = v236 + 1
    v238 = v237 + 1
    v239 = v238 + 1
    v240 = v239 + 1
    v241 = v240 + 1
    v242 = v241 + 1
    v243 = v242 + 1
    v244 = v243 + 1
    v245 = v244 + 1
    v246 = v245 + 1
    v247 = v246 + 1
    v248 = v247 + 1
    v249 = v248 + 1
    v250 = v249 + 1
    v251 = v250 + 1
    v252 = v251 + 1
    v253 = v252 + 1
    v254 = v253 + 1
    v255 = v254 + 1
    return v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19 + v20 + v21 + v22 + v23 + v24 + v25 + v26 + v27 + v28 + v29 + v30 + v31 + v32 + v33 + v34 + v35 + v36 + v37 + v38 + v39 + v40 + v41 + v42 + v43 + v44 + v45 + v46 + v47 + v48 + v49 + v50 + v51 + v52 + v53 + v54 + v55 + v56 + v57 + v58 + v59 + v60 + v61 + v62 + v63 + v64 + v65 + v66 + v67 + v68 + v69 + v70 + v71 + v72 + v73 + v74 + v75 + v76 + v77 + v78 + v79 + v80 + v81 + v82 + v83 + v84 + v85 + v86 + v87 + v88 + v89 + v90 + v91 + v92 + v93 + v94 + v95 + v96 + v97 + v98 + v99 + v100 + v101 + v102 + v103 + v104 + v105 + v106 + v107 + v108 + v109 + v110 + v111 + v112 + v113 + v114 + v115 + v116 + v117 + v118 + v119 + v120 + v121 + v122 + v123 + v124 + v125 + v126 + v127 + v128 + v129 + v130 + v131 + v132 + v133 + v134 + v135 + v136 + v137 + v138 + v139 + v140 + v141 + v142 + v143 + v144 + v145 + v146 + v147 + v148 + v149 + v150 + v151 + v152 + v153 + v154 + v155 + v156 + v157 + v158 + v159 + v160 + v161 + v162 + v163 + v164 + v165 + v166 + v167 + v168 + v169 + v170 + v171 + v172 + v173 + v174 + v175 + v176 + v177 + v178 + v179 + v180 + v181 + v182 + v183 + v184 + v185 + v186 + v187 + v188 + v189 + v190 + v191 + v192 + v193 + v194 + v195 + v196 + v197 + v198 + v199 + v200 + v201 + v202 + v203 + v204 + v205 + v206 + v207 + v208 + v209 + v210 + v211 + v212 + v213 + v214 + v215 + v216 + v217 + v218 + v219 + v220 + v221 + v222 + v223 + v224 + v225 + v226 + v227 + v228 + v229 + v230 + v231 + v232 + v233 + v234 + v235 + v236 + v237 + v238 + v239 + v240 + v241 + v242 + v243 + v244 + v245 + v246 + v247 + v248 + v249 + v250 + v251 + v252 + v253 + v254 + v255
```
</details>


The below is generated description

----

`Assembler.check_result()` holds the asserts for the single-byte register
encoding, with the comment `Limitation of the number of registers, from the
single-byte encoding`. For the registers themselves it never fires: it runs
after every instruction has already been written.

Nothing in the tree gets near the limit, so this is about what happens when
something does. Crossing it with `n` locals live at once and no constants:

```python
def f(x):
    v0 = x + 1
    v1 = v0 + 1
    ...
    return v0 + v1 + ...
```

`CodeWriter().transform_func_to_jitcode(f, [5])`:

| n | today |
|---|---|
| 255 | ok, `num_regs_i=255`, `constants_i=0` |
| 256 | `AssertionError:` — with no message |
| 257 | `ValueError: character code not in range(256)` |

At 256, `check_result()`'s `count_regs + len(constants) <= 256` passes and the
failure comes from `JitCode.setup()`'s own `assert num_regs_i < 256` in another
module. At 257 it never gets that far: `emit_reg()` already called `chr(256)`
while writing the instructions.

Registers and constants share that one-byte index space, so with constants in
the function the report names the wrong one. Writing the same body as
`v0 = x + 0`, `v1 = x + 1`, ... gives `too many constants` from `emit_const()`
at 256 and 300 locals, where it is the registers alone that are over.

So the check runs after the encoding it guards, and its bound is wrong for
registers alone: the limit is 255, not 256, because `JitCode.setup()` stores the
count itself in a single character.

This checks the counts in `assemble()`, immediately after `count_regs` is filled
in from `num_regs`, where they are already final — `count_reg()` has no callers,
so nothing grows them later. 256 and 257 both give `too many int registers: N`.
`check_result()` is left alone; its constants half is enforced incrementally by
`emit_const()` anyway.

No successful compilation changes.
