### PR TITLE
add implementations of `os.sched_{g,s}etaffinity`

### DIFF
--- a/pypy/module/posix/interp_posix.py
+++ b/pypy/module/posix/interp_posix.py
@@ -3134,19 +3134,21 @@ def sched_setparam(space, pid, w_param):
 
 
 @unwrap_spec(pid=int)
-def sched_getaffinity(space, pid):
+def sched_getaffinity(space, pid, __posonly__=None):
     """ Return the affinity of the process identified by pid (or the current
     process if zero). The affinity is returned as a set of CPU identifiers. """
     try:
         cpus = rposix.sched_getaffinity(pid)
     except OSError as e:
-        wrap_oserror(space, e, eintr_retry=True)
-    else:
-        return space.newset([space.newint(cpu) for cpu in cpus])
+        raise wrap_oserror(space, e)
+    except OverflowError:
+        raise oefmt(space.w_OverflowError,
+                    "could not allocate a large enough CPU set")
+    return space.newset([space.newint(cpu) for cpu in cpus])
 
 
 @unwrap_spec(pid=int)
-def sched_setaffinity(space, pid, w_mask):
+def sched_setaffinity(space, pid, w_mask, __posonly__=None):
     """ Set the CPU affinity of the process identified by pid to mask.
     mask should be an iterable of integers identifying CPUs. """
     cpus = []
@@ -3154,17 +3156,17 @@ def sched_setaffinity(space, pid, w_mask):
         if not space.isinstance_w(w_cpu, space.w_int):
             raise oefmt(space.w_TypeError,
                         "expected an iterator of ints, but iterator yielded %R",
-                        w_cpu)
+                        space.type(w_cpu))
         cpu = space.int_w(w_cpu)
         if cpu < 0:
             raise oefmt(space.w_ValueError, "negative CPU number")
         if cpu > INT_MAX - 1:
-            raise oefmt(space.w_OverflowError, "invalid CPU number")
+            raise oefmt(space.w_OverflowError, "CPU number too large")
         cpus.append(cpu)
     try:
         rposix.sched_setaffinity(pid, cpus)
     except OSError as e:
-        wrap_oserror(space, e, eintr_retry=True)
+        raise wrap_oserror(space, e)
 
 def splitdrive(p):
     # copied from ntpath.py, but changed to move the sep to the root.

--- a/pypy/module/posix/interp_posix.py
+++ b/pypy/module/posix/interp_posix.py
@@ -3132,6 +3132,40 @@ def sched_setparam(space, pid, w_param):
     else:
         return space.newint(res)
 
+
+@unwrap_spec(pid=int)
+def sched_getaffinity(space, pid):
+    """ Return the affinity of the process identified by pid (or the current
+    process if zero). The affinity is returned as a set of CPU identifiers. """
+    try:
+        cpus = rposix.sched_getaffinity(pid)
+    except OSError as e:
+        wrap_oserror(space, e, eintr_retry=True)
+    else:
+        return space.newset([space.newint(cpu) for cpu in cpus])
+
+
+@unwrap_spec(pid=int)
+def sched_setaffinity(space, pid, w_mask):
+    """ Set the CPU affinity of the process identified by pid to mask.
+    mask should be an iterable of integers identifying CPUs. """
+    cpus = []
+    for w_cpu in space.unpackiterable(w_mask):
+        if not space.isinstance_w(w_cpu, space.w_int):
+            raise oefmt(space.w_TypeError,
+                        "expected an iterator of ints, but iterator yielded %R",
+                        w_cpu)
+        cpu = space.int_w(w_cpu)
+        if cpu < 0:
+            raise oefmt(space.w_ValueError, "negative CPU number")
+        if cpu > INT_MAX - 1:
+            raise oefmt(space.w_OverflowError, "invalid CPU number")
+        cpus.append(cpu)
+    try:
+        rposix.sched_setaffinity(pid, cpus)
+    except OSError as e:
+        wrap_oserror(space, e, eintr_retry=True)
+
 def splitdrive(p):
     # copied from ntpath.py, but changed to move the sep to the root.
     # where os.path.splitpath('c:\\abc\\def.txt')

