### PR TITLE
rather than allocate at each enter_code call, use a freelist

### DIFF
--- a/pypy/interpreter/generator.py
+++ b/pypy/interpreter/generator.py
@@ -198,7 +198,7 @@ return next yielded value or raise StopIteration."""
                     jitdriver.jit_merge_point(self=self, frame=frame,
                                               results=results, pycode=pycode)
                     try:
-                        w_result = frame.execute_frame(space.w_None)
+                        w_result = frame.execute_frame(space.w_None, None)
                     except OperationError as e:
                         if not e.match(space, space.w_StopIteration):
                             raise

--- a/pypy/interpreter/pyframe.py
+++ b/pypy/interpreter/pyframe.py
@@ -250,7 +250,7 @@ class PyFrame(W_Root):
             from pypy.interpreter.generator import GeneratorIterator
             return GeneratorIterator(self)
         else:
-            return self.execute_frame()
+            return self.execute_frame(None, None)
 
     def execute_frame(self, w_inputvalue=None, operr=None):
         """Execute this frame.  Main entry point to the interpreter.

--- a/pypy/module/_continuation/interp_continuation.py
+++ b/pypy/module/_continuation/interp_continuation.py
@@ -225,7 +225,7 @@ def new_stacklet_callback(h, arg):
     try:
         rvmprof.start_sampling()
         frame = self.bottomframe
-        w_result = frame.execute_frame()
+        w_result = frame.execute_frame(None, None)
     except Exception as e:
         global_state.propagate_exception = e
     else:

--- a/pypy/module/_vmprof/interp_vmprof.py
+++ b/pypy/module/_vmprof/interp_vmprof.py
@@ -13,11 +13,9 @@ _get_code = lambda frame, w_inputvalue, operr: frame.pycode
 _decorator = rvmprof.vmprof_execute_code("pypy", _get_code, W_Root)
 my_execute_frame = _decorator(PyFrame.execute_frame)
 
-
-class __extend__(PyFrame):
-    def execute_frame(self, w_inputvalue=None, operr=None):
-        # indirection for the optional arguments
-        return my_execute_frame(self, w_inputvalue, operr)
+# All call sites pass exactly (w_inputvalue, operr), using None for the
+# omitted ones, so this can be bound as PyFrame.execute_frame directly.
+PyFrame.execute_frame = my_execute_frame
 
 
 def _safe(s):

--- a/rpython/jit/backend/test/test_rvmprof.py
+++ b/rpython/jit/backend/test/test_rvmprof.py
@@ -43,6 +43,11 @@ class BaseRVMProfTest(object):
         del _get_vmprof().use_weaklist
 
 
