### PR TITLE
Pyrepl syntax highlighting

### DIFF
--- a/extra_tests/test_pyrepl/infrastructure.py
+++ b/extra_tests/test_pyrepl/infrastructure.py
@@ -67,10 +67,13 @@ class TestConsole(Console):
         pass
     beep = forgetinput = finish = restore = prepare
 
+    def getheightwidth(self):
+        return self.height, self.width
+
     def _crash(self, *args, **kwargs):
         assert 0
 
-    move_cursor = set_cursor_vis = getheightwidth = push_char = clear = _crash
+    move_cursor = set_cursor_vis = push_char = clear = _crash
     flushoutput = wait = repaint = _crash
 
 

--- a/extra_tests/test_pyrepl/test_functional.py
+++ b/extra_tests/test_pyrepl/test_functional.py
@@ -11,7 +11,11 @@ import pytest
 try:
     from pexpect import spawn
 except ImportError:
-    pytest.skip(allow_module_level=True)
+    try:
+        pytest.skip("pexpect is not installed", allow_module_level=True)
+    except TypeError:
+        # PyPy's bundled pytest predates allow_module_level.
+        pytest.skip("pexpect is not installed")
 
 @contextmanager
 def start_repl(extra_env=dict(), explicit_pyrepl=True, colors=False):

--- a/extra_tests/test_pyrepl/test_readline.py
+++ b/extra_tests/test_pyrepl/test_readline.py
@@ -64,3 +64,29 @@ def test_insert_text_leading_tab():
     """
     readline.insert_text("\t")
     assert readline.get_line_buffer() == "\t"
+
+
+def test_append_history_file_only_writes_new_entries(tmpdir):
+    history_file = str(tmpdir / "history")
+    old_history = [
+        readline.get_history_item(i)
+        for i in range(1, readline.get_current_history_length() + 1)
+    ]
+    old_history_length = readline.get_history_length()
+    old_persisted_history_length = readline._wrapper.persisted_history_length
+    try:
+        readline.clear_history()
+        readline.set_history_length(0)
+
+        readline.add_history("first")
+        readline.append_history_file(history_file)
+        readline.add_history("second\nline")
+        readline.append_history_file(history_file)
+
+        assert (tmpdir / "history").read("rb") == b"first\nsecond\r\nline\n"
+    finally:
+        readline.clear_history()
+        for entry in old_history:
+            readline.add_history(entry)
+        readline.set_history_length(old_history_length)
+        readline._wrapper.persisted_history_length = old_persisted_history_length

--- a/extra_tests/test_pyrepl/test_readline.py
+++ b/extra_tests/test_pyrepl/test_readline.py
@@ -35,20 +35,26 @@ def test_nonascii_history():
 
     readline.clear_history()
     try:
-        readline.add_history("entrée 1")
-    except UnicodeEncodeError as err:
-        skip("Locale cannot encode test data: " + format(err))
-    readline.add_history("entrée 2")
-    readline.replace_history_item(1, "entrée 22")
-    readline.write_history_file(TESTFN)
-    readline.clear_history()
-    readline.read_history_file(TESTFN)
-    if is_editline:
-        # An add_history() call seems to be required for get_history_
-        # item() to register items from the file
-        readline.add_history("dummy")
-    assert readline.get_history_item(1) ==  "entrée 1"
-    assert readline.get_history_item(2) == "entrée 22"
+        try:
+            readline.add_history("entrée 1")
+        except UnicodeEncodeError as err:
+            skip("Locale cannot encode test data: " + format(err))
+        readline.add_history("entrée 2")
+        readline.replace_history_item(1, "entrée 22")
+        readline.write_history_file(TESTFN)
+        readline.clear_history()
+        readline.read_history_file(TESTFN)
+        if is_editline:
+            # An add_history() call seems to be required for get_history_
+            # item() to register items from the file
+            readline.add_history("dummy")
+        assert readline.get_history_item(1) ==  "entrée 1"
+        assert readline.get_history_item(2) == "entrée 22"
+    finally:
+        try:
+            os.unlink(TESTFN)
+        except FileNotFoundError:
+            pass
 
 def test_insert_text_leading_tab():
     """

--- a/extra_tests/test_pyrepl/test_syntax_highlighting.py
+++ b/extra_tests/test_pyrepl/test_syntax_highlighting.py
@@ -1,0 +1,62 @@
+from pyrepl.reader import Reader, disp_str
+from pyrepl.utils import gen_colors
+
+
+def highlighted_parts(source):
+    return [(source[c.span.start:c.span.end + 1], c.tag)
+            for c in gen_colors(source)]
+
+
+def test_token_colors():
+    source = "def answer(value: int = 42): # comment\n    return str(value)"
+    assert highlighted_parts(source) == [
+        ("def", "KEYWORD"), ("answer", "DEFINITION"), ("(", "OP"),
+        (":", "OP"), ("int", "BUILTIN"), ("=", "OP"),
+        ("42", "NUMBER"), (")", "OP"), (":", "OP"),
+        ("# comment", "COMMENT"), ("return", "KEYWORD"),
+        ("str", "BUILTIN"), ("(", "OP"), (")", "OP"),
+    ]
+
+
+def test_incomplete_strings_are_colored():
+    for source, expected in [
+        ('value = "still typing', '"still typing'),
+        ("value = '''two\nlines", "'''two\nlines"),
+    ]:
+        assert highlighted_parts(source)[-1] == (expected, "STRING")
+
+
+def test_fstring_expressions_are_colored_as_python():
+    parts = highlighted_parts('f"value={1 + len(items)}"')
+    assert ("value=", "STRING") in parts
+    assert ("1", "NUMBER") in parts
+    assert ("len", "BUILTIN") in parts
+    assert ("+", "OP") in parts
+
+
+def test_builtin_attribute_is_not_colored():
+    assert highlighted_parts("obj.list") == [(".", "OP")]
+
+
+def test_renderer_keeps_ansi_out_of_widths():
+    source = "def f"
+    chars, widths = disp_str(source, list(gen_colors(source)))
+    assert len(chars) == len(source)
+    assert widths == [1] * len(source)
+    assert "\x1b[" in "".join(chars)
+
+
+class FakeConsole:
+    width = 80
+    height = 24
+
+
+def test_reader_screen_contains_highlighting_but_cursor_uses_source_positions():
+    reader = Reader(FakeConsole())
+    reader.can_colorize = True
+    reader.buffer[:] = "def f():\n    return 42"
+    reader.pos = len(reader.buffer)
+    screen = reader.calc_screen()
+    assert "\x1b[" in "".join(screen)
+    assert reader.cxy == (17, 1)  # 13 source columns plus the four-column prompt
+    assert reader.screeninfo[1][1] == [1] * 13

--- a/extra_tests/test_pyrepl/test_syntax_highlighting.py
+++ b/extra_tests/test_pyrepl/test_syntax_highlighting.py
@@ -1,5 +1,5 @@
-from pyrepl.reader import Reader, disp_str
-from pyrepl.utils import gen_colors
+from pyrepl.reader import Reader
+from pyrepl.utils import disp_str, gen_colors
 
 
 def highlighted_parts(source):

--- a/lib-python/3/_colorize.py
+++ b/lib-python/3/_colorize.py
@@ -6,6 +6,8 @@ COLORIZE = True
 
 
 class ANSIColors:
+    BOLD = "\x1b[1m"
+    BOLD_BLUE = "\x1b[1;34m"
     BOLD_GREEN = "\x1b[1;32m"
     BOLD_MAGENTA = "\x1b[1;35m"
     BOLD_RED = "\x1b[1;31m"
@@ -15,6 +17,29 @@ class ANSIColors:
     RED = "\x1b[31m"
     RESET = "\x1b[0m"
     YELLOW = "\x1b[33m"
+
+
+def set_theme(t=None):
+    global theme
+    if t is not None:
+        theme = t
+        return
+    theme = {
+        "PROMPT": ANSIColors.BOLD_MAGENTA,
+        "KEYWORD": ANSIColors.BOLD_BLUE,
+        "KEYWORD_CONSTANT": ANSIColors.BOLD_BLUE,
+        "BUILTIN": "\x1b[36m",
+        "COMMENT": ANSIColors.RED,
+        "STRING": ANSIColors.GREEN,
+        "NUMBER": ANSIColors.YELLOW,
+        "OP": ANSIColors.RESET,
+        "DEFINITION": ANSIColors.BOLD,
+        "SOFT_KEYWORD": ANSIColors.BOLD_BLUE,
+        "RESET": ANSIColors.RESET,
+    }
+
+
+set_theme()
 
 
 NoColors = ANSIColors()

--- a/lib-python/3/test/support/__init__.py
+++ b/lib-python/3/test/support/__init__.py
@@ -59,6 +59,11 @@ __all__ = [
     "LOOPBACK_TIMEOUT", "INTERNET_TIMEOUT", "SHORT_TIMEOUT", "LONG_TIMEOUT",
     "Py_DEBUG", "EXCEEDS_RECURSION_LIMIT", "C_RECURSION_LIMIT",
     "skip_on_s390x",
+    "force_not_colorized",
+    "force_colorized",
+    "force_colorized_test_class",
+    "force_not_colorized_test_class",
+    "initialized_with_pyrepl",
     "BrokenIter",
     ]
 
@@ -1352,6 +1357,79 @@ def swap_attr(obj, attr, new_val):
         finally:
             if hasattr(obj, attr):
                 delattr(obj, attr)