--- a/pypy/module/posix/moduledef.py
+++ b/pypy/module/posix/moduledef.py
@@ -174,6 +174,9 @@ corresponding Unix manual entries for more information on calls."""
         interpleveldefs['sched_getparam'] = 'interp_posix.sched_getparam'
         appleveldefs['sched_param'] = 'app_posix.sched_param'
         interpleveldefs['sched_setparam'] = 'interp_posix.sched_setparam'
+    if hasattr(rposix, 'sched_setaffinity'):
+        interpleveldefs['sched_getaffinity'] = 'interp_posix.sched_getaffinity'
+        interpleveldefs['sched_setaffinity'] = 'interp_posix.sched_setaffinity'
 
     for name in ['setsid', 'getuid', 'geteuid', 'getgid', 'getegid', 'setuid',
                  'seteuid', 'setgid', 'setegid', 'getgroups', 'getpgrp',

--- a/pypy/module/posix/test/test_posix2.py
+++ b/pypy/module/posix/test/test_posix2.py
@@ -1141,7 +1141,6 @@ class AppTestPosix:
                 assert os.sched_getaffinity(0) == mask
             finally:
                 os.sched_setaffinity(0, mask)
-            raises(TypeError, os.sched_setaffinity, 0, ["0"])
 
     def test_write_buffer(self):
         os = self.posix

--- a/pypy/module/posix/test/test_posix2.py
+++ b/pypy/module/posix/test/test_posix2.py
@@ -1124,6 +1124,25 @@ class AppTestPosix:
             sp = os.sched_param(sched_priority=1)
             assert sp.sched_priority == 1
 
+    if hasattr(rposix, 'sched_setaffinity'):
+        def test_sched_affinity(self):
+            os = self.posix
+            mask = os.sched_getaffinity(0)
+            assert isinstance(mask, set)
+            assert len(mask) >= 1
+            assert all(isinstance(cpu, int) and cpu >= 0 for cpu in mask)
+            try:
+                smaller = set(mask)
+                if len(smaller) > 1:
+                    smaller.pop()
+                os.sched_setaffinity(0, smaller)
+                assert os.sched_getaffinity(0) == smaller
+                os.sched_setaffinity(0, iter(list(mask)))
+                assert os.sched_getaffinity(0) == mask
+            finally:
+                os.sched_setaffinity(0, mask)
+            raises(TypeError, os.sched_setaffinity, 0, ["0"])
+
     def test_write_buffer(self):
         os = self.posix
         fd = os.open(self.path2 + 'test_write_buffer',

--- a/rpython/rlib/rposix.py
+++ b/rpython/rlib/rposix.py
@@ -11,7 +11,7 @@ from rpython.rlib._os_support import (
     POSIX_SIZE_T, POSIX_SSIZE_T, utf8_traits, _LINUX)
 from rpython.rlib.objectmodel import (
     specialize, enforceargs, register_replacement_for, NOT_CONSTANT)
-from rpython.rlib.rarithmetic import intmask, widen
+from rpython.rlib.rarithmetic import intmask, widen, r_uint
 from rpython.rlib.signature import signature
 from rpython.tool.sourcetools import func_renamer
 from rpython.translator.platform import platform
@@ -3326,6 +3326,7 @@ if sys.platform.startswith('linux'):
                 """.split():
             locals()[name] = rffi_platform.DefinedConstantInteger(name)
         HAVE_UNSHARE = rffi_platform.Has('unshare')
+        HAVE_SCHED_SETAFFINITY = rffi_platform.Has('sched_setaffinity')
 
     cConfig = rffi_platform.configure(CConfig)
     for key, value in cConfig.items():
@@ -3339,3 +3340,63 @@ if sys.platform.startswith('linux'):
             save_err=rffi.RFFI_SAVE_ERRNO)
         def unshare(flags):
             return handle_posix_error('unshare', c_unshare(flags))
