### PR TITLE
Properly handle tp_dictoffset

### DIFF
--- a/pypy/module/cpyext/object.py
+++ b/pypy/module/cpyext/object.py
@@ -78,7 +78,14 @@ def _dealloc(space, obj):
 
 @cpython_api([PyObject], PyObjectP, error=CANNOT_FAIL)
 def _PyObject_GetDictPtr(space, op):
-    return lltype.nullptr(PyObjectP.TO)
+    pytype = op.c_ob_type
+    dictoffset = pytype.c_tp_dictoffset
+    if not dictoffset:
+        return lltype.nullptr(PyObjectP.TO)
+    if dictoffset < 0:
+        dictoffset += pytype.c_tp_basicsize
+    loc = rffi.ptradd(cts.cast("char *", op), dictoffset)
+    return cts.cast("PyObject **", loc)
 
 @cpython_api([PyObject], rffi.INT_real, error=-1)
 def PyObject_IsTrue(space, w_obj):

--- a/pypy/module/cpyext/pyobject.py
+++ b/pypy/module/cpyext/pyobject.py
@@ -13,6 +13,8 @@ from pypy.objspace.std.typeobject import W_TypeObject
 from pypy.objspace.std.noneobject import W_NoneObject
 from pypy.objspace.std.boolobject import W_BoolObject
 from pypy.objspace.std.objectobject import W_ObjectObject
+from pypy.objspace.std.dictmultiobject import W_DictMultiObject
+from pypy.objspace.std.mapdict import DevolvedDictTerminator
 from rpython.rlib.objectmodel import specialize, we_are_translated
 from rpython.rlib.objectmodel import keepalive_until_here
 from rpython.rtyper.annlowlevel import llhelper, cast_instance_to_base_ptr
@@ -263,23 +265,43 @@ def create_ref(space, w_obj, w_userdata=None, immortal=False):
     py_obj.c_ob_refcnt -= 1
     #
     typedescr.attach(space, py_obj, w_obj, w_userdata)
-    # This is probably not the best place for this stanza, but we need the
-    # w_obj so it cannot be done in allocate()
-    # It should probably also be in track_reference
-    if pytype.c_tp_dictoffset:
-        dictoffset = pytype.c_tp_dictoffset
-        try:
-            w_dict = space.getattr(w_obj, space.newtext("__dict__"))
-        except OperationError as e:
-            dictref = make_ref(space, space.w_None)
-        else:
-            dictref = make_ref(space, w_dict)
-        if dictoffset < 0:
-            dictoffset += pytype.c_tp_basicsize
-        loc = rffi.ptradd(cts.cast("char *", py_obj), dictoffset)
-        dictloc = cts.cast("PyObject **", loc)
-        dictloc[0] = dictref
     return py_obj
