### PR TITLE
Fix `bytes()`, `bytearray()` and `codecs` accepting `encoding=None`

### DIFF
--- a/pypy/interpreter/baseobjspace.py
+++ b/pypy/interpreter/baseobjspace.py
@@ -1822,6 +1822,22 @@ class ObjSpace(object):
     def text0_or_none_w(self, w_obj):
         return None if self.is_none(w_obj) else self.text0_w(w_obj)
 
+    def text_arg_w(self, w_obj, funcname, argname):
+        """Like text_w(), but reporting a failure the way the str converter
+        of CPython's Argument Clinic does.  Use it where an app-level None
+        must not be folded onto an omitted argument, which is what
+        text_or_none_w() above does."""
+        if self.is_none(w_obj):
+            # _PyArg_BadArgument() spells this type "None", not "NoneType"
+            raise oefmt(self.w_TypeError,
+                        "%s() argument '%s' must be str, not None",
+                        funcname, argname)
+        if not self.isinstance_w(w_obj, self.w_unicode):
+            raise oefmt(self.w_TypeError,
+                        "%s() argument '%s' must be str, not %T",
+                        funcname, argname, w_obj)
+        return self.text_w(w_obj)
+
     @specialize.argtype(1)
     def bytes_w(self, w_obj):
         """ Takes an application level :py:class:`bytes`

--- a/pypy/module/_codecs/interp_codecs.py
+++ b/pypy/module/_codecs/interp_codecs.py
@@ -611,8 +611,7 @@ def lookup_error(space, errors):
     return w_err_handler
 
 
-@unwrap_spec(encoding='text_or_none', errors='text_or_none')
-def encode(space, w_obj, encoding=None, errors=None):
+def encode(space, w_obj, w_encoding=None, w_errors=None):
     """encode(obj, [encoding[,errors]]) -> object
 
     Encodes obj using the codec registered for encoding. encoding defaults
@@ -622,6 +621,10 @@ def encode(space, w_obj, encoding=None, errors=None):
     'xmlcharrefreplace' as well as any other name registered with
     codecs.register_error that can handle ValueErrors.
     """
+    encoding = (None if w_encoding is None else
+                space.text_arg_w(w_encoding, 'encode', 'encoding'))
+    errors = (None if w_errors is None else
+              space.text_arg_w(w_errors, 'encode', 'errors'))
     if encoding is None:
         encoding = space.sys.defaultencoding
     w_encoder = space.getitem(lookup_codec(space, encoding), space.newint(0))
@@ -632,8 +635,7 @@ def readbuffer_encode(space, w_data, errors='strict'):
     s = space.getarg_w('s#', w_data)
     return space.newtuple2(space.newbytes(s), space.newint(len(s)))
 
-@unwrap_spec(encoding='text_or_none', errors='text_or_none')
-def decode(space, w_obj, encoding=None, errors=None):
+def decode(space, w_obj, w_encoding=None, w_errors=None):
     from pypy.objspace.std.unicodeobject import W_UnicodeObject
     """decode(obj, [encoding[,errors]]) -> object
 