+
+
+# PyPy-specific compatibility backport from the post-3.12 test.support.
+#
+# PyPy vendors a newer version of CPython's pyrepl and its tests on top of the
+# Python 3.12 standard library.  Those newer tests use force_not_colorized(),
+# which was added to CPython's test.support after 3.12.  Keep the helper here,
+# rather than modifying the imported tests, so they stay close to their
+# upstream versions and can reliably suppress ANSI escapes in exact-output
+# assertions.
+@contextlib.contextmanager
+def _force_color(color):
+    import _colorize
+    from .os_helper import EnvironmentVarGuard
+
+    with (
+        swap_attr(_colorize, "can_colorize", lambda: color),
+        EnvironmentVarGuard() as env,
+    ):
+        env.unset("FORCE_COLOR", "NO_COLOR", "PYTHON_COLORS")
+        env.set("FORCE_COLOR" if color else "NO_COLOR", "1")
+        yield
+
+
+def force_not_colorized(func):
+    """Force colorization off while running a test."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with _force_color(False):
+            return func(*args, **kwargs)
+    return wrapper
+
+
+def force_colorized(func):
+    """Force colorization on while running a test."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with _force_color(True):
+            return func(*args, **kwargs)
+    return wrapper
+
+
+def _force_colorized_test_class(cls, color):
+    original_setUpClass = cls.setUpClass
+
+    @classmethod
+    @functools.wraps(cls.setUpClass)
+    def new_setUpClass(cls):
+        cls.enterClassContext(_force_color(color))
+        original_setUpClass()
+
+    cls.setUpClass = new_setUpClass
+    return cls
+
+
+def force_colorized_test_class(cls):
+    """Force colorization on for an entire test class."""
+    return _force_colorized_test_class(cls, True)
+
+
+def force_not_colorized_test_class(cls):
+    """Force colorization off for an entire test class."""
+    return _force_colorized_test_class(cls, False)
+
+
+def initialized_with_pyrepl():
+    """Detect whether pyrepl was used during Python initialization."""
+    # The newer upstream test uses the implementation detail that CPython's
+    # pyrepl startup makes __main__ a Python module with a __file__.  On PyPy
+    # this remains false, which is the expected result asserted by the ported
+    # test.
+    return hasattr(sys.modules["__main__"], "__file__")
+# End PyPy-specific compatibility backport.
 
 @contextlib.contextmanager
 def swap_item(obj, item, new_val):

--- a/lib-python/3/test/test_pyrepl/support.py
+++ b/lib-python/3/test/test_pyrepl/support.py
@@ -7,6 +7,15 @@ from unittest.mock import MagicMock
 from pyrepl.console import Console, Event
 from pyrepl.readline import ReadlineAlikeReader, ReadlineConfig
 from pyrepl.simple_interact import _strip_final_indent
+from pyrepl.utils import ANSI_ESCAPE_SEQUENCE
+
+
+class ScreenEqualMixin:
+    def assert_screen_equal(self, reader, expected, clean=False):
+        actual = reader.screen
+        if clean:
+            actual = [ANSI_ESCAPE_SEQUENCE.sub("", line) for line in actual]
+        self.assertListEqual(actual, expected.split("\n"))
 
 
 def multiline_input(reader: ReadlineAlikeReader, namespace: dict | None = None):

--- a/lib-python/3/test/test_pyrepl/support.py
+++ b/lib-python/3/test/test_pyrepl/support.py
@@ -84,6 +84,9 @@ def prepare_console(events: Iterable[Event], **kwargs) -> MagicMock | Console:
     console.get_event.side_effect = events
     console.height = 100
     console.width = 80
+    console.getheightwidth = MagicMock(
+        side_effect=lambda: (console.height, console.width)
+    )
     for key, val in kwargs.items():
         setattr(console, key, val)
     return console

--- a/lib-python/3/test/test_pyrepl/test_interact.py
+++ b/lib-python/3/test/test_pyrepl/test_interact.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 from textwrap import dedent
 
-from test.support import force_not_colorized
+from test.support import force_not_colorized, is_pypy
 
 from pyrepl.console import InteractiveColoredConsole
 from pyrepl.simple_interact import _more_lines
