### PR TITLE
enable cp312-abi3 wheel imports

### DIFF
--- a/extra_tests/test_abi3_tags.py
+++ b/extra_tests/test_abi3_tags.py
@@ -1,0 +1,122 @@
+"""Tests for lib_pypy/_pypy_abi3_tags.py: PyPy advertising cp3XY-abi3 wheel
+tags to every copy of `packaging.tags` that gets imported."""
+import sys
+import textwrap
+
+import pytest
+
+abi3_tags = pytest.importorskip('_pypy_abi3_tags')
+
+FAKE_TAGS_PY = textwrap.dedent('''
+    from collections import namedtuple
+    Tag = namedtuple('Tag', 'interpreter abi platform')
+
+    def platform_tags():
+        return ['fakeplat']
+
+    def compatible_tags(python_version=None, interpreter=None, platforms=None):
+        platforms = list(platforms or platform_tags())
+        for p in platforms:
+            yield Tag('py3', 'none', p)
+        if interpreter:
+            yield Tag(interpreter, 'none', 'any')
+
+    def sys_tags():
+        yield Tag('pp312', 'pypy312_pp80', 'fakeplat')
+        yield from compatible_tags(interpreter='pp3')
+''')
+
+VERSION = 'cp%d%d' % sys.version_info[:2]
+
+
+@pytest.fixture
+def fake_packaging(tmp_path, monkeypatch):
+    """A `<unique>.packaging.tags` module on sys.path, mimicking the shape of
+    the real one (vendored copies live at e.g. `pip._vendor.packaging.tags`)."""
+    vendor = 'fakevendor_%d' % id(tmp_path)
+    pkg = tmp_path / vendor / 'packaging'
+    pkg.mkdir(parents=True)
+    (tmp_path / vendor / '__init__.py').write_text('')
+    (pkg / '__init__.py').write_text('')
+    (pkg / 'tags.py').write_text(FAKE_TAGS_PY)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in list(sys.modules):
+        if name.startswith(vendor):
+            monkeypatch.delitem(sys.modules, name)
+    return vendor + '.packaging.tags'
+
+
+def _import(name):
+    __import__(name)
+    return sys.modules[name]
+
+
+def test_finder_installed():
+    assert any(isinstance(f, abi3_tags._Abi3TagsFinder)
+               for f in sys.meta_path)
+
+
+def test_patched_on_import(fake_packaging):
+    tags = _import(fake_packaging)
+    assert getattr(tags, abi3_tags._PATCHED_ATTR)
+    assert tags.compatible_tags.__wrapped__ is not tags.compatible_tags
+
+
+def test_abi3_tags_for_running_interpreter(fake_packaging):
+    tags = _import(fake_packaging)
+    result = list(tags.compatible_tags(interpreter='pp%d%d' % sys.version_info[:2],
+                                       platforms=['p1', 'p2']))
+    abi3 = [t for t in result if t.abi == 'abi3']
+    assert abi3 == [tags.Tag(VERSION, 'abi3', 'p1'),
+                    tags.Tag(VERSION, 'abi3', 'p2')]
+    assert result[:2] == abi3
+    assert result[2:] == [tags.Tag('py3', 'none', 'p1'),
+                          tags.Tag('py3', 'none', 'p2'),
+                          tags.Tag('pp%d%d' % sys.version_info[:2], 'none', 'any')]
+
+
+def test_floor_is_312(fake_packaging):
+    tags = _import(fake_packaging)
+    result = list(tags.compatible_tags(interpreter='pp3', platforms=['p']))
+    versions = {t.interpreter for t in result if t.abi == 'abi3'}
+    assert VERSION in versions
+    assert 'cp311' not in versions
+    assert 'cp310' not in versions
+    assert all(int(v[3:]) >= 12 for v in versions)
+
+
+def test_no_abi3_for_other_targets(fake_packaging):
+    tags = _import(fake_packaging)
+    for interpreter in ['pp311', 'pp310', 'cp312', 'cp3', None]:
+        result = list(tags.compatible_tags(interpreter=interpreter,
+                                           platforms=['p']))
+        assert not [t for t in result if t.abi == 'abi3'], interpreter
+
+
+def test_sys_tags_goes_through_patch(fake_packaging):
+    tags = _import(fake_packaging)
+    result = [str(t) for t in tags.sys_tags()]
+    assert '%s-abi3-fakeplat' % VERSION in [
+        '-'.join(t) for t in tags.sys_tags()]
+    assert result.index(str(tags.Tag('pp312', 'pypy312_pp80', 'fakeplat'))) == 0
+
+
+def test_patch_is_idempotent(fake_packaging):
+    tags = _import(fake_packaging)
+    patched = tags.compatible_tags
+    abi3_tags.patch_tags_module(tags)
+    assert tags.compatible_tags is patched
+
+
+def test_from_import_sees_patched_function(fake_packaging):
+    tags = _import(fake_packaging)
+    ns = {}
+    exec('from %s import compatible_tags' % fake_packaging, ns)
+    assert ns['compatible_tags'] is tags.compatible_tags
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='no abi3 suffix on win32')
+def test_extension_suffix():
+    import importlib.machinery
+    assert '.abi3.so' in importlib.machinery.EXTENSION_SUFFIXES
+    assert '.so' not in importlib.machinery.EXTENSION_SUFFIXES