+
+    if cConfig['HAVE_SCHED_SETAFFINITY']:
+        # cpu_set_t is an array of unsigned long words in glibc and musl, so
+        # the mask is handled as such here instead of via the CPU_* macros.
+        CPU_MASK_P = rffi.CArrayPtr(rffi.ULONG)
+        CPU_MASK_BITS = rffi.sizeof(rffi.ULONG) * 8
+
+        c_sched_getaffinity = external('sched_getaffinity',
+            [rffi.PID_T, rffi.SIZE_T, rffi.VOIDP], rffi.INT,
+            compilation_info=CConfig._compilation_info_,
+            save_err=rffi.RFFI_SAVE_ERRNO)
+        c_sched_setaffinity = external('sched_setaffinity',
+            [rffi.PID_T, rffi.SIZE_T, rffi.VOIDP], rffi.INT,
+            compilation_info=CConfig._compilation_info_,
+            save_err=rffi.RFFI_SAVE_ERRNO)
+
+        def sched_getaffinity(pid):
+            """Returns the list of CPUs the process is allowed to run on."""
+            nwords = 1
+            while True:
+                with lltype.scoped_alloc(CPU_MASK_P.TO, nwords, zero=True) as mask:
+                    size = nwords * rffi.sizeof(rffi.ULONG)
+                    res = widen(c_sched_getaffinity(
+                        pid, rffi.cast(rffi.SIZE_T, size),
+                        rffi.cast(rffi.VOIDP, mask)))
+                    if res < 0:
+                        err = get_saved_errno()
+                        # the kernel's cpumask is wider than ours: retry
+                        if err == errno.EINVAL:
+                            nwords *= 2
+                            continue
+                        raise OSError(err, 'sched_getaffinity failed')
+                    cpus = []
+                    for i in range(nwords):
+                        word = widen(mask[i])
+                        if word == 0:
+                            continue
+                        for bit in range(CPU_MASK_BITS):
+                            if word & (r_uint(1) << bit):
+                                cpus.append(i * CPU_MASK_BITS + bit)
+                    return cpus
+
+        def sched_setaffinity(pid, cpus):
+            """Restricts the process to the given list of CPUs (non-negative
+            ints)."""
+            maxcpu = 0
+            for cpu in cpus:
+                assert cpu >= 0
+                if cpu > maxcpu:
+                    maxcpu = cpu
+            nwords = maxcpu // CPU_MASK_BITS + 1
+            with lltype.scoped_alloc(CPU_MASK_P.TO, nwords, zero=True) as mask:
+                for cpu in cpus:
+                    i = cpu // CPU_MASK_BITS
+                    mask[i] = rffi.cast(rffi.ULONG,
+                        widen(mask[i]) | (r_uint(1) << (cpu % CPU_MASK_BITS)))
+                size = nwords * rffi.sizeof(rffi.ULONG)
+                handle_posix_error('sched_setaffinity', c_sched_setaffinity(
+                    pid, rffi.cast(rffi.SIZE_T, size),
+                    rffi.cast(rffi.VOIDP, mask)))

--- a/rpython/rlib/rposix.py
+++ b/rpython/rlib/rposix.py
@@ -11,7 +11,7 @@ from rpython.rlib._os_support import (
     POSIX_SIZE_T, POSIX_SSIZE_T, utf8_traits, _LINUX)
 from rpython.rlib.objectmodel import (
     specialize, enforceargs, register_replacement_for, NOT_CONSTANT)
-from rpython.rlib.rarithmetic import intmask, widen, r_uint
+from rpython.rlib.rarithmetic import intmask, widen, r_uint, INT_MAX
 from rpython.rlib.signature import signature
 from rpython.tool.sourcetools import func_renamer
 from rpython.translator.platform import platform
@@ -3357,30 +3357,36 @@ if sys.platform.startswith('linux'):
             save_err=rffi.RFFI_SAVE_ERRNO)
 
         def sched_getaffinity(pid):
-            """Returns the list of CPUs the process is allowed to run on."""
-            nwords = 1
+            """Returns the list of CPUs the process is allowed to run on.
+
+            Raises OverflowError if no mask big enough for the kernel's
+            cpumask can be allocated."""
+            ncpus = CPU_MASK_BITS
             while True:
+                nwords = ncpus // CPU_MASK_BITS
                 with lltype.scoped_alloc(CPU_MASK_P.TO, nwords, zero=True) as mask:
                     size = nwords * rffi.sizeof(rffi.ULONG)
                     res = widen(c_sched_getaffinity(
                         pid, rffi.cast(rffi.SIZE_T, size),
                         rffi.cast(rffi.VOIDP, mask)))