@@ -122,6 +122,10 @@ SyntaxError: duplicate argument 'x' in function definition"""
             console.runsource(source)
             mock_showsyntaxerror.assert_called_once()
 
+    # This regression test and its ``value.lineno is not None`` fix were
+    # introduced in CPython 3.13.  PyPy's Python 3.12 code.py does not include
+    # that later maintenance fix yet.
+    @unittest.skipIf(is_pypy, "requires the CPython 3.13 null-byte code.py fix")
     def test_runsource_survives_null_bytes(self):
         console = InteractiveColoredConsole()
         source = "\x00\n"

--- a/lib-python/3/test/test_pyrepl/test_pyrepl.py
+++ b/lib-python/3/test/test_pyrepl/test_pyrepl.py
@@ -1055,6 +1055,66 @@ class TestPasteEvent(TestCase):
         self.assertEqual(output, input_code)
 
 
+class TestPyReplCtrlD(TestCase):
+    """Test Ctrl+D behavior in pyrepl to match the traditional REPL."""
+
+    def prepare_reader(self, events):
+        console = FakeConsole(events)
+        config = ReadlineConfig(readline_completer=None)
+        return ReadlineAlikeReader(console=console, config=config)
+
+    def test_ctrl_d_empty_line(self):
+        events = [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))]
+        reader = self.prepare_reader(events)
+        with self.assertRaises(EOFError):
+            multiline_input(reader)
+
+    def test_ctrl_d_multiline_with_new_line(self):
+        events = itertools.chain(
+            code_to_events("def f():\n    pass\n"),
+            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],
+        )
+        reader, _ = handle_all_events(events)
+        self.assertTrue(reader.finished)
+        self.assertEqual("def f():\n    pass\n", "".join(reader.buffer))
+
+    def test_ctrl_d_multiline_middle_of_line(self):
+        events = itertools.chain(
+            code_to_events("def f():\n    hello world"),
+            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))] * 5,
+            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],
+        )
+        reader, _ = handle_all_events(events)
+        self.assertFalse(reader.finished)
+        self.assertEqual("def f():\n    hello orld", "".join(reader.buffer))
+
+    def test_ctrl_d_multiline_end_of_line_no_newline(self):
+        events = itertools.chain(
+            code_to_events("def f():\n    hello"),
+            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],
+        )
+        reader, _ = handle_all_events(events)
+        self.assertFalse(reader.finished)
+        self.assertEqual("def f():\n    hello", "".join(reader.buffer))
+
+    def test_ctrl_d_single_line_middle_of_line(self):
+        events = itertools.chain(
+            code_to_events("hello"),
+            [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))],
+            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],
+        )
+        reader, _ = handle_all_events(events)
+        self.assertEqual("hell", "".join(reader.buffer))
+
+    def test_ctrl_d_single_line_end_no_newline(self):
+        events = itertools.chain(
+            code_to_events("hello"),
+            [Event(evt="key", data="\x04", raw=bytearray(b"\x04"))],
+        )
+        reader, _ = handle_all_events(events)
+        self.assertEqual("hello", "".join(reader.buffer))
+
+
 @skipUnless(pty, "requires pty")
 class TestDumbTerminal(ReplTestCase):
     @skipIf(is_pypy, "pypy errors differently")

--- a/lib-python/3/test/test_pyrepl/test_pyrepl.py
+++ b/lib-python/3/test/test_pyrepl/test_pyrepl.py
@@ -1311,6 +1311,10 @@ class TestMain(ReplTestCase):
                         self.assertIn("in x3", output)
                         self.assertIn("in <module>", output)
 
+    # This regression test and its ``value.lineno is not None`` fix were
+    # introduced in CPython 3.13.  PyPy's Python 3.12 code.py does not include
+    # that later maintenance fix yet.
+    @skipIf(is_pypy, "requires the CPython 3.13 null-byte code.py fix")
     def test_null_byte(self):
         output, exit_code = self.run_repl("\x00\nexit()\n")
         self.assertEqual(exit_code, 0)

--- a/lib-python/3/test/test_pyrepl/test_pyrepl.py
+++ b/lib-python/3/test/test_pyrepl/test_pyrepl.py
@@ -43,6 +43,8 @@ class ReplTestCase(TestCase):
         *,
         cmdline_args: list[str] | None = None,
         cwd: str | None = None,
+        timeout: float = SHORT_TIMEOUT,
+        exit_on_output: str | None = None,
     ) -> tuple[str, int]:
         temp_dir = None
         if cwd is None:
@@ -50,7 +52,12 @@ class ReplTestCase(TestCase):
             cwd = temp_dir.name
         try:
             return self._run_repl(
-                repl_input, env=env, cmdline_args=cmdline_args, cwd=cwd
+                repl_input,
+                env=env,
+                cmdline_args=cmdline_args,
+                cwd=cwd,
+                timeout=timeout,
+                exit_on_output=exit_on_output,
             )
         finally:
             if temp_dir is not None:
@@ -63,6 +70,8 @@ class ReplTestCase(TestCase):
         env: dict | None,
         cmdline_args: list[str] | None,
         cwd: str,
+        timeout: float,
+        exit_on_output: str | None,
     ) -> tuple[str, int]:
         assert pty
         master_fd, slave_fd = pty.openpty()
@@ -100,7 +109,7 @@ class ReplTestCase(TestCase):
         os.write(master_fd, repl_input.encode("utf-8"))
 
         output = []
-        while select.select([master_fd], [], [], SHORT_TIMEOUT)[0]:
+        while select.select([master_fd], [], [], timeout)[0]:
             try:
                 data = os.read(master_fd, 1024).decode("utf-8")
                 if not data:
@@ -108,6 +117,11 @@ class ReplTestCase(TestCase):
             except OSError:
                 break
             output.append(data)
+            if exit_on_output is not None:
+                output = ["".join(output)]
+                if exit_on_output in output[0]:
+                    process.kill()
+                    break
         else:
             os.close(master_fd)
             process.kill()
@@ -115,7 +129,7 @@ class ReplTestCase(TestCase):
 
         os.close(master_fd)
         try:
-            exit_code = process.wait(timeout=SHORT_TIMEOUT)
+            exit_code = process.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             process.kill()
             exit_code = process.wait()
@@ -1323,6 +1337,31 @@ class TestMain(ReplTestCase):
         self.assertIn("123", output)
         self.assertIn("spam", output)
         self.assertNotEqual(pathlib.Path(hfile.name).stat().st_size, 0)
+
+    def test_history_survives_crash(self):
+        env = os.environ.copy()
+
+        with tempfile.NamedTemporaryFile() as hfile:
+            env["PYTHON_HISTORY"] = hfile.name
+
+            output, exit_code = self.run_repl("1\n2\n3\nexit()\n", env=env)
+            self.assertEqual(exit_code, 0)
+
+            commands = "spam\nimport time\n0xcafe\ntime.sleep(1000)\nquit\n"
+            output, exit_code = self.run_repl(
+                commands, env=env, exit_on_output="51966"
+            )
+            self.assertNotEqual(exit_code, 0)
+
+            history = pathlib.Path(hfile.name).read_text()
+            self.assertIn("2", history)
+            self.assertIn("exit()", history)
+            self.assertIn("spam", history)
+            self.assertIn("import time", history)
+            # History is written after each command's output is printed. The
+            # command triggering process termination may not yet be written.
+            self.assertNotIn("sleep", history)
+            self.assertNotIn("quit", history)
 
     @force_not_colorized
     def test_correct_filename_in_syntaxerrors(self):

--- a/lib-python/3/test/test_pyrepl/test_reader.py
+++ b/lib-python/3/test/test_pyrepl/test_reader.py
@@ -1,13 +1,24 @@
 import itertools
 import functools
 import rlcompleter
+from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from .support import handle_all_events, handle_events_narrow_console, code_to_events, prepare_reader
-from test.support import import_helper
+from .support import (ScreenEqualMixin, handle_all_events,
+                      handle_events_narrow_console, code_to_events,
+                      prepare_reader)
+from test.support import cpython_only, force_colorized_test_class, import_helper
 from pyrepl.console import Event
 from pyrepl.reader import Reader
+from _colorize import theme
+
+
+_overrides = {"RESET": "z", "SOFT_KEYWORD": "K"}
+_syntax_colors = {
+    _overrides.get(name, name[0].lower()): value
+    for name, value in theme.items()
+}
 
 
 class TestReader(TestCase):
@@ -313,3 +324,88 @@ class TestReader(TestCase):
         reader, _ = handle_all_events(events, prepare_reader=completing_reader)
 
         self.assert_screen_equals(reader, f"{code}a")
+
+
+@force_colorized_test_class
+class TestReaderInColor(ScreenEqualMixin, TestCase):
+    def test_syntax_highlighting_basic(self):
+        code = dedent("""\
+            import re, sys
+            def funct(case: str = sys.platform) -> None:
+                match case:
+                    case "web": print("online")
+                    case _: print('other', len(case))
+            type Alias = list[int]
+            """)
+        expected = dedent("""\
+            {k}import{z} re{o},{z} sys
+            {k}def{z} {d}funct{z}{o}({z}case{o}:{z} {b}str{z} {o}={z} sys{o}.{z}platform{o}){z} {o}->{z} {k}None{z}{o}:{z}
+                {K}match{z} case{o}:{z}
+                    {K}case{z} {s}"web"{z}{o}:{z} {b}print{z}{o}({z}{s}"online"{z}{o}){z}
+                    {K}case{z} {K}_{z}{o}:{z} {b}print{z}{o}({z}{s}'other'{z}{o},{z} {b}len{z}{o}({z}case{o}){z}{o}){z}
+            {K}type{z} Alias {o}={z} {b}list{z}{o}[{z}{b}int{z}{o}]{z}
+            """).format(**_syntax_colors)
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, code, clean=True)
+        self.assert_screen_equal(reader, expected)
+
+    def test_syntax_highlighting_incomplete_string_first_line(self):
+        code = 'def unfinished(arg: str = "still typing'
+        expected = (
+            '{k}def{z} {d}unfinished{z}{o}({z}arg{o}:{z} {b}str{z} '
+            '{o}={z} {s}"still typing{z}'
+        ).format(**_syntax_colors)
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, expected)
+
+    def test_syntax_highlighting_incomplete_multiline_string(self):
+        code = "def f():\n    '''Still writing\n    the docstring"
+        expected = (
+            "{k}def{z} {d}f{z}{o}({z}{o}){z}{o}:{z}\n"
+            "    {s}'''Still writing{z}\n"
+            "{s}    the docstring{z}"
+        ).format(**_syntax_colors)
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, expected)
+
+    @cpython_only
+    def test_syntax_highlighting_incomplete_fstring(self):
+        code = dedent("""\
+            def unfinished_function():
+                var = f"Single-quote but {
+                1
+                +
+                1
+                } multi-line!
+            """)
+        expected = dedent("""\
+            {k}def{z} {d}unfinished_function{z}{o}({z}{o}){z}{o}:{z}
+                var {o}={z} {s}f"{z}{s}Single-quote but {z}{o}{OB}{z}
+                {n}1{z}
+                {o}+{z}
+                {n}1{z}
+                {o}{CB}{z}{s} multi-line!{z}
+            """).format(OB="{", CB="}", **_syntax_colors)
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, expected)
+
+    def test_syntax_highlighting_indentation_error(self):
+        code = "def f():\n    value = 1\n   oops"
+        expected = (
+            "{k}def{z} {d}f{z}{o}({z}{o}){z}{o}:{z}\n"
+            "    value {o}={z} {n}1{z}\n"
+            "   oops"
+        ).format(**_syntax_colors)
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, expected)
+
+    def test_syntax_highlighting_literal_braces_in_fstrings(self):
+        code = 'f"{{"\nf"}}"\nf"{{{0}}}"\nf"{ {0} }"'
+        expected = (
+            '{s}f"{z}{s}<<{z}{s}"{z}\n'
+            '{s}f"{z}{s}>>{z}{s}"{z}\n'
+            '{s}f"{z}{s}<<{z}{o}<{z}{n}0{z}{o}>{z}{s}>>{z}{s}"{z}\n'
+            '{s}f"{z}{o}<{z} {o}<{z}{n}0{z}{o}>{z} {o}>{z}{s}"{z}'
+        ).format(**_syntax_colors).replace("<", "{").replace(">", "}")
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, expected)

--- a/lib-python/3/test/test_pyrepl/test_reader.py
+++ b/lib-python/3/test/test_pyrepl/test_reader.py
@@ -376,6 +376,15 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         reader, _ = handle_all_events(code_to_events(code))
         self.assert_screen_equal(reader, expected)
 
+    def test_syntax_highlighting_incomplete_string_another_line(self):
+        code = 'def unfinished(\n    arg: str = "still typing'
+        expected = (
+            '{k}def{z} {d}unfinished{z}{o}({z}\n'
+            '    arg{o}:{z} {b}str{z} {o}={z} {s}"still typing{z}'
+        ).format(**_syntax_colors)
+        reader, _ = handle_all_events(code_to_events(code))
+        self.assert_screen_equal(reader, expected)
+
     def test_syntax_highlighting_incomplete_multiline_string(self):
         code = "def f():\n    '''Still writing\n    the docstring"
         expected = (
@@ -418,10 +427,21 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         self.assert_screen_equal(reader, expected)
 
     def test_syntax_highlighting_literal_braces_in_fstrings(self):
-        code = 'f"{{"\nf"}}"\nf"{{{0}}}"\nf"{ {0} }"'
+        code = (
+            'f"{{"\n'
+            'f"}}"\n'
+            'f"a{{b"\n'
+            'f"a}}b"\n'
+            'f"a{{b}}c"\n'
+            'f"{{{0}}}"\n'
+            'f"{ {0} }"'
+        )
         expected = (
             '{s}f"{z}{s}<<{z}{s}"{z}\n'
             '{s}f"{z}{s}>>{z}{s}"{z}\n'
+            '{s}f"{z}{s}a<<{z}{s}b{z}{s}"{z}\n'
+            '{s}f"{z}{s}a>>{z}{s}b{z}{s}"{z}\n'
+            '{s}f"{z}{s}a<<{z}{s}b>>{z}{s}c{z}{s}"{z}\n'
             '{s}f"{z}{s}<<{z}{o}<{z}{n}0{z}{o}>{z}{s}>>{z}{s}"{z}\n'
             '{s}f"{z}{o}<{z} {o}<{z}{n}0{z}{o}>{z} {o}>{z}{s}"{z}'
         ).format(**_syntax_colors).replace("<", "{").replace(">", "}")

--- a/lib-python/3/test/test_pyrepl/test_reader.py
+++ b/lib-python/3/test/test_pyrepl/test_reader.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from .support import (ScreenEqualMixin, handle_all_events,
                       handle_events_narrow_console, code_to_events,
-                      prepare_reader)
+                      prepare_console, prepare_reader)
 from test.support import cpython_only, force_colorized_test_class, import_helper
 from pyrepl.console import Event
 from pyrepl.reader import Reader
@@ -236,6 +236,9 @@ class TestReader(TestCase):
             console.get_event.side_effect = events
             console.height = 100
             console.width = 80
+            console.getheightwidth = MagicMock(
+                side_effect=lambda: (console.height, console.width)
+            )
             console.input_hook = input_hook
             return console
 
@@ -324,6 +327,21 @@ class TestReader(TestCase):
         reader, _ = handle_all_events(events, prepare_reader=completing_reader)
 
         self.assert_screen_equals(reader, f"{code}a")
+
+    def test_pos2xy_with_no_columns(self):
+        console = prepare_console([])
+        reader = prepare_reader(console)
+        # Simulate a resize to 0 columns.
+        reader.screeninfo = []
+        self.assertEqual(reader.pos2xy(), (0, 0))
+
+    def test_setpos_from_xy_for_non_printing_char(self):
+        code = "# non \u200c printing character"
+        events = code_to_events(code)
+
+        reader, _ = handle_all_events(events)
+        reader.setpos_from_xy(8, 0)
+        self.assertEqual(reader.pos, 7)
 
 
 @force_colorized_test_class

--- a/lib-python/3/test/test_pyrepl/test_unix_console.py
+++ b/lib-python/3/test/test_pyrepl/test_unix_console.py
@@ -252,8 +252,7 @@ class TestConsole(TestCase):
         events = itertools.chain(code_to_events(code))
         reader, console = handle_events_short_unix_console(events)
 
-        console.height = 2
-        console.getheightwidth = MagicMock(lambda _: (2, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (2, 80))
 
         def same_reader(_):
             return reader
@@ -288,8 +287,7 @@ class TestConsole(TestCase):
         events = itertools.chain(code_to_events(code))
         reader, console = handle_events_unix_console_height_3(events)
 
-        console.height = 1
-        console.getheightwidth = MagicMock(lambda _: (1, 80))
+        console.getheightwidth = MagicMock(side_effect=lambda: (1, 80))
 
         def same_reader(_):
             return reader

--- a/lib-python/3/test/test_pyrepl/test_utils.py
+++ b/lib-python/3/test/test_pyrepl/test_utils.py
@@ -80,3 +80,27 @@ class TestUtils(TestCase):
                     for color in gen_colors(code)
                 ]
                 self.assertEqual(actual, expected)
+
+    def test_soft_keyword_after_multiline_case(self):
+        code = "match value:\n    case (\n        1\n    ):\n        pass\n    case 2:"
+        highlighted_cases = [
+            (code[color.span.start:color.span.end + 1], color.tag)
+            for color in gen_colors(code)
+            if code[color.span.start:color.span.end + 1] == "case"
+        ]
+        self.assertEqual(
+            highlighted_cases,
+            [("case", "SOFT_KEYWORD"), ("case", "SOFT_KEYWORD")],
+        )
+
+    def test_type_soft_keyword_and_builtin(self):
+        code = "type type = type[type]"
+        highlighted_types = [
+            color.tag
+            for color in gen_colors(code)
+            if code[color.span.start:color.span.end + 1] == "type"
+        ]
+        self.assertEqual(
+            highlighted_types,
+            ["SOFT_KEYWORD", "BUILTIN", "BUILTIN", "BUILTIN"],
+        )

--- a/lib-python/3/test/test_pyrepl/test_utils.py
+++ b/lib-python/3/test/test_pyrepl/test_utils.py
@@ -1,9 +1,38 @@
 from unittest import TestCase
 
-from pyrepl.utils import gen_colors, prev_next_window
+from pyrepl.utils import gen_colors, prev_next_window, str_width, wlen
 
 
 class TestUtils(TestCase):
+    def test_str_width(self):
+        for character in [
+            "a", "1", "_", "!", "\x1a", "\u263a", "\uffb9",
+            "é", "\N{LATIN SMALL LETTER E WITH CEDILLA}", "\u00ad",
+        ]:
+            with self.subTest(character=character):
+                self.assertEqual(str_width(character), 1)
+
+        for character in [
+            "\N{COMBINING ACUTE ACCENT}",
+            "\N{ZERO WIDTH JOINER}",
+        ]:
+            with self.subTest(character=character):
+                self.assertEqual(str_width(character), 0)
+
+        for character in [chr(99989), chr(99999)]:
+            self.assertEqual(str_width(character), 2)
+
+    def test_wlen(self):
+        for character in ["a", "b", "1", "!", "_"]:
+            self.assertEqual(wlen(character), 1)
+        self.assertEqual(wlen("\x1a"), 2)
+        self.assertEqual(wlen(chr(3800)), 1)
+        self.assertEqual(wlen(chr(4352)), 2)
+        self.assertEqual(wlen("hello"), 5)
+        self.assertEqual(wlen("hello\x1a"), 7)
+        self.assertEqual(wlen("e\N{COMBINING ACUTE ACCENT}"), 1)
+        self.assertEqual(wlen("a\N{ZERO WIDTH JOINER}b"), 2)
+
     def test_prev_next_window(self):
         expected = [
             (None, 1, 2),

--- a/lib-python/3/test/test_pyrepl/test_utils.py
+++ b/lib-python/3/test/test_pyrepl/test_utils.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+
+from pyrepl.utils import gen_colors, prev_next_window
+
+
+class TestUtils(TestCase):
+    def test_prev_next_window(self):
+        expected = [
+            (None, 1, 2),
+            (1, 2, 3),
+            (2, 3, 4),
+            (3, 4, None),
+        ]
+        self.assertEqual(list(prev_next_window(iter([1, 2, 3, 4]))), expected)
+        self.assertEqual(list(prev_next_window(iter([1]))), [(None, 1, None)])
+
+        def raising_generator():
+            yield from [1, 2, 3, 4]
+            raise ZeroDivisionError
+
+        window = prev_next_window(raising_generator())
+        for item in expected:
+            self.assertEqual(next(window), item)
+        with self.assertRaises(ZeroDivisionError):
+            next(window)
+
+    def test_gen_colors_keyword_highlighting(self):
+        cases = [
+            ("a.set", [(".", "OP")]),
+            ("obj.list", [(".", "OP")]),
+            ("obj.match", [(".", "OP")]),
+            ("b. \\\n format", [(".", "OP")]),
+            ("set", [("set", "BUILTIN")]),
+            ("list", [("list", "BUILTIN")]),
+            ("    \n dict", [("dict", "BUILTIN")]),
+            ("match +1", [
+                ("match", "SOFT_KEYWORD"),
+                ("+", "OP"),
+                ("1", "NUMBER"),
+            ]),
+            ("match -1", [
+                ("match", "SOFT_KEYWORD"),
+                ("-", "OP"),
+                ("1", "NUMBER"),
+            ]),
+        ]
+        for code, expected in cases:
+            with self.subTest(code=code):
+                actual = [
+                    (code[color.span.start:color.span.end + 1], color.tag)
+                    for color in gen_colors(code)
+                ]
+                self.assertEqual(actual, expected)

--- a/lib_pypy/pyrepl/commands.py
+++ b/lib_pypy/pyrepl/commands.py
@@ -34,7 +34,6 @@ import time
 
 from .trace import trace
 
-
 # types
 if False:
     from .historical_reader import HistoricalReader
@@ -169,14 +168,14 @@ class unix_line_discard(KillCommand):
 class unix_word_rubout(KillCommand):
     def do(self) -> None:
         r = self.reader
-        for i in range(r.get_arg()):
+        for _ in range(r.get_arg()):
             self.kill_range(r.bow(), r.pos)
 
 
 class kill_word(KillCommand):
     def do(self) -> None:
         r = self.reader
-        for i in range(r.get_arg()):
+        for _ in range(r.get_arg()):
             self.kill_range(r.pos, r.eow())
 
 
@@ -231,15 +230,13 @@ class ctrl_c(Command):
 
 
 class suspend(Command):
-    import signal
-    # On windows, this will kill the REPL process
-    SIGSTOP = getattr(signal, "SIGSTOP", 9)
     def do(self) -> None:
+        import signal
 
         r = self.reader
         p = r.pos
         r.console.finish()
-        os.kill(os.getpid(), self.SIGSTOP)
+        os.kill(os.getpid(), signal.SIGSTOP)
         ## this should probably be done
         ## in a handler for SIGCONT?
         r.console.prepare()
@@ -287,7 +284,7 @@ class down(MotionCommand):
             x, y = r.pos2xy()
             new_y = y + 1
 
-            if new_y > r.max_row():
+            if r.eol() == len(b):
                 if r.historyi < len(r.history):
                     r.select_item(r.historyi + 1)
                     r.pos = r.eol(0)
@@ -416,14 +413,17 @@ class delete(EditCommand):
     def do(self) -> None:
         r = self.reader
         b = r.buffer
-        if (
-            r.pos == 0
-            and len(b) == 0  # this is something of a hack
-            and self.event[-1] == "\004"
-        ):
-            r.update_screen()
-            r.console.finish()
-            raise EOFError
+        if self.event[-1] == "\004":
+            if b and b[-1].endswith("\n"):
+                self.finish = True
+            elif (
+                r.pos == 0
+                and len(b) == 0  # this is something of a hack
+            ):
+                r.update_screen()
+                r.console.finish()
+                raise EOFError
+
         for i in range(r.get_arg()):
             if r.pos != len(b):
                 del b[r.pos]
@@ -464,13 +464,18 @@ class show_history(Command):
         from site import gethistoryfile  # type: ignore[attr-defined]
 
         history = os.linesep.join(self.reader.history[:])
-        with self.reader.suspend():
-            pager = get_pager()
-            pager(history, gethistoryfile())
+        self.reader.console.restore()
+        pager = get_pager()
+        pager(history, gethistoryfile())
+        self.reader.console.prepare()
+
+        # We need to copy over the state so that it's consistent between
+        # console and reader, and console does not overwrite/append stuff
+        self.reader.console.screen = self.reader.screen.copy()
+        self.reader.console.posxy = self.reader.cxy
 
 
 class paste_mode(Command):
-
     def do(self) -> None:
         self.reader.paste_mode = not self.reader.paste_mode
         self.reader.dirty = True

--- a/lib_pypy/pyrepl/commands.py
+++ b/lib_pypy/pyrepl/commands.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 import os
+import time
 
 # Categories of actions:
 #  killing
@@ -30,6 +31,8 @@ import os
 #  history
 #  finishing
 # [completion]
+
+from .trace import trace
 
 
 # types
@@ -473,13 +476,18 @@ class paste_mode(Command):
         self.reader.dirty = True
 
 
-class enable_bracketed_paste(Command):
+class perform_bracketed_paste(Command):
     def do(self) -> None:
-        self.reader.paste_mode = True
-        self.reader.in_bracketed_paste = True
-
-class disable_bracketed_paste(Command):
-    def do(self) -> None:
-        self.reader.paste_mode = False
-        self.reader.in_bracketed_paste = False
-        self.reader.dirty = True
+        done = "\x1b[201~"
+        data = ""
+        start = time.time()
+        while done not in data:
+            ev = self.reader.console.getpending()
+            data += ev.data
+        trace(
+            "bracketed pasting of {l} chars done in {s:.2f}s",
+            l=len(data),
+            s=time.time() - start,
+        )
+        self.reader.insert(data.replace(done, ""))
+        self.reader.last_refresh_cache.invalidated = True

--- a/lib_pypy/pyrepl/historical_reader.py
+++ b/lib_pypy/pyrepl/historical_reader.py
@@ -71,6 +71,18 @@ class previous_history(commands.Command):
         r.select_item(r.historyi - 1)
 
 
+class history_search_backward(commands.Command):
+    def do(self) -> None:
+        r = self.reader
+        r.search_next(forwards=False)
+
+
+class history_search_forward(commands.Command):
+    def do(self) -> None:
+        r = self.reader
+        r.search_next(forwards=True)
+
+
 class restore_history(commands.Command):
     def do(self) -> None:
         r = self.reader
@@ -234,6 +246,8 @@ class HistoricalReader(Reader):
             isearch_forwards,
             isearch_backwards,
             operate_and_get_next,
+            history_search_backward,
+            history_search_forward,
         ]:
             self.commands[c.__name__] = c
             self.commands[c.__name__.replace("_", "-")] = c
@@ -251,8 +265,10 @@ class HistoricalReader(Reader):
             (r"\C-s", "forward-history-isearch"),
             (r"\M-r", "restore-history"),
             (r"\M-.", "yank-arg"),
-            (r"\<page down>", "last-history"),
-            (r"\<page up>", "first-history"),
+            (r"\<page down>", "history-search-forward"),
+            (r"\x1b[6~", "history-search-forward"),
+            (r"\<page up>", "history-search-backward"),
+            (r"\x1b[5~", "history-search-backward"),
         )
 
     def select_item(self, i: int) -> None:
@@ -274,13 +290,17 @@ class HistoricalReader(Reader):
 
     @contextmanager
     def suspend(self) -> SimpleContextManager:
-        with super().suspend():
-            try:
-                old_history = self.history[:]
-                del self.history[:]
-                yield
-            finally:
-                self.history[:] = old_history
+        with super().suspend(), self.suspend_history():
+            yield
+
+    @contextmanager
+    def suspend_history(self) -> SimpleContextManager:
+        try:
+            old_history = self.history[:]
+            del self.history[:]
+            yield
+        finally:
+            self.history[:] = old_history
 
     def prepare(self) -> None:
         super().prepare()
@@ -304,6 +324,59 @@ class HistoricalReader(Reader):
             return "(%s-search `%s') " % (d, self.isearch_term)
         else:
             return super().get_prompt(lineno, cursor_on_line)
+
+    def search_next(self, *, forwards: bool) -> None:
+        """Search history for the current line contents up to the cursor.
+
+        Selects the first item found. If nothing is under the cursor, any next
+        item in history is selected.
+        """
+        pos = self.pos
+        s = self.get_unicode()
+        history_index = self.historyi
+
+        # In multiline contexts, we're only interested in the current line.
+        nl_index = s.rfind('\n', 0, pos)
+        prefix = s[nl_index + 1:pos]
+        pos = len(prefix)
+
+        match_prefix = len(prefix)
+        len_item = 0
+        if history_index < len(self.history):
+            len_item = len(self.get_item(history_index))
+        if len_item and pos == len_item:
+            match_prefix = False
+        elif not pos:
+            match_prefix = False
+
+        while 1:
+            if forwards:
+                out_of_bounds = history_index >= len(self.history) - 1
+            else:
+                out_of_bounds = history_index == 0
+            if out_of_bounds:
+                if forwards and not match_prefix:
+                    self.pos = 0
+                    self.buffer = []
+                    self.dirty = True
+                else:
+                    self.error("not found")
+                return
+
+            history_index += 1 if forwards else -1
+            s = self.get_item(history_index)
+
+            if not match_prefix:
+                self.select_item(history_index)
+                return
+
+            len_acc = 0
+            for i, line in enumerate(s.splitlines(keepends=True)):
+                if line.startswith(prefix):
+                    self.select_item(history_index)
+                    self.pos = pos + len_acc
+                    return
+                len_acc += len(line)
 
     def isearch_next(self) -> None:
         st = self.isearch_term

--- a/lib_pypy/pyrepl/reader.py
+++ b/lib_pypy/pyrepl/reader.py
@@ -106,8 +106,7 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
         (r"\M-9", "digit-arg"),
         (r"\M-\n", "accept"),
         ("\\\\", "self-insert"),
-        (r"\x1b[200~", "enable_bracketed_paste"),
-        (r"\x1b[201~", "disable_bracketed_paste"),
+        (r"\x1b[200~", "perform-bracketed-paste"),
         (r"\x03", "ctrl-c"),
     ]
     + [(c, "self-insert") for c in map(chr, range(32, 127)) if c != "\\"]
@@ -203,7 +202,6 @@ class Reader:
     dirty: bool = False
     finished: bool = False
     paste_mode: bool = False
-    in_bracketed_paste: bool = False
     commands: dict[str, type[Command]] = field(default_factory=make_default_commands)
     last_command: type[Command] | None = None
     syntax_table: dict[str, int] = field(default_factory=make_default_syntax_table)
@@ -220,7 +218,6 @@ class Reader:
     ## cached metadata to speed up screen refreshes
     @dataclass
     class RefreshCache:
-        in_bracketed_paste: bool = False
         screen: list[str] = field(default_factory=list)
         screeninfo: list[tuple[int, list[int]]] = field(init=False)
         line_end_offsets: list[int] = field(default_factory=list)
@@ -234,7 +231,6 @@ class Reader:
                          screen: list[str],
                          screeninfo: list[tuple[int, list[int]]],
             ) -> None:
-            self.in_bracketed_paste = reader.in_bracketed_paste
             self.screen = screen.copy()
             self.screeninfo = screeninfo.copy()
             self.pos = reader.pos
@@ -247,8 +243,7 @@ class Reader:
                 return False
             dimensions = reader.console.width, reader.console.height
             dimensions_changed = dimensions != self.dimensions
-            paste_changed = reader.in_bracketed_paste != self.in_bracketed_paste
-            return not (dimensions_changed or paste_changed)
+            return not dimensions_changed
 
         def get_cached_location(self, reader: Reader) -> tuple[int, int]:
             if self.invalidated:
@@ -474,7 +469,7 @@ class Reader:
         'lineno'."""
         if self.arg is not None and cursor_on_line:
             prompt = f"(arg: {self.arg}) "