--- a/lib-python/3/site.py
+++ b/lib-python/3/site.py
@@ -712,6 +712,11 @@ def main():
     sethelper()
     if not sys.flags.isolated:
         enablerlcompleter()
+    if is_pypy:
+        try:
+            import _pypy_abi3_tags
+        except Exception:
+            pass
     execsitecustomize()
     if ENABLE_USER_SITE:
         execusercustomize()

--- a/lib_pypy/_pypy_abi3_tags.py
+++ b/lib_pypy/_pypy_abi3_tags.py
@@ -1,0 +1,123 @@
+"""Make wheel installers accept CPython abi3 wheels on PyPy.
+
+PyPy >= 3.12 can load CPython abi3 wheels whose Py_LIMITED_API floor is
+3.12 or newer: cpyext's PyObject header matches CPython's, the limited-API
+symbols are exported under their bare CPython names, and from 3.12 on the
+limited API turns Py_INCREF/Py_DECREF into calls to _Py_IncRef/_Py_DecRef.
+Wheels with an older floor (cp37-abi3 ... cp311-abi3) still inline the
+ob_refcnt arithmetic and must not be accepted, so the floor here is a hard
+3.12, independent of the running version.
+
+Which wheel tags an interpreter supports is decided by the `packaging`
+library, of which several copies exist (standalone, vendored in pip,
+setuptools, ...), and none of them know that a non-CPython interpreter can
+support abi3.  Rather than patch each copy, install a sys.meta_path finder
+that wraps the loader of any `packaging.tags` module (`packaging.tags`,
+`pip._vendor.packaging.tags`, ...) and, once the module has executed,
+replaces its `compatible_tags` with one that first yields
+cp3XY-abi3-<platform> for 3.12 <= XY <= the running version.  That slot is
+after the native pp3XY tags (a PyPy wheel still wins) and before the
+py3-none-* tags (an abi3 binary wheel beats a pure-Python one, as on
+CPython), and it is reached by both `sys_tags()` and pip's own
+`get_supported()`, which bypasses `sys_tags()`.
+"""
+import sys
+
+_ABI3_FLOOR_MINOR = 12
+_TAGS_MODULE = 'packaging.tags'
+_PATCHED_ATTR = '_pypy_abi3_patched'
+
+
+def _is_tags_module(fullname):
+    return (fullname == _TAGS_MODULE or
+            fullname.endswith('.' + _TAGS_MODULE))
+
+
+def _abi3_interpreters():
+    version = sys.version_info[:2]
+    return ('pp%d' % version[0], 'pp%d%d' % version)
+
+
+def _abi3_versions():
+    major, minor = sys.version_info[:2]
+    return ['cp%d%d' % (major, m)
+            for m in range(minor, _ABI3_FLOOR_MINOR - 1, -1)]
+
+
+def patch_tags_module(tags):
+    if getattr(tags, _PATCHED_ATTR, False):
+        return
+    orig_compatible_tags = tags.compatible_tags
+    Tag = tags.Tag
+    interpreters = _abi3_interpreters()
+    versions = _abi3_versions()
+
+    def compatible_tags(python_version=None, interpreter=None,
+                        platforms=None):
+        platforms = list(platforms or tags.platform_tags())
+        if interpreter in interpreters:
+            for version in versions:
+                for platform_ in platforms:
+                    yield Tag(version, 'abi3', platform_)
+        yield from orig_compatible_tags(python_version, interpreter,
+                                        platforms)
+
+    compatible_tags.__wrapped__ = orig_compatible_tags
+    compatible_tags.__doc__ = orig_compatible_tags.__doc__
+    tags.compatible_tags = compatible_tags
+    setattr(tags, _PATCHED_ATTR, True)
+
+
+class _PatchingLoader:
+    def __init__(self, loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        return self._loader.create_module(spec)
+
+    def exec_module(self, module):
+        self._loader.exec_module(module)
+        patch_tags_module(module)
+
+    def __getattr__(self, name):
+        return getattr(self._loader, name)
+
+
+class _Abi3TagsFinder:
+    def find_spec(self, fullname, path=None, target=None):
+        if not _is_tags_module(fullname):
+            return None
+        meta_path = sys.meta_path
+        try:
+            start = meta_path.index(self) + 1
+        except ValueError:
+            start = 0
+        for finder in meta_path[start:]:
+            find_spec = getattr(finder, 'find_spec', None)
+            if find_spec is None:
+                continue
+            spec = find_spec(fullname, path, target)
+            if spec is not None:
+                break
+        else:
+            return None
+        loader = spec.loader
+        if loader is None or not hasattr(loader, 'exec_module'):
+            return None
+        spec.loader = _PatchingLoader(loader)
+        return spec
+
+
+def install():
+    if sys.platform == 'win32':
+        # abi3 wheels ship a bare '.pyd' there, which _imp.extension_suffixes()
+        # does not (yet) include
+        return
+    if not any(isinstance(finder, _Abi3TagsFinder) for finder in sys.meta_path):
+        sys.meta_path.insert(0, _Abi3TagsFinder())
+    for name, module in list(sys.modules.items()):
+        if _is_tags_module(name) and module is not None:
+            patch_tags_module(module)
+
+
+install()

--- a/pypy/module/cpyext/methodobject.py
+++ b/pypy/module/cpyext/methodobject.py
@@ -579,16 +579,26 @@ def PyCMethod_New(space, ml, w_self, w_name, w_type):
                 "but no METH_METHOD flag");
         return W_PyCFunctionObject(space, ml, w_self, w_name)
 