+
+
+class CPyExtDictTerminator(DevolvedDictTerminator):
+    """Per-class terminator for cpyext types with a nonzero tp_dictoffset
+    (see W_PyCTypeObject.get_terminator in cpyext/typeobject.py, overriding
+    W_TypeObject.get_terminator). Subclasses DevolvedDictTerminator so every
+    dict-kind attribute access already routes through obj.getdict() -- there
+    is no per-object unboxed fast path, because the C struct field must stay
+    authoritative. dictoffset is fixed per w_cls (basicsize doesn't vary per
+    instance), so it's computed once by the caller instead of re-read here.
+    """
+    def __init__(self, space, w_cls, dictoffset):
+        DevolvedDictTerminator.__init__(self, space, w_cls)
+        self.dictoffset = dictoffset
+
+    def build_dict(self, obj, space):
+        # Called once per object (mapdict caches the result), so this is not
+        # a hot path -- no need for a live/re-checking strategy here. Either
+        # adopt whatever's already published at the struct field, or create
+        # and publish a plain dict, mirroring PyObject_GenericGetDict's
+        # get-or-create semantics. Either way there's exactly one dict
+        # object for the lifetime of the instance: the struct field and
+        # obj.getdict() always agree because they name the same object,
+        # not because anything re-checks them against each other.
+        py_obj = as_pyobj(space, obj)
+        loc = rffi.ptradd(cts.cast("char *", py_obj), self.dictoffset)
+        dictptr = cts.cast("PyObject **", loc)
+        pyobj = dictptr[0]
+        if pyobj:
+            result = from_ref(space, pyobj)
+        else:
+            result = space.newdict()
+            dictptr[0] = make_ref(space, result)
+        assert isinstance(result, W_DictMultiObject)
+        return result
+
 
 def track_reference(space, py_obj, w_obj):
     """

--- a/pypy/module/cpyext/src/object.c
+++ b/pypy/module/cpyext/src/object.c
@@ -262,10 +262,9 @@ int
 _PyObject_VisitManagedDict(PyObject *obj, visitproc visit, void *arg)
 {
     PyTypeObject *tp = Py_TYPE(obj);
-    if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
+    if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0 || !tp->tp_dictoffset) {
         return 0;
     }
-    assert(tp->tp_dictoffset);
     PyObject **dictptr = (PyObject **)((char *)obj + tp->tp_dictoffset);
     if (*dictptr != NULL) {
         int vret = visit(*dictptr, arg);
@@ -279,10 +278,9 @@ void
 _PyObject_ClearManagedDict(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
-    if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
+    if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0 || !tp->tp_dictoffset) {
         return;
     }
-    assert(tp->tp_dictoffset);
     PyObject **dictptr = (PyObject **)((char *)obj + tp->tp_dictoffset);
     Py_CLEAR(*dictptr);
 }

--- a/pypy/module/cpyext/test/test_typeobject.py
+++ b/pypy/module/cpyext/test/test_typeobject.py
@@ -2616,6 +2616,36 @@ class AppTestSlots(AppTestCpythonExtensionBase):
         assert dict1 is dict4
         assert isinstance(dict1, dict)
 
+    def test_managed_dict(self):
+        # Cython sets Py_TPFLAGS_MANAGED_DICT without an explicit
+        # __dictoffset__ member (that's the whole point of the flag on
+        # CPython -- storage is managed internally, not at a fixed struct
+        # offset). This used to raise "cannot use Py_TPFLAGS_MANAGED_DICT"
+        # at type-creation time.
+        module = self.import_extension("foo", [
+            ("get_managed_dict_type", "METH_NOARGS",
+            """
+                    return PyType_FromSpec(&ManagedDict_spec);
+            """),
+            ], prologue="""
+                static PyType_Slot ManagedDict_slots[] = {
+                    {0, 0},
+                };
+
+                static PyType_Spec ManagedDict_spec = {
+                    "foo.ManagedDict",
+                    sizeof(PyObject),
+                    0,
+                    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_MANAGED_DICT,
+                    ManagedDict_slots
+                };
+            """)
+        w_managed_dict_type = module.get_managed_dict_type()
+        inst = w_managed_dict_type()
+        inst.foo = 42
+        assert inst.foo == 42
+        assert inst.__dict__ == {"foo": 42}
+
     def test_unhashable(self):
         if not self.runappdirect:
             skip('pointer to function equality available'

--- a/pypy/module/cpyext/test/test_typeobject.py
+++ b/pypy/module/cpyext/test/test_typeobject.py
@@ -696,6 +696,75 @@ class AppTestSlots(AppTestCpythonExtensionBase):
         cls.w__check_type_object = cls.space.wrap(
             gateway.interp2app(_check_type_object))
 
+    def test_nanobind2_tp_traverse(self):
+        # Taken from https://github.com/wjakob/pypy_issues at commit 89a8585
+        import gc
+        import sys
+        if sys.implementation.name == 'pypy':
+            skip("tp_traverse not yet implemented in PyPy")
+        module = self.import_module(name='nanobind2', filename="nanobind2")
+        # Create an unreferenced cycle
+        a = module.wrapper()
+        a.nested = a
+        del a
+        for i in range(5):
+            gc.collect()
+        gl = module.global_list
+        assert gl == ['wrapper tp_init called.',
+                      'wrapper tp_traverse called.',
+                      'wrapper tp_traverse called.',
+                      'wrapper tp_clear called.',
+                      'wrapper tp_dealloc called.',
+                     ]
+
+    def test_nanobind2_module_attributes(self):
+        # Taken from https://github.com/wjakob/pypy_issues at commit 89a8585
+        import sys
+        module = self.import_module(name='nanobind2', filename="nanobind2")
+
+        f = module.func()
+        if sys.version_info >= (3, 9) or sys.implementation.name == 'pypy':
+            assert f.__module__   == "my_module"
+        else:
+            assert f.__module__   == "nanobind2"
+        assert f.__name__ == "my_name"
+        assert f.__qualname__ == "my_qualname"
+
+    def test_nanobind2_vectorcall_method(self):
+        # Taken from https://github.com/wjakob/pypy_issues at commit 89a8585
+        module = self.import_module(name='nanobind2', filename="nanobind2")
+
+        class A:
+            def __init__(self):
+                self.value = 0
+
+            def my_method(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+                return "success"
+
+        a = A()
+        assert module.method_call(a) == "success"
+        assert a.args == (1234,) and a.kwargs == {}
+        assert module.method_call_kw(a) == "success"
+        assert a.args == (1234,) and a.kwargs == {"foo" : "bar"}
+
+
+        def unbound_method(*args, **kwargs):
+            args_value.update(args)
+            kwargs_value.update(kwargs)
+            return "unbound"
+
+        a.my_method = unbound_method
+        kwargs_value = {}
+        args_value = set()
+
+
+        assert module.method_call(a) == "unbound"
+        assert args_value == set([1234]) and kwargs_value == {}
+        assert module.method_call_kw(a) == "unbound"
+        assert args_value == set([1234]) and kwargs_value == {"foo" : "bar"}
+
     def test_sq_item_negative_index(self):
         # issue 5526: __getitem__/__setitem__/__delitem__ must adjust a
         # negative index with sq_length before handing it to the slot,
@@ -2449,8 +2518,104 @@ class AppTestSlots(AppTestCpythonExtensionBase):
         inst = module.negative_dictoffset()()
         inst.foo = 42
         assert inst.dictobj == inst.__dict__
-        assert inst.dictobj == {"foo": 42} 
- 
+        assert inst.dictobj == {"foo": 42}
+
+    def test_dictoffset_struct_field_sync(self):
+        # https://github.com/pypy/pypy/issues/5515 -- a tp_new that
+        # explicitly zeroes the raw __dictoffset__ struct field (as CPython
+        # extensions do to get lazy dict creation) must not desync it from
+        # what PyObject_GenericGetDict/__dict__/_PyObject_GetDictPtr see.
+        module = self.import_extension("foo", [
+            ("get_custom_type", "METH_NOARGS",
+            """
+                    return PyType_FromSpec(&Custom_spec);
+            """),
+            ("investigate_dict", "METH_O",
+            """
+                    PyObject *dict1 = PyObject_GenericGetDict(args, NULL);
+                    PyObject *dict2 = ((CustomObject *)args)->d;
+                    Py_XINCREF(dict2);
+                    PyObject *dict3 = PyObject_GetAttrString(args, "__dict__");
+                    PyObject *dict4 = NULL;
+                    PyObject **dict4p = _PyObject_GetDictPtr(args);
+                    if (dict4p) {
+                        dict4 = *dict4p;
+                        Py_XINCREF(dict4);
+                    }
+                    if (!dict1 || !dict2 || !dict3 || !dict4) {
+                        Py_XDECREF(dict1);
+                        Py_XDECREF(dict2);
+                        Py_XDECREF(dict3);
+                        Py_XDECREF(dict4);
+                        Py_RETURN_NONE;
+                    }
+                    return Py_BuildValue("(OOOO)", dict1, dict2, dict3, dict4);
+            """),
+
+            ], prologue="""
+                #include <structmember.h>
+                typedef struct {
+                    PyObject_HEAD
+                    PyObject *d;
+                } CustomObject;
+
+                static PyObject *
+                Custom_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+                {
+                    CustomObject *self;
+                    self = (CustomObject *) type->tp_alloc(type, 0);
+                    if (self != NULL) {
+                        self->d = NULL;
+                    }
+                    return (PyObject *) self;
+                }
+
+                static void
+                Custom_dealloc(CustomObject *self)
+                {
+                    PyTypeObject *tp = Py_TYPE(self);
+                    Py_XDECREF(self->d);
+                    PyObject_Free(self);
+                    Py_DECREF(tp);
+                }
+
+                static PyMemberDef Custom_members[] = {
+                    {"__dictoffset__", T_PYSSIZET, offsetof(CustomObject, d),
+                        READONLY, 0},
+                    {NULL}
+                };
+
+                static PyGetSetDef Custom_getsets[] = {
+                    {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
+                    {NULL}
+                };
+
+                static PyType_Slot Custom_slots[] = {
+                    {Py_tp_members, Custom_members},
+                    {Py_tp_getset, Custom_getsets},
+                    {Py_tp_new, Custom_new},
+                    {Py_tp_dealloc, Custom_dealloc},
+                    {0, 0},
+                };
+
+                static PyType_Spec Custom_spec = {
+                    "foo.Custom",
+                    sizeof(CustomObject),
+                    0,
+                    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+                    Custom_slots
+                };
+            """)
+        w_custom_type = module.get_custom_type()
+        inst = w_custom_type()
+        result = module.investigate_dict(inst)
+        assert result is not None
+        dict1, dict2, dict3, dict4 = result
+        assert dict1 is dict2
+        assert dict1 is dict3
+        assert dict1 is dict4
+        assert isinstance(dict1, dict)
+
     def test_unhashable(self):
         if not self.runappdirect:
             skip('pointer to function equality available'
@@ -2596,75 +2761,6 @@ class AppTestSlots(AppTestCpythonExtensionBase):
             assert value == 1234
 
         module.call(f)
-
-    def test_nanobind2_tp_traverse(self):
-        # Taken from https://github.com/wjakob/pypy_issues at commit 89a8585
-        import gc
-        import sys
-        if sys.implementation.name == 'pypy':
-            skip("tp_traverse not yet implemented in PyPy")
-        module = self.import_module(name='nanobind2', filename="nanobind2")
-        # Create an unreferenced cycle
-        a = module.wrapper()
-        a.nested = a
-        del a
-        for i in range(5):
-            gc.collect()
-        gl = module.global_list
-        assert gl == ['wrapper tp_init called.',
-                      'wrapper tp_traverse called.',
-                      'wrapper tp_traverse called.',
-                      'wrapper tp_clear called.',
-                      'wrapper tp_dealloc called.',
-                     ]
-
-    def test_nanobind2_module_attributes(self):
-        # Taken from https://github.com/wjakob/pypy_issues at commit 89a8585
-        import sys
-        module = self.import_module(name='nanobind2', filename="nanobind2")
-
-        f = module.func()
-        if sys.version_info >= (3, 9) or sys.implementation.name == 'pypy':
-            assert f.__module__   == "my_module"
-        else:
-            assert f.__module__   == "nanobind2"
-        assert f.__name__ == "my_name"
-        assert f.__qualname__ == "my_qualname"
-
-    def test_nanobind2_vectorcall_method(self):
-        # Taken from https://github.com/wjakob/pypy_issues at commit 89a8585
-        module = self.import_module(name='nanobind2', filename="nanobind2")
-
-        class A:
-            def __init__(self):
-                self.value = 0
-
-            def my_method(self, *args, **kwargs):
-                self.args = args
-                self.kwargs = kwargs
-                return "success"
-
-        a = A()
-        assert module.method_call(a) == "success"
-        assert a.args == (1234,) and a.kwargs == {}
-        assert module.method_call_kw(a) == "success"
-        assert a.args == (1234,) and a.kwargs == {"foo" : "bar"}
-
-
-        def unbound_method(*args, **kwargs):
-            args_value.update(args)
-            kwargs_value.update(kwargs)
-            return "unbound"
-
-        a.my_method = unbound_method
-        kwargs_value = {}
-        args_value = set()
-
-
-        assert module.method_call(a) == "unbound"
-        assert args_value == set([1234]) and kwargs_value == {}
-        assert module.method_call_kw(a) == "unbound"
-        assert args_value == set([1234]) and kwargs_value == {"foo" : "bar"}
 
     def test_nanobind3(self):
         module = self.import_module(name='nanobind3', filename="nanobind3")

--- a/pypy/module/cpyext/typeobject.py
+++ b/pypy/module/cpyext/typeobject.py
@@ -33,7 +33,7 @@ from pypy.module.cpyext.methodobject import (W_PyCClassMethodObject,
 from pypy.module.cpyext.modsupport import convert_method_defs
 from pypy.module.cpyext.pyobject import (
     make_ref, from_ref, get_typedescr, make_typedescr,
-    track_reference, decref, as_pyobj, incref)
+    track_reference, decref, as_pyobj, incref, CPyExtDictTerminator)
 from pypy.module.cpyext.slotdefs import (
     slotdefs_for_tp_slots, slotdefs_for_wrappers, get_slot_tp_function,
     llslot)
@@ -606,6 +606,8 @@ def get_type_name(name):
 
 
 class W_PyCTypeObject(W_TypeObject):
+    _cpyext_dictoffset = 0
+
     @jit.dont_look_inside
     def __init__(self, space, pto):
         bases_w = space.fixedview(from_ref(space, pto.c_tp_bases))
@@ -662,6 +664,10 @@ class W_PyCTypeObject(W_TypeObject):
         if pto.c_tp_weaklistoffset > 0:
             extra -= rffi.sizeof(rffi.VOIDP)
         new_layout = (extra > 0 or pto.c_tp_itemsize > 0)
+        dictoffset = pto.c_tp_dictoffset
+        if dictoffset < 0:
+            dictoffset += pto.c_tp_basicsize
+        self._cpyext_dictoffset = dictoffset
         self.flag_cpytype = True
         W_TypeObject.__init__(self, space, name,
             bases_w or [space.w_object], dict_w, force_new_layout=new_layout,
@@ -676,6 +682,11 @@ class W_PyCTypeObject(W_TypeObject):
             rawdoc = rffi.constcharp2str(pto.c_tp_doc)
             self.w_doc = space.newtext_or_none(extract_doc(rawdoc, name))
             self.text_signature = extract_txtsig(rawdoc, name)
+
+    def get_terminator(self, space, typedef):
+        if self._cpyext_dictoffset:
+            return CPyExtDictTerminator(space, self, self._cpyext_dictoffset)
+        return W_TypeObject.get_terminator(self, space, typedef)
 
     def _cpyext_attach_pyobj(self, space, py_obj):
         self._cpy_ref = py_obj

--- a/pypy/module/cpyext/typeobject.py
+++ b/pypy/module/cpyext/typeobject.py
@@ -19,7 +19,7 @@ from pypy.module.cpyext.api import (
     Py_TPFLAGS_LONG_SUBCLASS, Py_TPFLAGS_LIST_SUBCLASS,
     Py_TPFLAGS_TUPLE_SUBCLASS, Py_TPFLAGS_UNICODE_SUBCLASS,
     Py_TPFLAGS_DICT_SUBCLASS, Py_TPFLAGS_BASE_EXC_SUBCLASS,
-    Py_TPFLAGS_TYPE_SUBCLASS, Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_WEAKREF,
+    Py_TPFLAGS_TYPE_SUBCLASS, Py_TPFLAGS_MANAGED_WEAKREF,
     Py_TPFLAGS_BYTES_SUBCLASS, Py_TPFLAGS_BASETYPE, Py_TPFLAGS_DISALLOW_INSTANTIATION,
     Py_TPFLAGS_HAVE_VECTORCALL, Py_TPFLAGS_METHOD_DESCRIPTOR, Py_TPFLAGS_IMMUTABLETYPE,
     Py_TPFLAGS_HAVE_GC,
@@ -896,8 +896,6 @@ def type_realize(space, py_obj):
     flags = widen(pto.c_tp_flags)
     assert flags & Py_TPFLAGS_READY == 0
     assert flags & Py_TPFLAGS_READYING == 0
-    if flags & Py_TPFLAGS_MANAGED_DICT:
-        raise oefmt(space.w_RuntimeError, "cannot use Py_TPFLAGS_MANAGED_DICT")
     if flags & Py_TPFLAGS_MANAGED_WEAKREF:
         raise oefmt(space.w_RuntimeError, "cannot use Py_TPFLAGS_MANAGED_WEAKREF")
     pto.c_tp_flags = rffi.cast(rffi.ULONG, flags | Py_TPFLAGS_READYING)

--- a/pypy/objspace/std/mapdict.py
+++ b/pypy/objspace/std/mapdict.py
@@ -312,6 +312,17 @@ class Terminator(AbstractAttribute):
     def _read_terminator(self, obj, name, attrkind):
         return None
 
+    def build_dict(self, obj, space):
+        """Build the W_DictMultiObject returned by obj.getdict() the first
+        time it's requested (see _obj_getdict below). Overridden by
+        CPyExtDictTerminator (pypy.module.cpyext.pyobject) to back the dict
+        with the C-visible tp_dictoffset field instead of this object's own
+        mapdict storage; kept here, not in cpyext, so mapdict.py doesn't
+        need to know cpyext exists."""
+        strategy = space.fromcache(MapDictStrategy)
+        storage = strategy.erase(obj)
+        return W_DictObject(space, strategy, storage)
+
     def _write_terminator(self, obj, name, attrkind, w_value):
         obj._get_mapdict_map().add_attr(obj, name, attrkind, w_value)
         if attrkind == DICT and obj._get_mapdict_map().num_attributes() >= LIMIT_MAP_ATTRIBUTES:
@@ -874,9 +885,7 @@ def _obj_getdict(self, space):
         assert isinstance(w_dict, W_DictMultiObject)
         return w_dict
 
-    strategy = space.fromcache(MapDictStrategy)
-    storage = strategy.erase(self)
-    w_dict = W_DictObject(space, strategy, storage)
+    w_dict = terminator.build_dict(self, space)
     flag = self._get_mapdict_map().write(self, "dict", SPECIAL, w_dict)
     assert flag
     return w_dict

--- a/pypy/objspace/std/typeobject.py
+++ b/pypy/objspace/std/typeobject.py
@@ -251,16 +251,24 @@ class W_TypeObject(W_Root):
             # dict_w of any of the types in the mro changes, or if the mro
             # itself changes
             self._version_tag = VersionTag()
-        from pypy.objspace.std.mapdict import DictTerminator, NoDictTerminator
         # if the typedef has a dict, then the rpython-class does all the dict
         # management, which means from the point of view of mapdict there is no
         # dict.
         typedef = self.layout.typedef
         self.flag_method_descriptor = typedef.method_descriptor
+        self.terminator = self.get_terminator(space, typedef)
+
+    def get_terminator(self, space, typedef):
+        # overridden by W_PyCTypeObject when tp_dictoffset is set, to back
+        # the dict with the C-visible struct field instead of mapdict's own
+        # storage. Kept as a plain method (not a field like flag_cpytype) so
+        # that ordinary, non-cpyext W_TypeObject instances don't carry an
+        # unused field just for this.
+        from pypy.objspace.std.mapdict import DictTerminator, NoDictTerminator
         if (self.hasdict and not typedef.hasdict):
-            self.terminator = DictTerminator(space, self)
+            return DictTerminator(space, self)
         else:
-            self.terminator = NoDictTerminator(space, self)
+            return NoDictTerminator(space, self)
 
     @not_rpython
     def __repr__(self):


### PR DESCRIPTION
Add a check and a mechanism to handle a non-zero tp_dictoffset via `__dictoffest__` in cpyext via a new ` CPyExtDictTerminator`. Also added the test from #5515. Fixes #5515.

This is separate from the opposite issue of using tp_dictoffset==-1 and Py_TPFLAGS_MANAGED_DICT.

Additionally reorder tests to avoid a trigger of an existing leaktester failure, that too hard to actually solve