-        elif self.paste_mode and not self.in_bracketed_paste:
+        elif self.paste_mode:
             prompt = "(paste) "
         elif "\n" in self.buffer:
             if lineno == 0:
@@ -632,9 +627,6 @@ class Reader:
 
     def refresh(self) -> None:
         """Recalculate and refresh the screen."""
-        if self.in_bracketed_paste and self.buffer and not self.buffer[-1] == "\n":
-            return
-
         # this call sets up self.cxy, so call it first.
         self.screen = self.calc_screen()
         self.console.refresh(self.screen, self.cxy)

--- a/lib_pypy/pyrepl/reader.py
+++ b/lib_pypy/pyrepl/reader.py
@@ -25,12 +25,11 @@ import sys
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
-import unicodedata
 import _colorize  # type: ignore[import-not-found]
 
 
 from . import commands, console, input
-from .utils import ANSI_ESCAPE_SEQUENCE, gen_colors, str_width
+from .utils import disp_str, gen_colors, unbracket, wlen
 from .trace import trace
 
 
@@ -38,51 +37,6 @@ from .trace import trace
 Command = commands.Command
 if False:
     from .types import Callback, SimpleContextManager, KeySpec, CommandName
-
-
-def disp_str(buffer: str, colors=None, start_index=0) -> tuple[list[str], list[int]]:
-    """disp_str(buffer:string) -> (string, [int])
-
-    Return the string that should be the printed representation of
-    |buffer| and a list detailing where the characters of |buffer|
-    get used up.  E.g.:
-
-    The strings in the first result correspond one-to-one with source
-    characters. ANSI styling is attached to those strings and therefore does
-    not affect cursor positions or wrapping.
-
-    """
-    b: list[int] = []
-    s: list[str] = []
-    while colors and colors[0].span.end < start_index:
-        colors.pop(0)
-    pre_color = ""
-    if colors and colors[0].span.start < start_index:
-        pre_color = _colorize.theme[colors[0].tag]
-    for i, c in enumerate(buffer, start_index):
-        if colors and colors[0].span.start == i:
-            pre_color = _colorize.theme[colors[0].tag]
-        if c == '\x1a':
-            rendered = c
-            b.append(2)
-        elif ord(c) < 128:
-            rendered = c
-            b.append(1)
-        elif unicodedata.category(c).startswith("C"):
-            rendered = r"\u%04x" % ord(c)
-            b.append(len(rendered))
-        else:
-            rendered = c
-            b.append(str_width(c))
-        post_color = ""
-        if colors and colors[0].span.end == i:
-            post_color = _colorize.theme["RESET"]
-            colors.pop(0)
-        s.append(pre_color + rendered + post_color)
-        pre_color = ""
-    if buffer and colors and colors[0].span.start < i < colors[0].span.end:
-        s[-1] += _colorize.theme["RESET"]
-    return s, b
 
 
 # syntax classes:
@@ -368,8 +322,8 @@ class Reader:
         cursor_found = False
         lines_beyond_cursor = 0
         for ln, line in enumerate(lines, num_common_lines):
-            ll = len(line)
-            if 0 <= pos <= ll:
+            line_len = len(line)
+            if 0 <= pos <= line_len:
                 self.lxy = pos, ln
                 cursor_found = True
             elif cursor_found:
@@ -383,33 +337,32 @@ class Reader:
                 prompt_from_cache = False
                 prompt = ""
             else:
-                prompt = self.get_prompt(ln, ll >= pos >= 0)
+                prompt = self.get_prompt(ln, line_len >= pos >= 0)
             while "\n" in prompt:
                 pre_prompt, _, prompt = prompt.partition("\n")
                 last_refresh_line_end_offsets.append(offset)
                 screen.append(pre_prompt)
                 screeninfo.append((0, []))
-            pos -= ll + 1
-            prompt, lp = self.process_prompt(prompt)
-            chars, l2 = disp_str(line, colors, offset)
-            wrapcount = (sum(l2) + lp) // self.console.width
-            if wrapcount == 0:
-                offset += ll + 1  # Takes all of the line plus the newline
+            pos -= line_len + 1
+            prompt, prompt_len = self.process_prompt(prompt)
+            chars, char_widths = disp_str(line, colors, offset)
+            wrapcount = (sum(char_widths) + prompt_len) // self.console.width
+            if wrapcount == 0 or not char_widths:
+                offset += line_len + 1  # Takes all of the line plus the newline
                 last_refresh_line_end_offsets.append(offset)
                 screen.append(prompt + "".join(chars))
-                screeninfo.append((lp, l2))
+                screeninfo.append((prompt_len, char_widths))
             else:
-                i = 0
-                while chars:
-                    prelen = lp if i == 0 else 0
+                pre = prompt
+                prelen = prompt_len
+                for wrap in range(wrapcount + 1):
                     index_to_wrap_before = 0
                     column = 0
-                    for character_width in l2:
-                        if column + character_width >= self.console.width - prelen:
+                    for char_width in char_widths:
+                        if column + char_width + prelen >= self.console.width:
                             break
                         index_to_wrap_before += 1
-                        column += character_width
-                    pre = prompt if i == 0 else ""
+                        column += char_width
                     if len(chars) > index_to_wrap_before:
                         offset += index_to_wrap_before
                         post = "\\"
@@ -419,11 +372,14 @@ class Reader:
                         post = ""
                         after = []
                     last_refresh_line_end_offsets.append(offset)