-@cts.decl("PyCFunction PyCFunction_GetFunction(PyObject *)", abi3=True)
-def PyCFunction_GetFunction(space, w_obj):
+def _pycfunction_w(space, w_obj):
     try:
-        cfunction = space.interp_w(W_PyCFunctionObject, w_obj)
+        return space.interp_w(W_PyCFunctionObject, w_obj)
     except OperationError as e:
         if e.match(space, space.w_TypeError):
             raise oefmt(space.w_SystemError,
                         "bad argument to internal function")
         raise
-    return cfunction.ml.c_ml_meth
+
+@cts.decl("PyCFunction PyCFunction_GetFunction(PyObject *)", abi3=True)
+def PyCFunction_GetFunction(space, w_obj):
+    return _pycfunction_w(space, w_obj).ml.c_ml_meth
+
+@cpython_api([PyObject], PyObject, result_borrowed=True, abi3=True)
+def PyCFunction_GetSelf(space, w_obj):
+    return _pycfunction_w(space, w_obj).w_self
+
+@cpython_api([PyObject], rffi.INT_real, error=-1, abi3=True)
+def PyCFunction_GetFlags(space, w_obj):
+    return rffi.cast(rffi.INT_real, _pycfunction_w(space, w_obj).flags)
 
 @cpython_api([PyObject], PyObject)
 def PyStaticMethod_New(space, w_func):

--- a/pypy/module/cpyext/src/abi3_misc.c
+++ b/pypy/module/cpyext/src/abi3_misc.c
@@ -53,18 +53,6 @@ PyAPI_FUNC(int) PyDict_MergeFromSeq2(PyObject *d, PyObject *seq2, int override)
     return -1;
 }
 
-PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject * _a0)
-{
-    PyErr_SetString(PyExc_NotImplementedError, "PyCFunction_GetFlags() is not implemented in PyPy");
-    return -1;
-}
-
-PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject * _a0)
-{
-    PyErr_SetString(PyExc_NotImplementedError, "PyCFunction_GetSelf() is not implemented in PyPy");
-    return NULL;
-}
-
 PyAPI_FUNC(PyObject*) PyFloat_GetInfo(void)
 {
     PyErr_SetString(PyExc_NotImplementedError, "PyFloat_GetInfo() is not implemented in PyPy");

--- a/pypy/module/cpyext/test/test_import.py
+++ b/pypy/module/cpyext/test/test_import.py
@@ -92,3 +92,11 @@ class AppTestImportLogic(AppTestCpythonExtensionBase):
         _sys = module.getmodule('sys')
         assert sys is _sys
         assert module.getmodule('not_in_sys_modules') is None
+
+    def test_abi3_extension_suffix(self):
+        import sys, _imp
+        suffixes = _imp.extension_suffixes()
+        if sys.platform != 'win32':
+            assert '.abi3.so' in suffixes
+        assert '.so' not in suffixes
+        assert '.pyd' not in suffixes

--- a/pypy/module/cpyext/test/test_methodobject.py
+++ b/pypy/module/cpyext/test/test_methodobject.py
@@ -177,12 +177,32 @@ class AppTestMethodObject(AppTestCpythonExtensionBase):
                  Py_RETURN_FALSE;
              '''
              ),
+            ('getSelf', 'METH_O',
+             '''
+             PyObject *m_self = PyCFunction_GetSelf(args);
+             if (!m_self) return NULL;
+             return Py_NewRef(m_self);
+             '''
+             ),
+            ('getFlags', 'METH_O',
+             '''
+             int flags = PyCFunction_GetFlags(args);
+             if (flags == -1 && PyErr_Occurred()) return NULL;
+             return PyLong_FromLong(flags);
+             '''
+             ),
             ])
         assert mod.isCFunction(mod.getModule) == "getModule"
         assert mod.getModule(mod.getModule) == 'MyModule'
         if self.runappdirect:  # XXX: fails untranslated
             assert mod.isSameFunction(mod.getModule)
         raises(SystemError, mod.isSameFunction, 1)
+        # module-level PyCFunctions are bound to their module
+        assert mod.getSelf(mod.getModule) is mod
+        assert mod.getFlags(mod.getModule) == 8  # METH_O
+        assert mod.getFlags(mod.isCFunction) == 8
+        raises(SystemError, mod.getSelf, 1)
+        raises(SystemError, mod.getFlags, 1)
 
     def test_function_as_method(self):
         # Unlike user functions, builtins don't become methods

--- a/pypy/module/cpyext/typeobject.py
+++ b/pypy/module/cpyext/typeobject.py
@@ -900,7 +900,9 @@ def cpyext_vectorcall_call_changed(space, w_type):
 def _realized_pto(space, w_type):
     # type.__basicsize__ and friends are read by C extensions (the limited
     # API has no other way to learn a type's layout), so they must report
-    # the layout of the cpyext PyTypeObject, materializing it if needed
+    # the layout of the cpyext PyTypeObject, materializing it if needed.
+    # This may be the very first use of cpyext in the process.
+    space.fromcache(State).make_sure_cpyext_is_imported()
     pto = rffi.cast(PyTypeObjectPtr, as_pyobj(space, w_type))
     keepalive_until_here(w_type)
     return pto

--- a/pypy/module/imp/interp_imp.py
+++ b/pypy/module/imp/interp_imp.py
@@ -12,6 +12,10 @@ def extension_suffixes(space):
     suffixes_w = []
     so_ext = importing.get_so_extension(space)
     suffixes_w.append(space.newtext(so_ext))
+    if space.config.objspace.usemodules.cpyext and not importing._WIN32:
+        # CPython abi3 wheels ship <name>.abi3.so; deliberately not a bare
+        # '.so', so full-API CPython extensions stay unfindable
+        suffixes_w.append(space.newtext('.abi3' + importing.SO))
     return space.newlist(suffixes_w)
 
 def get_magic(space):

--- a/pypy/module/imp/test/apptest_import.py
+++ b/pypy/module/imp/test/apptest_import.py
@@ -86,8 +86,13 @@ def test_create_dynamic_null():
 
 def test_ext_suffixes():
     import _imp
-    for suffix in _imp.extension_suffixes():
+    suffixes = _imp.extension_suffixes()
+    for suffix in suffixes:
         assert suffix.endswith(('.pyd', '.so'))
+    import sys
+    if sys.platform != 'win32' and 'cpyext' in sys.builtin_module_names:
+        assert '.abi3.so' in suffixes
+    assert '.so' not in suffixes
 
 
 def test_obscure_functions():


### PR DESCRIPTION
This should complete the idea from #3397 to allow pypy to import abi3 wheels if they are built for python3.12 and up.

There is a hack to monkey patch packaging (used by pip and others) to allow pypy to download and install cp312-abi3 wheels. That should be upstreamed to the official channels once we are sure this works.

Still TODO: Windows needs a python3.dll reflector like CPython. 

With this branch, I seem to be able to install onnx (but its numpy dependency requires a build-from-source) which is based on nanobind. I can also install and run pyzmq, which is based on cython. It imports, tries to get the cffi backend, fails since the abi3 wheel does not ship that backend, and loads the cython based one instead. Creating a socket PAIR round-trip works.