### PR TITLE
Fix `int()` raising `TypeError` instead of `ValueError` for a bad base

### DIFF
--- a/pypy/objspace/std/intobject.py
+++ b/pypy/objspace/std/intobject.py
@@ -1075,7 +1075,14 @@ def _new_baseint(space, w_value, w_base=None):
         except OperationError as e:
             if not e.match(space, space.w_OverflowError):
                 raise
-            base = 37 # this raises the right error in string_to_bigint()
+            base = 37 # out of range, so the check below raises
+
+        # CPython validates the base range in long_new_impl(), before it
+        # dispatches on the type of the value.  The message is the one
+        # NumberStringParser builds for the string path.
+        if base != 0 and (base < 2 or base > 36):
+            raise oefmt(space.w_ValueError,
+                        "int() base must be >= 2 and <= 36, or 0")
 
         if space.isinstance_w(w_value, space.w_unicode):
             from pypy.objspace.std.unicodeobject import unicode_to_decimal_w

--- a/pypy/objspace/std/test/test_intobject.py
+++ b/pypy/objspace/std/test/test_intobject.py
@@ -427,6 +427,19 @@ class TestW_IntObject:
         assert result == f1
 
 class AppTestInt(object):
+    def test_base_range_checked_before_value_type(self):
+        # CPython's long_new_impl validates the base range before it dispatches
+        # on the type of the first argument.
+        raises(ValueError, int, None, 1)
+        raises(ValueError, int, None, -35)
+        raises(ValueError, int, None, 37)
+        raises(ValueError, int, [], 1)
+        raises(ValueError, int, '10', 1)
+        raises(TypeError, int, None, 10)
+        assert int('10', 2) == 2
+        assert int('ff', 16) == 255
+        assert int('10', 0) == 10
+
     def test_hash(self):
         assert hash(-1) == (-1).__hash__() == -2
         assert hash(-2) == (-2).__hash__() == -2


### PR DESCRIPTION
## Description

`int(x, base)` with a non-string `x` and an out-of-range `base` raises `TypeError`, where CPython raises `ValueError`. `_new_baseint` converts `base` with `space.getindex_w` but leaves the range check to the number parser in `rpython/rlib/rstring.py`, which is only reachable once `x` has been accepted as `str`, `bytes`, or `bytearray`. CPython's [`long_new_impl`](https://github.com/python/cpython/blob/v3.11.15/Objects/longobject.c#L5380-L5390) checks the range before it dispatches on the type of `x`.

#### AS-IS
```
>>>> int(None, 1)
TypeError: int() can't convert non-string with explicit base
```

#### TO-BE
```
>>> int(None, 1)
ValueError: int() base must be >= 2 and <= 36, or 0
```
(matching CPython 3.11.15)

## Changes

- Range-check `base` in `_new_baseint` right after `space.getindex_w`, ahead of the `str` / `bytes` / non-string dispatch. The string path already produces this exact message through `rpython/rlib/rstring.py`, so the check moves rather than a new message being introduced.
- Add a test that an out-of-range base wins over the non-string `TypeError`.