-                    screen.append(pre + "".join(chars[:index_to_wrap_before]) + post)
-                    screeninfo.append((prelen, l2[:index_to_wrap_before] + after))
+                    render = pre + "".join(chars[:index_to_wrap_before]) + post
+                    render_widths = char_widths[:index_to_wrap_before] + after
+                    screen.append(render)
+                    screeninfo.append((prelen, render_widths))
                     chars = chars[index_to_wrap_before:]
-                    l2 = l2[index_to_wrap_before:]
-                    i += 1
+                    char_widths = char_widths[index_to_wrap_before:]
+                    pre = ""
+                    prelen = 0
         self.screeninfo = screeninfo
         self.cxy = self.pos2xy()
         if self.msg:
@@ -436,42 +392,9 @@ class Reader:
 
     @staticmethod
     def process_prompt(prompt: str) -> tuple[str, int]:
-        """Process the prompt.
-
-        This means calculate the length of the prompt. The character \x01
-        and \x02 are used to bracket ANSI control sequences and need to be
-        excluded from the length calculation.  So also a copy of the prompt
-        is returned with these control characters removed."""
-
-        # The logic below also ignores the length of common escape
-        # sequences if they were not explicitly within \x01...\x02.
-        # They are CSI (or ANSI) sequences  ( ESC [ ... LETTER )
-
-        # wlen from utils already excludes ANSI_ESCAPE_SEQUENCE chars,
-        # which breaks the logic below so we redefine it here.
-        def wlen(s: str) -> int:
-            return sum(str_width(i) for i in s)
-
-        out_prompt = ""
-        l = wlen(prompt)
-        pos = 0
-        while True:
-            s = prompt.find("\x01", pos)
-            if s == -1:
-                break
-            e = prompt.find("\x02", s)
-            if e == -1:
-                break
-            # Found start and end brackets, subtract from string length
-            l = l - (e - s + 1)
-            keep = prompt[pos:s]
-            l -= sum(map(wlen, ANSI_ESCAPE_SEQUENCE.findall(keep)))
-            out_prompt += keep + prompt[s + 1 : e]
-            pos = e + 1
-        keep = prompt[pos:]
-        l -= sum(map(wlen, ANSI_ESCAPE_SEQUENCE.findall(keep)))
-        out_prompt += keep
-        return out_prompt, l
+        out_prompt = unbracket(prompt, including_content=False)
+        visible_prompt = unbracket(prompt, including_content=True)
+        return out_prompt, wlen(visible_prompt)
 
     def bow(self, p: int | None = None) -> int:
         """Return the 0-based index of the word break preceding p most
@@ -579,9 +502,9 @@ class Reader:
         pos = 0
         i = 0
         while i < y:
-            prompt_len, character_widths = self.screeninfo[i]
-            offset = len(character_widths) - character_widths.count(0)
-            in_wrapped_line = prompt_len + sum(character_widths) >= self.console.width
+            prompt_len, char_widths = self.screeninfo[i]
+            offset = len(char_widths)
+            in_wrapped_line = prompt_len + sum(char_widths) >= self.console.width
             if in_wrapped_line:
                 pos += offset - 1  # -1 cause backslash is not in buffer
             else:
@@ -592,6 +515,7 @@ class Reader:
         cur_x = self.screeninfo[i][0]
         while cur_x < x:
             if self.screeninfo[i][1][j] == 0:
+                j += 1
                 continue
             cur_x += self.screeninfo[i][1][j]
             j += 1
@@ -601,28 +525,28 @@ class Reader:
 
     def pos2xy(self) -> tuple[int, int]:
         """Return the x, y coordinates of position 'pos'."""
-        # this *is* incomprehensible, yes.
-        y = 0
+        prompt_len, y = 0, 0
+        char_widths: list[int] = []
         pos = self.pos
         assert 0 <= pos <= len(self.buffer)
-        if pos == len(self.buffer):
+        if pos == len(self.buffer) and len(self.screeninfo) > 0:
             y = len(self.screeninfo) - 1
-            p, l2 = self.screeninfo[y]
-            return p + sum(l2) + l2.count(0), y
+            prompt_len, char_widths = self.screeninfo[y]
+            return prompt_len + sum(char_widths), y
 
-        for p, l2 in self.screeninfo:
-            l = len(l2) - l2.count(0)
-            in_wrapped_line = p + sum(l2) >= self.console.width
-            offset = l - 1 if in_wrapped_line else l  # need to remove backslash
+        for prompt_len, char_widths in self.screeninfo:
+            offset = len(char_widths)
+            in_wrapped_line = prompt_len + sum(char_widths) >= self.console.width
+            if in_wrapped_line:
+                offset -= 1
             if offset >= pos:
                 break
 
-            if p + sum(l2) >= self.console.width:
-                pos -= l - 1  # -1 cause backslash is not in buffer
-            else:
-                pos -= l + 1  # +1 cause newline is in buffer
+            if not in_wrapped_line:
+                offset += 1
+            pos -= offset
             y += 1
-        return p + sum(l2[:pos]), y
+        return prompt_len + sum(char_widths[:pos]), y
 
     def insert(self, text: str | list[str]) -> None:
         """Insert 'text' at the insertion point."""

--- a/lib_pypy/pyrepl/reader.py
+++ b/lib_pypy/pyrepl/reader.py
@@ -608,6 +608,15 @@ class Reader:
                 setattr(self, arg, prev_state[arg])
             self.prepare()
 
+    @contextmanager
+    def suspend_colorization(self) -> SimpleContextManager:
+        try:
+            old_can_colorize = self.can_colorize
+            self.can_colorize = False
+            yield
+        finally:
+            self.can_colorize = old_can_colorize
+
     def finish(self) -> None:
         """Called when a command signals that we're finished."""
         pass

--- a/lib_pypy/pyrepl/reader.py
+++ b/lib_pypy/pyrepl/reader.py
@@ -84,7 +84,7 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
         (r"\C-w", "unix-word-rubout"),
         (r"\C-x\C-u", "upcase-region"),
         (r"\C-y", "yank"),
-        (r"\C-z", "suspend"), 
+        *(() if sys.platform == "win32" else ((r"\C-z", "suspend"), )),
         (r"\M-b", "backward-word"),
         (r"\M-c", "capitalize-word"),
         (r"\M-d", "kill-word"),
@@ -119,6 +119,7 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
         (r"\<right>", "right"),
         (r"\C-\<right>", "forward-word"),
         (r"\<delete>", "delete"),
+        (r"\x1b[3~", "delete"),
         (r"\<backspace>", "backspace"),
         (r"\M-\<backspace>", "backward-kill-word"),
         (r"\<end>", "end-of-line"),  # was 'end'

--- a/lib_pypy/pyrepl/reader.py
+++ b/lib_pypy/pyrepl/reader.py
@@ -144,16 +144,17 @@ class Reader:
     Instance variables of note include:
 
       * buffer:
-        A *list* (*not* a string at the moment :-) containing all the
-        characters that have been entered.
+        A per-character list containing all the characters that have been
+        entered. Does not include color information.
       * console:
         Hopefully encapsulates the OS dependent stuff.
       * pos:
         A 0-based index into 'buffer' for where the insertion point
         is.
       * screeninfo:
-        Ahem.  This list contains some info needed to move the
-        insertion point around reasonably efficiently.
+        A list of screen position tuples. Each list element is a tuple
+        representing information on visible line length for a given line.
+        Allows for efficient skipping of color escape sequences.
       * cxy, lxy:
         the position of the insertion point in screen ...
       * syntax_table:
@@ -312,9 +313,12 @@ class Reader:
 
         prompt_from_cache = (offset and self.buffer[offset - 1] != "\n")
 
-        colors = list(gen_colors(self.get_unicode())) if self.can_colorize else None
+        if self.can_colorize:
+            colors = list(gen_colors(self.get_unicode()))
+        else:
+            colors = None
+        trace("colors = {colors}", colors=colors)
         lines = "".join(self.buffer[offset:]).split("\n")
-
         cursor_found = False
         lines_beyond_cursor = 0
         for ln, line in enumerate(lines, num_common_lines):
@@ -388,6 +392,12 @@ class Reader:
 
     @staticmethod
     def process_prompt(prompt: str) -> tuple[str, int]:
+        r"""Return a tuple with the prompt string and its visible length.
+
+        The prompt string has the zero-width brackets recognized by shells
+        (\x01 and \x02) removed.  The length ignores anything between those
+        brackets as well as any ANSI escape sequences.
+        """
         out_prompt = unbracket(prompt, including_content=False)
         visible_prompt = unbracket(prompt, including_content=True)
         return out_prompt, wlen(visible_prompt)
@@ -511,7 +521,7 @@ class Reader:
         cur_x = self.screeninfo[i][0]
         while cur_x < x:
             if self.screeninfo[i][1][j] == 0:
-                j += 1
+                j += 1  # prevent potential future infinite loop
                 continue
             cur_x += self.screeninfo[i][1][j]
             j += 1
@@ -521,10 +531,13 @@ class Reader:
 
     def pos2xy(self) -> tuple[int, int]:
         """Return the x, y coordinates of position 'pos'."""
+
         prompt_len, y = 0, 0
         char_widths: list[int] = []
         pos = self.pos
         assert 0 <= pos <= len(self.buffer)
+
+        # optimize for the common case: typing at the end of the buffer
         if pos == len(self.buffer) and len(self.screeninfo) > 0:
             y = len(self.screeninfo) - 1
             prompt_len, char_widths = self.screeninfo[y]
@@ -534,12 +547,14 @@ class Reader:
             offset = len(char_widths)
             in_wrapped_line = prompt_len + sum(char_widths) >= self.console.width
             if in_wrapped_line:
-                offset -= 1
+                offset -= 1  # need to remove line-wrapping backslash
+
             if offset >= pos:
                 break
 
             if not in_wrapped_line:
-                offset += 1
+                offset += 1  # there's a newline in buffer
+
             pos -= offset
             y += 1
         return prompt_len + sum(char_widths[:pos]), y
@@ -553,6 +568,7 @@ class Reader:
     def update_cursor(self) -> None:
         """Move the cursor to reflect changes in self.pos"""
         self.cxy = self.pos2xy()
+        trace("update_cursor({pos}) = {cxy}", pos=self.pos, cxy=self.cxy)
         self.console.move_cursor(*self.cxy)
 
     def after_command(self, cmd: Command) -> None:
@@ -613,6 +629,7 @@ class Reader:
         finally:
             self.can_colorize = old_can_colorize
 
+
     def finish(self) -> None:
         """Called when a command signals that we're finished."""
         pass
@@ -628,6 +645,7 @@ class Reader:
 
     def refresh(self) -> None:
         """Recalculate and refresh the screen."""
+        self.console.height, self.console.width = self.console.getheightwidth()
         # this call sets up self.cxy, so call it first.
         self.screen = self.calc_screen()
         self.console.refresh(self.screen, self.cxy)

--- a/lib_pypy/pyrepl/reader.py
+++ b/lib_pypy/pyrepl/reader.py
@@ -26,11 +26,11 @@ import sys
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 import unicodedata
-from _colorize import can_colorize, ANSIColors  # type: ignore[import-not-found]
+import _colorize  # type: ignore[import-not-found]
 
 
 from . import commands, console, input
-from .utils import ANSI_ESCAPE_SEQUENCE, wlen, str_width
+from .utils import ANSI_ESCAPE_SEQUENCE, gen_colors, str_width
 from .trace import trace
 
 
@@ -40,34 +40,49 @@ if False:
     from .types import Callback, SimpleContextManager, KeySpec, CommandName
 
 
-def disp_str(buffer: str) -> tuple[str, list[int]]:
+def disp_str(buffer: str, colors=None, start_index=0) -> tuple[list[str], list[int]]:
     """disp_str(buffer:string) -> (string, [int])
 
     Return the string that should be the printed representation of
     |buffer| and a list detailing where the characters of |buffer|
     get used up.  E.g.:
 
-    >>> disp_str(chr(3))
-    ('^C', [1, 0])
+    The strings in the first result correspond one-to-one with source
+    characters. ANSI styling is attached to those strings and therefore does
+    not affect cursor positions or wrapping.
 
     """
     b: list[int] = []
     s: list[str] = []
-    for c in buffer:
+    while colors and colors[0].span.end < start_index:
+        colors.pop(0)
+    pre_color = ""
+    if colors and colors[0].span.start < start_index:
+        pre_color = _colorize.theme[colors[0].tag]
+    for i, c in enumerate(buffer, start_index):
+        if colors and colors[0].span.start == i:
+            pre_color = _colorize.theme[colors[0].tag]
         if c == '\x1a':
-            s.append(c)
+            rendered = c
             b.append(2)
         elif ord(c) < 128:
-            s.append(c)
+            rendered = c
             b.append(1)
         elif unicodedata.category(c).startswith("C"):
-            c = r"\u%04x" % ord(c)
-            s.append(c)
-            b.extend([0] * (len(c) - 1))
+            rendered = r"\u%04x" % ord(c)
+            b.append(len(rendered))
         else:
-            s.append(c)
+            rendered = c
             b.append(str_width(c))
-    return "".join(s), b
+        post_color = ""
+        if colors and colors[0].span.end == i:
+            post_color = _colorize.theme["RESET"]
+            colors.pop(0)
+        s.append(pre_color + rendered + post_color)
+        pre_color = ""
+    if buffer and colors and colors[0].span.start < i < colors[0].span.end:
+        s[-1] += _colorize.theme["RESET"]
+    return s, b
 
 
 # syntax classes:
@@ -309,7 +324,7 @@ class Reader:
         self.screeninfo = [(0, [])]
         self.cxy = self.pos2xy()
         self.lxy = (self.pos, 0)
-        self.can_colorize = can_colorize()
+        self.can_colorize = _colorize.can_colorize()
 
         self.last_refresh_cache.screeninfo = self.screeninfo
         self.last_refresh_cache.pos = self.pos
@@ -347,6 +362,7 @@ class Reader:
 
         prompt_from_cache = (offset and self.buffer[offset - 1] != "\n")
 
+        colors = list(gen_colors(self.get_unicode())) if self.can_colorize else None
         lines = "".join(self.buffer[offset:]).split("\n")
 
         cursor_found = False
@@ -375,16 +391,16 @@ class Reader:
                 screeninfo.append((0, []))
             pos -= ll + 1
             prompt, lp = self.process_prompt(prompt)
-            l, l2 = disp_str(line)
-            wrapcount = (wlen(l) + lp) // self.console.width
+            chars, l2 = disp_str(line, colors, offset)
+            wrapcount = (sum(l2) + lp) // self.console.width
             if wrapcount == 0:
                 offset += ll + 1  # Takes all of the line plus the newline
                 last_refresh_line_end_offsets.append(offset)
-                screen.append(prompt + l)
+                screen.append(prompt + "".join(chars))
                 screeninfo.append((lp, l2))
             else:
                 i = 0
-                while l:
+                while chars:
                     prelen = lp if i == 0 else 0
                     index_to_wrap_before = 0
                     column = 0
@@ -394,7 +410,7 @@ class Reader:
                         index_to_wrap_before += 1
                         column += character_width
                     pre = prompt if i == 0 else ""
-                    if len(l) > index_to_wrap_before:
+                    if len(chars) > index_to_wrap_before:
                         offset += index_to_wrap_before
                         post = "\\"
                         after = [1]
@@ -403,9 +419,9 @@ class Reader:
                         post = ""
                         after = []
                     last_refresh_line_end_offsets.append(offset)
-                    screen.append(pre + l[:index_to_wrap_before] + post)
+                    screen.append(pre + "".join(chars[:index_to_wrap_before]) + post)
                     screeninfo.append((prelen, l2[:index_to_wrap_before] + after))
-                    l = l[index_to_wrap_before:]
+                    chars = chars[index_to_wrap_before:]
                     l2 = l2[index_to_wrap_before:]
                     i += 1
         self.screeninfo = screeninfo
@@ -548,7 +564,7 @@ class Reader:
             prompt = self.ps1
 
         if self.can_colorize:
-            prompt = f"{ANSIColors.BOLD_MAGENTA}{prompt}{ANSIColors.RESET}"
+            prompt = f"{_colorize.theme['PROMPT']}{prompt}{_colorize.theme['RESET']}"
         return prompt
 
     def push_input_trans(self, itrans: input.KeymapTranslator) -> None:

--- a/lib_pypy/pyrepl/readline.py
+++ b/lib_pypy/pyrepl/readline.py
@@ -359,10 +359,6 @@ class maybe_accept(commands.Command):
         r = self.reader  # type: ignore[assignment]
         r.dirty = True  # this is needed to hide the completion menu, if visible
 
-        if self.reader.in_bracketed_paste:
-            r.insert("\n")
-            return
-
         # if there are already several lines and the cursor
         # is not on the last one, always insert a new \n.
         text = r.get_unicode()

--- a/lib_pypy/pyrepl/readline.py
+++ b/lib_pypy/pyrepl/readline.py
@@ -89,6 +89,7 @@ __all__ = [
     "set_pre_input_hook",
     "set_startup_hook",
     "write_history_file",
+    "append_history_file",
     # ---- multiline extensions ----
     "multiline_input",
 ]
@@ -431,6 +432,7 @@ class _ReadlineWrapper:
     f_out: int = -1
     reader: ReadlineAlikeReader | None = field(default=None, repr=False)
     saved_history_length: int = -1
+    persisted_history_length: int = 0
     startup_hook: Callback | None = None
     pre_input_hook: Callback | None = None
     config: ReadlineConfig = field(default_factory=ReadlineConfig, repr=False)
@@ -561,6 +563,7 @@ class _ReadlineWrapper:
                         del buffer[:]
                     if line:
                         history.append(line)
+        self.persisted_history_length = self.get_current_history_length()
 
     def write_history_file(self, filename: str = gethistoryfile()) -> None:
         maxlength = self.saved_history_length
@@ -570,8 +573,22 @@ class _ReadlineWrapper:
                 entry = entry.replace("\n", "\r\n")  # multiline history support
                 f.write(entry + "\n")
 
+    def append_history_file(self, filename: str = gethistoryfile()) -> None:
+        reader = self.get_reader()
+        saved_length = self.persisted_history_length
+        length = self.get_current_history_length() - saved_length
+        history = reader.get_trimmed_history(length)
+        with open(
+            os.path.expanduser(filename), "a", encoding="utf-8", newline="\n"
+        ) as f:
+            for entry in history:
+                entry = entry.replace("\n", "\r\n")  # multiline history support
+                f.write(entry + "\n")
+        self.persisted_history_length = saved_length + length
+
     def clear_history(self) -> None:
         del self.get_reader().history[:]
+        self.persisted_history_length = 0
 
     def get_history_item(self, index: int) -> str | None:
         history = self.get_reader().history
@@ -645,6 +662,7 @@ set_history_length = _wrapper.set_history_length
 get_current_history_length = _wrapper.get_current_history_length
 read_history_file = _wrapper.read_history_file
 write_history_file = _wrapper.write_history_file
+append_history_file = _wrapper.append_history_file
 clear_history = _wrapper.clear_history
 get_history_item = _wrapper.get_history_item
 remove_history_item = _wrapper.remove_history_item