-                    if res < 0:
-                        err = get_saved_errno()
-                        # the kernel's cpumask is wider than ours: retry
-                        if err == errno.EINVAL:
-                            nwords *= 2
-                            continue
+                    if res >= 0:
+                        cpus = []
+                        for i in range(nwords):
+                            word = widen(mask[i])
+                            if word == 0:
+                                continue
+                            for bit in range(CPU_MASK_BITS):
+                                if word & (r_uint(1) << bit):
+                                    cpus.append(i * CPU_MASK_BITS + bit)
+                        return cpus
+                    err = get_saved_errno()
+                    if err != errno.EINVAL:
                         raise OSError(err, 'sched_getaffinity failed')
-                    cpus = []
-                    for i in range(nwords):
-                        word = widen(mask[i])
-                        if word == 0:
-                            continue
-                        for bit in range(CPU_MASK_BITS):
-                            if word & (r_uint(1) << bit):
-                                cpus.append(i * CPU_MASK_BITS + bit)
-                    return cpus
+                if ncpus > INT_MAX // 2:
+                    raise OverflowError(
+                        "could not allocate a large enough CPU set")
+                # EINVAL: the kernel's cpumask may be wider than ours, retry
+                ncpus *= 2
 
         def sched_setaffinity(pid, cpus):
             """Restricts the process to the given list of CPUs (non-negative

--- a/rpython/rlib/test/test_rposix.py
+++ b/rpython/rlib/test/test_rposix.py
@@ -964,6 +964,29 @@ def test_sched_rr_get_interval():
     assert interval >= 0
     assert interval < 1.
 
+@pytest.mark.skipif(not hasattr(rposix, 'sched_setaffinity'),
+    reason="Requires working rposix.sched_setaffinity()")
+def test_sched_affinity():
+    mask = rposix.sched_getaffinity(0)
+    assert len(mask) >= 1
+    assert mask == sorted(set(mask))
+    with pytest.raises(OSError):
+        rposix.sched_getaffinity(-1)
+
+    def f(cpu):
+        cpus = rposix.sched_getaffinity(0)
+        try:
+            rposix.sched_setaffinity(0, [cpu])
+            return rposix.sched_getaffinity(0)[0]
+        finally:
+            rposix.sched_setaffinity(0, cpus)
+
+    assert f(mask[-1]) == mask[-1]
+    assert interpret(f, [mask[-1]]) == mask[-1]
+    fn = compile(f, [int])
+    assert fn(mask[-1]) == mask[-1]
+    assert rposix.sched_getaffinity(0) == mask
+
 @pytest.mark.skipif(not hasattr(rposix, 'sched_getscheduler'),
     reason="Requires working rposix.sched_getscheduler()")
 def test_get_and_set_scheduler_and_param():

--- a/rpython/rlib/test/test_rposix.py
+++ b/rpython/rlib/test/test_rposix.py
@@ -987,6 +987,21 @@ def test_sched_affinity():
     assert fn(mask[-1]) == mask[-1]
     assert rposix.sched_getaffinity(0) == mask
 
+@pytest.mark.skipif(not hasattr(rposix, 'sched_setaffinity'),
+    reason="Requires working rposix.sched_setaffinity()")
+def test_sched_getaffinity_persistent_einval(monkeypatch):
+    from rpython.rtyper.lltypesystem import rffi
+    sizes = []
+    def einval(pid, size, mask):
+        sizes.append(size)
+        return rffi.cast(rffi.INT, -1)
+    monkeypatch.setattr(rposix, 'c_sched_getaffinity', einval)
+    monkeypatch.setattr(rposix, 'get_saved_errno', lambda: errno.EINVAL)
+    monkeypatch.setattr(rposix, 'INT_MAX', 4 * rposix.CPU_MASK_BITS)
+    with pytest.raises(OverflowError):
+        rposix.sched_getaffinity(0)
+    assert len(sizes) == 3
+
 @pytest.mark.skipif(not hasattr(rposix, 'sched_getscheduler'),
     reason="Requires working rposix.sched_getscheduler()")
 def test_get_and_set_scheduler_and_param():


### PR DESCRIPTION
Related to issue #2375.

The code was generated by Claude, but I've personally reviewed it and cross-checked with
CPython's implementation.