@@ -644,6 +646,10 @@ def decode(space, w_obj, encoding=None, errors=None):
     as well as any other name registered with codecs.register_error that is
     able to handle ValueErrors.
     """
+    encoding = (None if w_encoding is None else
+                space.text_arg_w(w_encoding, 'decode', 'encoding'))
+    errors = (None if w_errors is None else
+              space.text_arg_w(w_errors, 'decode', 'errors'))
     if encoding is None:
         encoding = space.sys.defaultencoding
     w_decoder = space.getitem(lookup_codec(space, encoding), space.newint(1))

--- a/pypy/module/_codecs/test/test_codecs.py
+++ b/pypy/module/_codecs/test/test_codecs.py
@@ -11,6 +11,32 @@ class AppTestCodecs:
         import _codecs
         raises(TypeError, _codecs.register, 1)
 
+    def test_encode_decode_arguments_must_be_str(self):
+        # a supplied None is a type error; an omitted argument is not
+        import codecs
+        e = raises(TypeError, codecs.encode, 'a', 'utf-8', None)
+        assert str(e.value) == (
+            "encode() argument 'errors' must be str, not None")
+        e = raises(TypeError, codecs.encode, 'a', None, None)
+        assert str(e.value) == (
+            "encode() argument 'encoding' must be str, not None")
+        e = raises(TypeError, codecs.encode, 'a', 'utf-8', 1)
+        assert str(e.value) == (
+            "encode() argument 'errors' must be str, not int")
+        e = raises(TypeError, codecs.decode, b'a', 'utf-8', None)
+        assert str(e.value) == (
+            "decode() argument 'errors' must be str, not None")
+        e = raises(TypeError, codecs.decode, b'a', None, None)
+        assert str(e.value) == (
+            "decode() argument 'encoding' must be str, not None")
+        assert codecs.encode('a') == b'a'
+        assert codecs.encode('a', 'utf-8') == b'a'
+        assert codecs.encode('a', 'utf-8', 'strict') == b'a'
+        assert codecs.encode('a', encoding='utf-8') == b'a'
+        assert codecs.decode(b'a') == 'a'
+        assert codecs.decode(b'a', 'utf-8') == 'a'
+        assert codecs.decode(b'a', 'utf-8', 'strict') == 'a'
+
     def test_bigU_codecs(self):
         u = u'\U00010001\U00020002\U00030003\U00040004\U00050005'
         for encoding in ('utf-8', 'utf-16', 'utf-16-le', 'utf-16-be',

--- a/pypy/module/_multiprocessing/interp_semaphore.py
+++ b/pypy/module/_multiprocessing/interp_semaphore.py
@@ -569,10 +569,12 @@ class W_SemLock(W_Root):
     def _finalize_(self):
         delete_semaphore(self.handle)
 
-@unwrap_spec(kind=int, value=int, maxvalue=int, name='text', unlink=int)
-def descr_new(space, w_subtype, kind, value, maxvalue, name, unlink):
+@unwrap_spec(kind=int, value=int, maxvalue=int, unlink=int)
+def descr_new(space, w_subtype, kind, value, maxvalue, w_name, unlink):
     if kind != RECURSIVE_MUTEX and kind != SEMAPHORE:
         raise oefmt(space.w_ValueError, "unrecognized kind")
+
+    name = space.text_arg_w(w_name, 'SemLock', 'name')
 
     counter = space.fromcache(CounterState).getCount()
 

--- a/pypy/module/_multiprocessing/test/test_semaphore.py
+++ b/pypy/module/_multiprocessing/test/test_semaphore.py
@@ -69,6 +69,20 @@ class AppTestSemaphore:
         sem._after_fork()
         assert sem._count() == 0
 
+    def test_semaphore_name_must_be_str(self):
+        from _multiprocessing import SemLock
+        kind = self.SEMAPHORE
+        value = 1
+        maxvalue = 1
+        e = raises(TypeError, SemLock, kind, value, maxvalue, None,
+                    unlink=True)
+        assert str(e.value) == (
+            "SemLock() argument 'name' must be str, not None")
+        e = raises(TypeError, SemLock, kind, value, maxvalue, 1,
+                    unlink=True)
+        assert str(e.value) == (
+            "SemLock() argument 'name' must be str, not int")
+
     @pytest.mark.skipif(sys.platform == 'darwin', reason="Hangs on macOSX")
     def test_recursive(self):
         from _multiprocessing import SemLock

--- a/pypy/objspace/std/bytearrayobject.py
+++ b/pypy/objspace/std/bytearrayobject.py
@@ -243,9 +243,12 @@ class W_BytearrayObject(W_BufferExporter):
             w_result = space.call_function(w_bytearraytype, w_result)
         return w_result
 
-    @unwrap_spec(encoding='text_or_none', errors='text_or_none')
-    def descr_init(self, space, w_source=None, encoding=None, errors=None):
+    def descr_init(self, space, w_source=None, w_encoding=None, w_errors=None):
         assert isinstance(self, W_BytearrayObject)
+        encoding = (None if w_encoding is None else
+                    space.text_arg_w(w_encoding, 'bytearray', 'encoding'))
+        errors = (None if w_errors is None else
+                  space.text_arg_w(w_errors, 'bytearray', 'errors'))
         data = [c for c in newbytesdata_w(space, w_source, encoding, errors)]
         data += "\0"
         self._data = resizable_list_supporting_raw_ptr(data)

--- a/pypy/objspace/std/bytesobject.py
+++ b/pypy/objspace/std/bytesobject.py
@@ -559,9 +559,12 @@ class W_BytesObject(W_AbstractBytesObject):
         return space.newlist_bytes(lst)
 
     @staticmethod
-    @unwrap_spec(encoding='text_or_none', errors='text_or_none')
-    def descr_new(space, w_stringtype, w_source=None, encoding=None,
-                  errors=None):
+    def descr_new(space, w_stringtype, w_source=None, w_encoding=None,
+                  w_errors=None):
+        encoding = (None if w_encoding is None else
+                    space.text_arg_w(w_encoding, 'bytes', 'encoding'))
+        errors = (None if w_errors is None else
+                  space.text_arg_w(w_errors, 'bytes', 'errors'))
         if (w_source and space.is_w(w_stringtype, space.w_bytes)
                 and encoding is None and errors is None):
             # special-case 'bytes(byte_object)'

--- a/pypy/objspace/std/test/test_bytearrayobject.py
+++ b/pypy/objspace/std/test/test_bytearrayobject.py
@@ -832,6 +832,25 @@ class AppTestBytesArray:
         raises(TypeError, bytearray, b'', 'ascii')
         raises(TypeError, bytearray, '')
 
+    def test_constructor_encoding_must_be_str(self):
+        # a supplied None is a type error; an omitted argument is not
+        e = raises(TypeError, bytearray, 0, None)
+        assert str(e.value) == (
+            "bytearray() argument 'encoding' must be str, not None")
+        e = raises(TypeError, bytearray, 'abc', None)
+        assert str(e.value) == (
+            "bytearray() argument 'encoding' must be str, not None")
+        e = raises(TypeError, bytearray, 0, 1)
+        assert str(e.value) == (
+            "bytearray() argument 'encoding' must be str, not int")
+        e = raises(TypeError, bytearray, 0, 'utf-8', None)
+        assert str(e.value) == (
+            "bytearray() argument 'errors' must be str, not None")
+        assert bytearray(0) == bytearray(b'')
+        assert bytearray('abc', 'utf-8') == bytearray(b'abc')
+        assert bytearray('abc', 'utf-8', 'strict') == bytearray(b'abc')
+        assert bytearray('abc', encoding='utf-8') == bytearray(b'abc')
+
     def test_dont_force_offset(self):
         def make(x=b'abcdefghij', shift=3):
             b = bytearray(b'?'*shift + x)

--- a/pypy/objspace/std/test/test_bytesobject.py
+++ b/pypy/objspace/std/test/test_bytesobject.py
@@ -1062,6 +1062,25 @@ class AppTestBytesObject:
         raises(TypeError, bytes, b'', 'ascii')
         raises(TypeError, bytes, '')
 
+    def test_constructor_encoding_must_be_str(self):
+        # a supplied None is a type error; an omitted argument is not
+        e = raises(TypeError, bytes, (), None)
+        assert str(e.value) == (
+            "bytes() argument 'encoding' must be str, not None")
+        e = raises(TypeError, bytes, 'abc', None)
+        assert str(e.value) == (
+            "bytes() argument 'encoding' must be str, not None")
+        e = raises(TypeError, bytes, (), 1)
+        assert str(e.value) == (
+            "bytes() argument 'encoding' must be str, not int")
+        e = raises(TypeError, bytes, (), 'utf-8', None)
+        assert str(e.value) == (
+            "bytes() argument 'errors' must be str, not None")
+        assert bytes(()) == b''
+        assert bytes('abc', 'utf-8') == b'abc'
+        assert bytes('abc', 'utf-8', 'strict') == b'abc'
+        assert bytes('abc', encoding='utf-8') == b'abc'
+
     def test_constructor_subclass(self):
         class Sub(bytes):
             pass


### PR DESCRIPTION
## Description

`bytes()`, `bytearray()`, `codecs.encode()` and `codecs.decode()` accept an explicit `None` for `encoding` or `errors` and carry on with the default, where CPython raises `TypeError`. All four declare `@unwrap_spec(encoding='text_or_none', errors='text_or_none')`, and `space.text_or_none_w` maps an app-level `None` onto the RPython `None` an omitted argument already carries, so nothing downstream can tell `bytearray(0, None)` from `bytearray(0)`. CPython types these parameters as clinic `str` and decides presence from `fastargs[1] != NULL` before checking the value, so a supplied `None` reaches [`_PyArg_BadArgument`](https://github.com/python/cpython/blob/v3.11.15/Objects/clinic/bytearrayobject.c.h#L36-L40). `str()` already gets this right in PyPy, since it takes its two arguments wrapped and unwraps them in `get_encoding_and_errors`.

#### AS-IS
```
>>>> bytearray(0, None)
bytearray(b'')
>>>> bytes((), None)
b''
>>>> codecs.encode('a', 'utf-8', None)
b'a'
>>>> codecs.decode(b'a', 'utf-8', None)
'a'
```

#### TO-BE
```
>>> bytearray(0, None)
TypeError: bytearray() argument 'encoding' must be str, not None
>>> bytes((), None)
TypeError: bytes() argument 'encoding' must be str, not None
>>> codecs.encode('a', 'utf-8', None)
TypeError: encode() argument 'errors' must be str, not None
>>> codecs.decode(b'a', 'utf-8', None)
TypeError: decode() argument 'errors' must be str, not None
```
(matching CPython 3.11.15)

For the codecs the `None` is not merely a wrong type: it is read as `'strict'`, so code that passed `errors='ignore'` through a wrapper gets a `UnicodeEncodeError` that CPython never reaches. `bytes('abc', None)` and `bytearray('abc', None)` also change, from `string argument without an encoding` to the message above.

## Changes

- Add `space.text_arg_w()` next to `text_or_none_w()`. It unwraps a `str` and reports a failure the way the Argument Clinic converter does. It takes only wrapped values, so the caller still decides what an omitted argument means.
- Take `encoding` and `errors` wrapped in `bytes.__new__`, `bytearray.__init__`, `codecs.encode` and `codecs.decode`, and route them through it. `text_or_none` itself is unchanged: the AST and typedef layers rely on its current meaning.
- Add tests for the four constructors and functions.