--- a/lib_pypy/pyrepl/simple_interact.py
+++ b/lib_pypy/pyrepl/simple_interact.py
@@ -128,7 +128,9 @@ def run_multiline_interactive_console(
         reader.history.pop()  # skip internal commands in history
         command = REPL_COMMANDS[statement]
         if callable(command):
-            command()
+            # Make sure that history does not change because of commands
+            with reader.suspend_history(), reader.suspend_colorization():
+                command()
             return True
 
         if isinstance(command, str):

--- a/lib_pypy/pyrepl/simple_interact.py
+++ b/lib_pypy/pyrepl/simple_interact.py
@@ -32,8 +32,9 @@ import os
 import sys
 import code
 import ast
+import warnings
 
-from .readline import _get_reader, multiline_input
+from .readline import _get_reader, append_history_file, multiline_input
 
 TYPE_CHECKING = False
 
@@ -165,6 +166,10 @@ def run_multiline_interactive_console(
             linecache._register_code(input_name, statement, "<stdin>")  # type: ignore[attr-defined]
             more = console.push(_strip_final_indent(statement), filename=input_name, _symbol="single")  # type: ignore[call-arg]
             assert not more
+            try:
+                append_history_file()
+            except (FileNotFoundError, PermissionError, OSError) as e:
+                warnings.warn(f"failed to open the history file for writing: {e}")
             input_n += 1
         except KeyboardInterrupt:
             r = _get_reader()

--- a/lib_pypy/pyrepl/types.py
+++ b/lib_pypy/pyrepl/types.py
@@ -6,3 +6,5 @@ KeySpec = str  # like r"\C-c"
 CommandName = str  # like "interrupt"
 EventTuple = tuple[CommandName, str]
 Completer = Callable[[str, int], str | None]
+CharBuffer = list[str]
+CharWidths = list[int]

--- a/lib_pypy/pyrepl/utils.py
+++ b/lib_pypy/pyrepl/utils.py
@@ -1,8 +1,167 @@
-import re
-import unicodedata
+import builtins
 import functools
+import keyword
+import re
+import token as T
+import tokenize
+import unicodedata
+
+from io import StringIO
+from typing import Iterator, NamedTuple
 
 ANSI_ESCAPE_SEQUENCE = re.compile(r"\x1b\[[ -@]*[A-~]")
+IDENTIFIERS_AFTER = {"def", "class"}
+KEYWORD_CONSTANTS = {"True", "False", "None"}
+BUILTINS = {str(name) for name in dir(builtins) if not name.startswith("_")}
+
+
+class Span(NamedTuple):
+    start: int
+    end: int
+
+    @classmethod
+    def from_token(cls, token, line_lengths):
+        end_offset = -1
+        if token.type == T.FSTRING_MIDDLE and token.string.endswith(("{", "}")):
+            # A visible trailing brace comes from a doubled brace in the input.
+            end_offset += 1
+        return cls(
+            line_lengths[token.start[0] - 1] + token.start[1],
+            line_lengths[token.end[0] - 1] + token.end[1] + end_offset,
+        )
+
+
+class ColorSpan(NamedTuple):
+    span: Span
+    tag: str
+
+
+def gen_colors(buffer: str) -> Iterator[ColorSpan]:
+    sio = StringIO(buffer)
+    line_lengths = [0] + [len(line) for line in sio.readlines()]
+    for i in range(1, len(line_lengths)):
+        line_lengths[i] += line_lengths[i - 1]
+    sio.seek(0)
+    last_emitted = None
+    try:
+        for color in gen_colors_from_token_stream(
+            tokenize.generate_tokens(sio.readline), line_lengths
+        ):
+            yield color
+            last_emitted = color
+    except SyntaxError:
+        return
+    except tokenize.TokenError as error:
+        yield from recover_unterminated_string(
+            error, line_lengths, last_emitted, buffer
+        )
+
+
+def recover_unterminated_string(error, line_lengths, last_emitted, buffer):
+    message, location = error.args
+    if location is None:
+        return
+    line_no, column = location
+    if message.startswith((
+        "unterminated string literal",
+        "unterminated f-string literal",
+        "EOF in multi-line string",
+        "unterminated triple-quoted f-string literal",
+    )):
+        start = line_lengths[line_no - 1] + column
+        end = line_lengths[-1] - 1
+        if last_emitted and start <= last_emitted.span.start:
+            start = last_emitted.span.end + 1
+        yield ColorSpan(Span(start, end), "STRING")
+
+
+def gen_colors_from_token_stream(token_generator, line_lengths):
+    is_definition_name = False
+    bracket_level = 0
+    string_tokens = {T.STRING, T.FSTRING_START, T.FSTRING_MIDDLE, T.FSTRING_END}
+    for previous, token, following in prev_next_window(token_generator):
+        if token.start == token.end:
+            continue
+        if token.type in string_tokens:
+            tag = "STRING"
+        elif token.type == T.COMMENT:
+            tag = "COMMENT"
+        elif token.type == T.NUMBER:
+            tag = "NUMBER"
+        elif token.type == T.OP:
+            if token.string in "([{":
+                bracket_level += 1
+            elif token.string in ")]}":
+                bracket_level -= 1
+            tag = "OP"
+        elif token.type == T.ERRORTOKEN and token.string in {'"', "'"}:
+            # Python 3.12 represents an unfinished single-quoted string as an
+            # ERRORTOKEN followed by ordinary tokens rather than TokenError.
+            start = line_lengths[token.start[0] - 1] + token.start[1]
+            end = line_lengths[token.start[0]] - 1
+            yield ColorSpan(Span(start, end), "STRING")
+            return
+        elif token.type == T.NAME:
+            if is_definition_name:
+                is_definition_name = False
+                tag = "DEFINITION"
+            elif keyword.iskeyword(token.string):
+                tag = ("KEYWORD_CONSTANT" if token.string in KEYWORD_CONSTANTS
+                       else "KEYWORD")
+                if token.string in IDENTIFIERS_AFTER:
+                    is_definition_name = True
+            elif (keyword.issoftkeyword(token.string) and bracket_level == 0
+                  and is_soft_keyword_used(previous, token, following)):
+                tag = "SOFT_KEYWORD"
+            elif (token.string in BUILTINS
+                  and not (previous and previous.exact_type == T.DOT)):
+                tag = "BUILTIN"
+            else:
+                continue
+        else:
+            continue
+        yield ColorSpan(Span.from_token(token, line_lengths), tag)
+
+
+def is_soft_keyword_used(previous, token, following):
+    if token.string == "_":
+        return bool(previous and previous.string == "case"
+                    and following and following.string == ":")
+    at_statement_start = previous is None or previous.type in {
+        T.NEWLINE, T.INDENT, T.DEDENT
+    } or previous.string == ":"
+    if not at_statement_start or following is None:
+        return False
+    if token.string == "type":
+        return following.type == T.NAME and not keyword.iskeyword(following.string)
+    if token.string not in {"match", "case"}:
+        return False
+    if following.type in {T.NUMBER, T.STRING, T.FSTRING_START, T.NAME}:
+        return True
+    allowed = "(*-[{~" if token.string == "case" else "(*-+[{~"
+    return following.type == T.OP and following.string in allowed
+
+
+def prev_next_window(iterable):
+    iterator = iter(iterable)
+    try:
+        current = next(iterator)
+    except StopIteration:
+        return
+    previous = None
+    while True:
+        try:
+            following = next(iterator)
+        except StopIteration:
+            yield previous, current, None
+            return
+        except Exception:
+            # Emit the last token obtained before propagating the tokenizer's
+            # error on the next iteration.
+            yield previous, current, None
+            raise
+        yield previous, current, following
+        previous, current = current, following
 
 
 @functools.cache

--- a/lib_pypy/pyrepl/utils.py
+++ b/lib_pypy/pyrepl/utils.py
@@ -5,11 +5,16 @@ import re
 import token as T
 import tokenize
 import unicodedata
+import _colorize  # type: ignore[import-not-found]
 
 from io import StringIO
 from typing import Iterator, NamedTuple
 
+from .types import CharBuffer, CharWidths
+
 ANSI_ESCAPE_SEQUENCE = re.compile(r"\x1b\[[ -@]*[A-~]")
+ZERO_WIDTH_BRACKET = re.compile(r"\x01.*?\x02")
+ZERO_WIDTH_TRANS = str.maketrans({"\x01": "", "\x02": ""})
 IDENTIFIERS_AFTER = {"def", "class"}
 KEYWORD_CONSTANTS = {"True", "False", "None"}
 BUILTINS = {str(name) for name in dir(builtins) if not name.startswith("_")}
@@ -168,6 +173,11 @@ def prev_next_window(iterable):
 def str_width(c: str) -> int:
     if ord(c) < 128:
         return 1
+    if unicodedata.combining(c):
+        return 0
+    category = unicodedata.category(c)
+    if category == "Cf" and c != "\u00ad":
+        return 0
     w = unicodedata.east_asian_width(c)
     if w in ('N', 'Na', 'H', 'A'):
         return 1
@@ -175,9 +185,58 @@ def str_width(c: str) -> int:
 
 
 def wlen(s: str) -> int:
-    if len(s) == 1:
+    if len(s) == 1 and s != "\x1a":
         return str_width(s)
     length = sum(str_width(i) for i in s)
     # remove lengths of any escape sequences
     sequence = ANSI_ESCAPE_SEQUENCE.findall(s)
-    return length - sum(len(i) for i in sequence)
+    return length - sum(len(i) for i in sequence) + s.count("\x1a")
+
+
+def unbracket(s: str, including_content: bool = False) -> str:
+    if including_content:
+        return ZERO_WIDTH_BRACKET.sub("", s)
+    return s.translate(ZERO_WIDTH_TRANS)
+
+
+def disp_str(
+    buffer: str, colors: list[ColorSpan] | None = None, start_index: int = 0
+) -> tuple[CharBuffer, CharWidths]:
+    """Convert source into one rendered cell and display width per character."""
+    chars: CharBuffer = []
+    char_widths: CharWidths = []
+    if not buffer:
+        return chars, char_widths
+
+    while colors and colors[0].span.end < start_index:
+        colors.pop(0)
+    pre_color = ""
+    if colors and colors[0].span.start < start_index:
+        pre_color = _colorize.theme[colors[0].tag]
+
+    for i, c in enumerate(buffer, start_index):
+        if colors and colors[0].span.start == i:
+            pre_color = _colorize.theme[colors[0].tag]
+        if c == "\x1a":
+            rendered = c
+            char_widths.append(2)
+        elif ord(c) < 128:
+            rendered = c
+            char_widths.append(1)
+        elif unicodedata.category(c).startswith("C"):
+            rendered = r"\u%04x" % ord(c)
+            char_widths.append(len(rendered))
+        else:
+            rendered = c
+            char_widths.append(str_width(c))
+
+        post_color = ""
+        if colors and colors[0].span.end == i:
+            post_color = _colorize.theme["RESET"]
+            colors.pop(0)
+        chars.append(pre_color + rendered + post_color)
+        pre_color = ""
+
+    if colors and colors[0].span.start < i < colors[0].span.end:
+        chars[-1] += _colorize.theme["RESET"]
+    return chars, char_widths


### PR DESCRIPTION
This ports CPython 3.14's interactive syntax highlighting to PyPy's Python 3.12 pyrepl and brings the closely related renderer and input behavior in line with upstream.

<img width="1321" height="361" alt="image" src="https://github.com/user-attachments/assets/f4cfad00-47a3-4a78-a450-48033915ee7e" />