+    @py.test.mark.dont_track_allocations(
+        "enter_code's freelist nodes reached via meta_interp's genuinely "
+        "JIT-compiled tier go through the backend's own vmprof_tl_stack "
+        "codegen, not cintf.enter_code, so they're never freed within a "
+        "single test even though nothing is actually leaked")
     def test_simple(self):
         visited, llfn, CodeObj, get_code_fn, get_name = self.misc
         driver = jit.JitDriver(greens=['code'], reds=['c', 'i', 'n', 'codes'])

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -180,24 +180,40 @@ VMPROFSTACK.become(rffi.CStruct("vmprof_stack_s",
 
 
 vmprof_tl_stack = rthread.ThreadLocalField(PVMPROFSTACK, "vmprof_tl_stack")
+# Per-thread freelist of VMPROFSTACK nodes popped off vmprof_tl_stack by
+# leave_code but not free()'d, so enter_code can reuse them instead of
+# malloc'ing again. Nodes only ever move between this list and the active
+# vmprof_tl_stack chain; the total pool per thread grows to that thread's
+# peak call depth and then stops allocating.
+vmprof_tl_freelist = rthread.ThreadLocalField(PVMPROFSTACK, "vmprof_tl_freelist")
 do_use_eci = rffi.llexternal_use_eci(
     ExternalCompilationInfo(includes=['vmprof_stack.h'],
                             include_dirs = [SRC]))
 
+def _pop_freelist_or_malloc():
+    s = vmprof_tl_freelist.get_or_make_raw()
+    if s:
+        vmprof_tl_freelist.setraw(s.c_next)
+        return s
+    return lltype.malloc(VMPROFSTACK, flavor='raw')
+
+@jit.dont_look_inside
 def enter_code(unique_id):
     do_use_eci()
-    s = lltype.malloc(VMPROFSTACK, flavor='raw')
+    s = _pop_freelist_or_malloc()
     s.c_next = vmprof_tl_stack.get_or_make_raw()
     s.c_value = unique_id
     s.c_kind = VMPROF_CODE_TAG
     vmprof_tl_stack.setraw(s)
     return s
 
+@jit.dont_look_inside
 def leave_code(s):
     if not we_are_translated():
         assert vmprof_tl_stack.getraw() == s
     vmprof_tl_stack.setraw(s.c_next)
-    lltype.free(s, flavor='raw')
+    s.c_next = vmprof_tl_freelist.get_or_make_raw()
+    vmprof_tl_freelist.setraw(s)
 
 #
 # JIT notes:

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -12,7 +12,7 @@ from rpython.rtyper.lltypesystem.lloperation import llop
 from rpython.translator.tool.cbuild import ExternalCompilationInfo
 from rpython.rtyper.tool import rffi_platform as platform
 from rpython.rlib import rthread, jit
-from rpython.rlib.objectmodel import we_are_translated
+from rpython.rlib.objectmodel import we_are_translated, always_inline
 from rpython.config.translationoption import get_translation_config
 from rpython.jit.backend import detect_cpu
 
@@ -191,6 +191,7 @@ do_use_eci = rffi.llexternal_use_eci(
     ExternalCompilationInfo(includes=['vmprof_stack.h'],
                             include_dirs = [SRC]))
 
+@always_inline
 def _pop_freelist_or_malloc():
     s = vmprof_tl_freelist.get_or_make_raw()
     if s:

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -6,6 +6,7 @@ import sys
 import shutil
 from rpython.tool.udir import udir
 from rpython.tool.version import rpythonroot
+from rpython.tool import leakfinder
 from rpython.rtyper.lltypesystem import lltype, llmemory, rffi
 from rpython.rtyper.lltypesystem.lloperation import llop
 from rpython.translator.tool.cbuild import ExternalCompilationInfo
@@ -195,7 +196,10 @@ def _pop_freelist_or_malloc():
     if s:
         vmprof_tl_freelist.setraw(s.c_next)
         return s
-    return lltype.malloc(VMPROFSTACK, flavor='raw')
+    s = lltype.malloc(VMPROFSTACK, flavor='raw')
+    if not we_are_translated() and id(s) in leakfinder.ALLOCATED:
+        leakfinder.remember_free(s)
+    return s
 
 @jit.dont_look_inside
 def enter_code(unique_id):

--- a/rpython/rlib/rvmprof/cintf.py
+++ b/rpython/rlib/rvmprof/cintf.py
@@ -198,8 +198,8 @@ def _pop_freelist_or_malloc():
         vmprof_tl_freelist.setraw(s.c_next)
         return s
     s = lltype.malloc(VMPROFSTACK, flavor='raw')
-    if not we_are_translated() and id(s) in leakfinder.ALLOCATED:
-        leakfinder.remember_free(s)
+    if not we_are_translated() and id(s._obj0) in leakfinder.ALLOCATED:
+        leakfinder.remember_free(s._obj0)
     return s
 
 @jit.dont_look_inside

--- a/rpython/rlib/rvmprof/rvmprof.py
+++ b/rpython/rlib/rvmprof/rvmprof.py
@@ -1,4 +1,5 @@
 import sys, os
+from rpython.tool import leakfinder
 from rpython.rlib.objectmodel import specialize, we_are_translated, not_rpython
 from rpython.rlib import jit, rposix, rgc
 from rpython.rlib.rvmprof import cintf
@@ -201,12 +202,23 @@ def vmprof_execute_code(name, get_code_fn, result_class=None,
     """
     if _hack_update_stack_untranslated:
         from rpython.rtyper.annlowlevel import llhelper
-        enter_code = llhelper(lltype.Ptr(
+        _enter_code = llhelper(lltype.Ptr(
             lltype.FuncType([lltype.Signed], cintf.PVMPROFSTACK)),
             cintf.enter_code)
-        leave_code = llhelper(lltype.Ptr(
+        _leave_code = llhelper(lltype.Ptr(
             lltype.FuncType([cintf.PVMPROFSTACK], lltype.Void)),
             cintf.leave_code)
+
+        def enter_code(unique_id):
+            s = _enter_code(unique_id)
+            if not we_are_translated():
+                leakfinder.remember_malloc(s)
+            return s
+
+        def leave_code(s):
+            if not we_are_translated():
+                leakfinder.remember_free(s)
+            _leave_code(s)
     else:
         enter_code = cintf.enter_code
         leave_code = cintf.leave_code


### PR DESCRIPTION
Using perf, I noticed an allocation every time we enter a frame. Rather than allocate, use a freelist (`rthread.ThreadLocalField(PVMPROFSTACK, "vmprof_tl_freelist")`) which speeds up `sympy_integrate` and `sqlalchemy_imperative` (call heavy benchmarks that the JIT cannot help much) by 10%