### PR TITLE
Avoid deprecated sysconfig check_home arguments

### DIFF
--- a/lib-python/3/distutils/command/install.py
+++ b/lib-python/3/distutils/command/install.py
@@ -336,7 +336,7 @@ class install(Command):
             self.config_vars['userbase'] = self.install_userbase
             self.config_vars['usersite'] = self.install_usersite
 
-        if sysconfig.is_python_build(True):
+        if sysconfig.is_python_build():
             self.config_vars['srcdir'] = sysconfig.get_config_var('srcdir')
 
         self.expand_basedirs()

--- a/lib-python/3/distutils/tests/test_install.py
+++ b/lib-python/3/distutils/tests/test_install.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unittest
 import site
+import warnings
 
 from test.support import captured_stdout, requires_subprocess
 
@@ -182,6 +183,15 @@ class InstallTestCase(support.TempdirManager,
         cmd.prefix = None
         cmd.user = 'user'
         self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+
+    def test_finalize_options_does_not_use_deprecated_check_home(self):
+        dist = Distribution({'name': 'xx'})
+        cmd = install(dist)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'error', message='check_home argument is deprecated')
+            cmd.ensure_finalized()
 
     def test_record(self):
         install_dir = self.mkdtemp()

--- a/lib-python/3/test/test_venv.py
+++ b/lib-python/3/test/test_venv.py
@@ -18,6 +18,7 @@ import sys
 import sysconfig
 import tempfile
 import shlex
+import warnings
 from test.support import (captured_stdout, captured_stderr,
                           skip_if_broken_multiprocessing_synchronize, verbose,
                           requires_subprocess, is_emscripten, is_wasi,
@@ -123,6 +124,13 @@ class BasicTest(BaseTest):
         rmtree(self.env_dir)
         self.run_with_capture(venv.create, pathlib.Path(self.env_dir))
         self._check_output_of_default_create()
+
+    def test_create_does_not_use_deprecated_check_home(self):
+        rmtree(self.env_dir)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'error', message='check_home argument is deprecated')
+            venv.create(self.env_dir)
 
     def _check_output_of_default_create(self):
         self.isdir(self.bindir)

--- a/lib-python/3/venv/__init__.py
+++ b/lib-python/3/venv/__init__.py
@@ -401,7 +401,7 @@ class EnvBuilder:
                 else:
                     raise RuntimeError(f"problem finding exe {exe} in {suffixes}")
 
-            if sysconfig.is_python_build(True):
+            if sysconfig.is_python_build():
                 # copy init.tcl
                 for root, dirs, files in os.walk(context.python_dir):
                     if 'init.tcl' in files:


### PR DESCRIPTION
CPython fixed the same Python 3.11 warning in [python/cpython#98741](https://github.com/python/cpython/issues/98741). [PyPy 3.12](https://github.com/pypy/pypy/commit/9429f81e6550) already contains the corrected calls. Its py3.11 branch retained the deprecated arguments.

PyPy emits a `DeprecationWarning` when distutils or venv checks whether it is running from a source build.

Call `sysconfig.is_python_build` without its deprecated `check_home` argument in distutils and venv. Add regression coverage that promotes the `check_home` deprecation to an error in both runtime paths.
